### PR TITLE
bug: console: dont cache AWS credentials

### DIFF
--- a/packages/agent-creator/uv.lock
+++ b/packages/agent-creator/uv.lock
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "agent-creator-a2a-server"
-version = "0.9.2"
+version = "0.10.0"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },
@@ -2001,7 +2001,7 @@ wheels = [
 
 [[package]]
 name = "ringier-a2a-sdk"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "../ringier-a2a-sdk" }
 dependencies = [
     { name = "a2a-sdk" },

--- a/packages/agent-runner/uv.lock
+++ b/packages/agent-runner/uv.lock
@@ -110,7 +110,7 @@ dev = [
 
 [[package]]
 name = "agent-runner"
-version = "0.9.2"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },
@@ -2485,7 +2485,7 @@ wheels = [
 
 [[package]]
 name = "ringier-a2a-sdk"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "../ringier-a2a-sdk" }
 dependencies = [
     { name = "a2a-sdk" },

--- a/packages/console-backend/playground_backend/services/conversation_service.py
+++ b/packages/console-backend/playground_backend/services/conversation_service.py
@@ -6,7 +6,6 @@ from datetime import datetime, timedelta, timezone
 import httpx
 import uuid6
 from aiodynamo.client import Client
-from aiodynamo.credentials import Credentials, Key, StaticCredentials
 from aiodynamo.errors import ItemNotFound
 from aiodynamo.expressions import F, HashAndRangeKeyCondition, HashKey
 from aiodynamo.http.httpx import HTTPX
@@ -14,6 +13,7 @@ from aiodynamo.http.httpx import HTTPX
 from ..config import config
 from ..exceptions import ConversationOwnershipError
 from ..models.conversation import Conversation
+from ..utils.aws_credentials import BotoRefreshableCredentials
 
 logger = logging.getLogger(__name__)
 
@@ -28,9 +28,9 @@ class ConversationService:
         # Conversations TTL - 90 days for retention
         self.conversation_ttl_seconds = 7776000  # 90 days
 
-        # Use auto credentials - handles ECS, EKS Pod Identity, env vars,
-        # and ~/.aws/credentials with automatic token refresh
-        credentials = Credentials.auto()
+        # Use boto3 refreshable credentials - handles all AWS credential sources
+        # (EKS Pod Identity, IRSA, env vars, profiles) with automatic token refresh
+        credentials = BotoRefreshableCredentials()
 
         self.client = Client(
             HTTPX(httpx.AsyncClient()),

--- a/packages/console-backend/playground_backend/services/conversation_service.py
+++ b/packages/console-backend/playground_backend/services/conversation_service.py
@@ -1,10 +1,8 @@
 """Conversation service for managing conversations in DynamoDB."""
 
 import logging
-import os
 from datetime import datetime, timedelta, timezone
 
-import boto3
 import httpx
 import uuid6
 from aiodynamo.client import Client
@@ -30,21 +28,9 @@ class ConversationService:
         # Conversations TTL - 90 days for retention
         self.conversation_ttl_seconds = 7776000  # 90 days
 
-        try:
-            _ = os.environ["ECS_CONTAINER_METADATA_URI"]
-            credentials = Credentials.auto()
-            logger.info("Using auto credentials (ECS environment)")
-        except KeyError:
-            boto_session = boto3.Session()
-            boto3_credentials = boto_session.get_credentials()
-            credentials = StaticCredentials(
-                key=Key(
-                    id=boto3_credentials.access_key,
-                    secret=boto3_credentials.secret_key,
-                    token=boto3_credentials.token,
-                )
-            )
-            logger.info("Using static credentials (local environment)")
+        # Use auto credentials - handles ECS, EKS Pod Identity, env vars,
+        # and ~/.aws/credentials with automatic token refresh
+        credentials = Credentials.auto()
 
         self.client = Client(
             HTTPX(httpx.AsyncClient()),

--- a/packages/console-backend/playground_backend/services/messages_service.py
+++ b/packages/console-backend/playground_backend/services/messages_service.py
@@ -8,13 +8,13 @@ from typing import Any, cast
 import httpx
 from a2a.types import FilePart, FileWithUri, Part, TaskState
 from aiodynamo.client import Client
-from aiodynamo.credentials import Credentials
 from aiodynamo.expressions import F, HashAndRangeKeyCondition, HashKey
 from aiodynamo.http.httpx import HTTPX
 from uuid6 import uuid7
 
 from ..config import config
 from ..models.message import Message
+from ..utils.aws_credentials import BotoRefreshableCredentials
 from .file_storage_service import FileStorageService
 
 logger = logging.getLogger(__name__)
@@ -220,9 +220,9 @@ class MessagesService:
         # Messages TTL - 90 days for retention
         self.message_ttl_seconds = 7776000  # 90 days
 
-        # Use auto credentials - handles ECS, EKS Pod Identity, env vars,
-        # and ~/.aws/credentials with automatic token refresh
-        credentials = Credentials.auto()
+        # Use boto3 refreshable credentials - handles all AWS credential sources
+        # (EKS Pod Identity, IRSA, env vars, profiles) with automatic token refresh
+        credentials = BotoRefreshableCredentials()
 
         self.client = Client(
             HTTPX(httpx.AsyncClient()),

--- a/packages/console-backend/playground_backend/services/messages_service.py
+++ b/packages/console-backend/playground_backend/services/messages_service.py
@@ -2,15 +2,13 @@
 
 import json
 import logging
-import os
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 
-import boto3
 import httpx
 from a2a.types import FilePart, FileWithUri, Part, TaskState
 from aiodynamo.client import Client
-from aiodynamo.credentials import Credentials, Key, StaticCredentials
+from aiodynamo.credentials import Credentials
 from aiodynamo.expressions import F, HashAndRangeKeyCondition, HashKey
 from aiodynamo.http.httpx import HTTPX
 from uuid6 import uuid7
@@ -222,21 +220,9 @@ class MessagesService:
         # Messages TTL - 90 days for retention
         self.message_ttl_seconds = 7776000  # 90 days
 
-        try:
-            _ = os.environ["ECS_CONTAINER_METADATA_URI"]
-            credentials = Credentials.auto()
-            logger.info("Using auto credentials (ECS environment)")
-        except KeyError:
-            boto_session = boto3.Session()
-            boto3_credentials = boto_session.get_credentials()
-            credentials = StaticCredentials(
-                key=Key(
-                    id=boto3_credentials.access_key,
-                    secret=boto3_credentials.secret_key,
-                    token=boto3_credentials.token,
-                )
-            )
-            logger.info("Using static credentials (local environment)")
+        # Use auto credentials - handles ECS, EKS Pod Identity, env vars,
+        # and ~/.aws/credentials with automatic token refresh
+        credentials = Credentials.auto()
 
         self.client = Client(
             HTTPX(httpx.AsyncClient()),

--- a/packages/console-backend/playground_backend/services/session_service.py
+++ b/packages/console-backend/playground_backend/services/session_service.py
@@ -6,7 +6,6 @@ from uuid import uuid4
 
 import httpx
 from aiodynamo.client import Client
-from aiodynamo.credentials import Credentials
 from aiodynamo.errors import ItemNotFound
 from aiodynamo.expressions import F, UpdateExpression, Value
 from aiodynamo.http.httpx import HTTPX
@@ -14,6 +13,7 @@ from aiodynamo.http.httpx import HTTPX
 from ..config import config
 from ..exceptions import SessionNotFoundError, SessionOwnershipError
 from ..models.session import StoredSession
+from ..utils.aws_credentials import BotoRefreshableCredentials
 
 logger = logging.getLogger(__name__)
 
@@ -27,9 +27,9 @@ class SessionService:
         self.table_name = dynamodb_config.sessions_table
         self.session_ttl_seconds = config.session_ttl_seconds
 
-        # Use auto credentials - handles ECS, EKS Pod Identity, env vars,
-        # and ~/.aws/credentials with automatic token refresh
-        credentials = Credentials.auto()
+        # Use boto3 refreshable credentials - handles all AWS credential sources
+        # (EKS Pod Identity, IRSA, env vars, profiles) with automatic token refresh
+        credentials = BotoRefreshableCredentials()
 
         self.client = Client(
             HTTPX(httpx.AsyncClient()),

--- a/packages/console-backend/playground_backend/services/session_service.py
+++ b/packages/console-backend/playground_backend/services/session_service.py
@@ -1,14 +1,12 @@
 """Session service for managing user sessions in DynamoDB."""
 
 import logging
-import os
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
-import boto3
 import httpx
 from aiodynamo.client import Client
-from aiodynamo.credentials import Credentials, Key, StaticCredentials
+from aiodynamo.credentials import Credentials
 from aiodynamo.errors import ItemNotFound
 from aiodynamo.expressions import F, UpdateExpression, Value
 from aiodynamo.http.httpx import HTTPX
@@ -29,23 +27,9 @@ class SessionService:
         self.table_name = dynamodb_config.sessions_table
         self.session_ttl_seconds = config.session_ttl_seconds
 
-        # Initialize aiodynamo client with appropriate credentials
-        # Use auto credentials in ECS, static credentials locally
-        try:
-            _ = os.environ["ECS_CONTAINER_METADATA_URI"]
-            credentials = Credentials.auto()
-            logger.info("Using auto credentials (ECS environment)")
-        except KeyError:
-            boto_session = boto3.Session()
-            boto3_credentials = boto_session.get_credentials()
-            credentials = StaticCredentials(
-                key=Key(
-                    id=boto3_credentials.access_key,
-                    secret=boto3_credentials.secret_key,
-                    token=boto3_credentials.token,
-                )
-            )
-            logger.info("Using static credentials (local environment)")
+        # Use auto credentials - handles ECS, EKS Pod Identity, env vars,
+        # and ~/.aws/credentials with automatic token refresh
+        credentials = Credentials.auto()
 
         self.client = Client(
             HTTPX(httpx.AsyncClient()),

--- a/packages/console-backend/playground_backend/services/socket_session_service.py
+++ b/packages/console-backend/playground_backend/services/socket_session_service.py
@@ -5,13 +5,13 @@ from datetime import datetime, timedelta, timezone
 
 import httpx
 from aiodynamo.client import Client
-from aiodynamo.credentials import Credentials
 from aiodynamo.errors import ItemNotFound
 from aiodynamo.expressions import F, UpdateExpression, Value
 from aiodynamo.http.httpx import HTTPX
 
 from ..config import config
 from ..models.socket_session import SocketSession
+from ..utils.aws_credentials import BotoRefreshableCredentials
 
 logger = logging.getLogger(__name__)
 
@@ -33,9 +33,9 @@ class SocketSessionService:
         # 48 hours is a safety buffer for orphaned records from crashes/ungraceful disconnects
         self.session_ttl_seconds = 172800  # 48 hours
 
-        # Use auto credentials - handles ECS, EKS Pod Identity, env vars,
-        # and ~/.aws/credentials with automatic token refresh
-        credentials = Credentials.auto()
+        # Use boto3 refreshable credentials - handles all AWS credential sources
+        # (EKS Pod Identity, IRSA, env vars, profiles) with automatic token refresh
+        credentials = BotoRefreshableCredentials()
 
         self.client = Client(
             HTTPX(httpx.AsyncClient()),

--- a/packages/console-backend/playground_backend/services/socket_session_service.py
+++ b/packages/console-backend/playground_backend/services/socket_session_service.py
@@ -1,13 +1,11 @@
 """Socket session service for managing Socket.IO sessions in DynamoDB."""
 
 import logging
-import os
 from datetime import datetime, timedelta, timezone
 
-import boto3
 import httpx
 from aiodynamo.client import Client
-from aiodynamo.credentials import Credentials, Key, StaticCredentials
+from aiodynamo.credentials import Credentials
 from aiodynamo.errors import ItemNotFound
 from aiodynamo.expressions import F, UpdateExpression, Value
 from aiodynamo.http.httpx import HTTPX
@@ -35,23 +33,9 @@ class SocketSessionService:
         # 48 hours is a safety buffer for orphaned records from crashes/ungraceful disconnects
         self.session_ttl_seconds = 172800  # 48 hours
 
-        # Initialize aiodynamo client with appropriate credentials
-        # Use auto credentials in ECS, static credentials locally
-        try:
-            _ = os.environ["ECS_CONTAINER_METADATA_URI"]
-            credentials = Credentials.auto()
-            logger.info("Using auto credentials (ECS environment)")
-        except KeyError:
-            boto_session = boto3.Session()
-            boto3_credentials = boto_session.get_credentials()
-            credentials = StaticCredentials(
-                key=Key(
-                    id=boto3_credentials.access_key,
-                    secret=boto3_credentials.secret_key,
-                    token=boto3_credentials.token,
-                )
-            )
-            logger.info("Using static credentials (local environment)")
+        # Use auto credentials - handles ECS, EKS Pod Identity, env vars,
+        # and ~/.aws/credentials with automatic token refresh
+        credentials = Credentials.auto()
 
         self.client = Client(
             HTTPX(httpx.AsyncClient()),

--- a/packages/console-backend/playground_backend/utils/aws_credentials.py
+++ b/packages/console-backend/playground_backend/utils/aws_credentials.py
@@ -1,0 +1,41 @@
+"""Refreshable AWS credentials for aiodynamo using boto3's credential chain.
+
+aiodynamo's built-in Credentials.auto() uses its own httpx-based HTTP client to
+reach EKS Pod Identity / IMDS metadata endpoints, which can fail in certain EKS
+network configurations. boto3/botocore's credential chain handles these endpoints
+reliably and supports automatic token refresh.
+
+This module bridges the two: it implements aiodynamo's credential interface but
+delegates to boto3 for actual credential resolution and refresh.
+"""
+
+import logging
+
+import boto3
+from aiodynamo.credentials import Key
+
+logger = logging.getLogger(__name__)
+
+
+class BotoRefreshableCredentials:
+    """Credentials that delegate to boto3's credential chain with auto-refresh.
+
+    Unlike aiodynamo's StaticCredentials, this calls get_frozen_credentials()
+    on each DynamoDB request, allowing boto3 to transparently refresh expired
+    tokens (e.g., EKS Pod Identity, IRSA, instance profiles).
+    """
+
+    def __init__(self) -> None:
+        session = boto3.Session()
+        self._credentials = session.get_credentials()
+        if self._credentials is None:
+            raise RuntimeError("No AWS credentials found by boto3")
+        logger.info("Using boto3 refreshable credentials")
+
+    async def get_key(self, http: object) -> Key:
+        creds = self._credentials.get_frozen_credentials()
+        return Key(
+            id=creds.access_key,
+            secret=creds.secret_key,
+            token=creds.token,
+        )

--- a/packages/console-backend/uv.lock
+++ b/packages/console-backend/uv.lock
@@ -1869,7 +1869,7 @@ wheels = [
 
 [[package]]
 name = "playground-backend"
-version = "0.9.2"
+version = "0.10.0"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["all"] },
@@ -2590,7 +2590,7 @@ wheels = [
 
 [[package]]
 name = "ringier-a2a-sdk"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "../ringier-a2a-sdk" }
 dependencies = [
     { name = "a2a-sdk" },

--- a/packages/orchestrator-agent/uv.lock
+++ b/packages/orchestrator-agent/uv.lock
@@ -1524,7 +1524,7 @@ wheels = [
 
 [[package]]
 name = "orchestrator-agent-a2a-server"
-version = "0.9.2"
+version = "0.10.0"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },
@@ -2316,7 +2316,7 @@ wheels = [
 
 [[package]]
 name = "ringier-a2a-sdk"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "../ringier-a2a-sdk" }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
This caused "token expired" errors in the pod.

Opus found:
>The DynamoDB client credentials are being snapshotted as static values at startup and never refreshed.

## Checklist
- [x] I have performed a self-review of my code
- [ ] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨
