### PR TITLE
feat: outbound SCIM nightly full sync + group member pre-sync

### DIFF
--- a/packages/console-backend/app.py
+++ b/packages/console-backend/app.py
@@ -214,6 +214,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Start scheduler engine
     await app.state.scheduler_engine.start()
 
+    # Start outbound SCIM nightly full-sync (if enabled)
+    if config.outbound_scim.nightly_sync_enabled and hasattr(app.state, "outbound_scim_push_service"):
+        app.state.outbound_scim_push_service.start_nightly_sync(
+            hour_utc=config.outbound_scim.nightly_sync_hour_utc,
+        )
+
     # Start internal cost logger for catalog sync cost tracking
     from console_backend.services.llm_cost_tracking import _internal_cost_logger
 
@@ -234,6 +240,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     if hasattr(app.state, "scheduler_engine"):
         await app.state.scheduler_engine.stop()
         logger.info("Scheduler engine stopped")
+    if hasattr(app.state, "outbound_scim_push_service"):
+        await app.state.outbound_scim_push_service.stop_nightly_sync()
+        logger.info("Outbound SCIM nightly sync stopped")
     if _internal_cost_logger is not None:
         await _internal_cost_logger.shutdown()
         logger.info("Internal cost logger stopped")

--- a/packages/console-backend/console_backend/config.py
+++ b/packages/console-backend/console_backend/config.py
@@ -119,6 +119,17 @@ class SchedulerConfig(BaseModel):
     )  # NOTE: supports just bedrock models for now, but can be extended in the future
 
 
+class OutboundScimConfig(BaseModel):
+    """Outbound SCIM provisioning configuration."""
+
+    nightly_sync_enabled: bool = Field(
+        default_factory=lambda: os.getenv("OUTBOUND_SCIM_NIGHTLY_SYNC_ENABLED", "true").lower() == "true"
+    )
+    nightly_sync_hour_utc: int = Field(
+        default_factory=lambda: int(os.getenv("OUTBOUND_SCIM_NIGHTLY_SYNC_HOUR_UTC", "2"))
+    )
+
+
 class AutoApproveConfig(BaseModel):
     """Auto-approve constraints for sub-agents."""
 
@@ -126,8 +137,6 @@ class AutoApproveConfig(BaseModel):
         default_factory=lambda: int(os.getenv("AUTO_APPROVE_MAX_SYSTEM_PROMPT_LENGTH", "500"))
     )
     max_mcp_tools_count: int = Field(default_factory=lambda: int(os.getenv("AUTO_APPROVE_MAX_MCP_TOOLS_COUNT", "3")))
-
-
 class TwilioVerifyConfig(BaseModel):
     """Twilio Verify configuration for phone number verification."""
 
@@ -280,6 +289,7 @@ class Config(BaseModel):
     mcp_gateway: MCPGatewayConfig = Field(default_factory=MCPGatewayConfig)
     file_storage: FileStorageConfig = Field(default_factory=FileStorageConfig)
     scheduler: SchedulerConfig = Field(default_factory=SchedulerConfig)
+    outbound_scim: OutboundScimConfig = Field(default_factory=OutboundScimConfig)
     auto_approve: AutoApproveConfig = Field(default_factory=AutoApproveConfig)
     twilio_verify: TwilioVerifyConfig = Field(default_factory=TwilioVerifyConfig)
     catalog: CatalogConfig = Field(default_factory=CatalogConfig)

--- a/packages/console-backend/console_backend/services/outbound_scim_push_service.py
+++ b/packages/console-backend/console_backend/services/outbound_scim_push_service.py
@@ -6,6 +6,7 @@ Uses fire-and-forget pattern with retries and audit logging for failures.
 
 import asyncio
 import logging
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 import httpx
@@ -36,6 +37,7 @@ class OutboundScimPushService:
         self._endpoint_service: "OutboundScimEndpointService | None" = None
         self._audit_service: AuditService | None = None
         self._db_session_factory: async_sessionmaker[AsyncSession] | None = None
+        self._nightly_task: asyncio.Task | None = None
 
     def set_endpoint_service(self, service: "OutboundScimEndpointService") -> None:
         self._endpoint_service = service
@@ -141,6 +143,84 @@ class OutboundScimPushService:
         )
 
         return {"users_queued": users_queued, "groups_queued": groups_queued}
+
+    # ─── Nightly Full Sync ───────────────────────────────────────────────────
+
+    def start_nightly_sync(self, hour_utc: int = 2) -> None:
+        """Start background task that runs push_all for every active endpoint daily.
+
+        Runs once per day at the given UTC hour. Safe to call multiple times — no-op
+        if already running. Use stop_nightly_sync() during graceful shutdown.
+        """
+        if self._nightly_task is not None and not self._nightly_task.done():
+            return
+        if not 0 <= hour_utc <= 23:
+            raise ValueError(f"hour_utc must be in [0, 23], got {hour_utc}")
+        self._nightly_task = asyncio.create_task(
+            self._nightly_sync_loop(hour_utc),
+            name="outbound-scim-nightly-sync",
+        )
+        logger.info(f"Outbound SCIM nightly sync scheduled at {hour_utc:02d}:00 UTC")
+
+    async def stop_nightly_sync(self) -> None:
+        """Cancel the nightly sync background task."""
+        if self._nightly_task is None:
+            return
+        self._nightly_task.cancel()
+        try:
+            await self._nightly_task
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            logger.warning(f"Outbound SCIM nightly sync task raised on shutdown: {e}")
+        self._nightly_task = None
+
+    async def _nightly_sync_loop(self, hour_utc: int) -> None:
+        """Sleep until the next scheduled run, execute, repeat."""
+        while True:
+            now = datetime.now(timezone.utc)
+            next_run = now.replace(hour=hour_utc, minute=0, second=0, microsecond=0)
+            if next_run <= now:
+                next_run += timedelta(days=1)
+            sleep_seconds = (next_run - now).total_seconds()
+            logger.debug(
+                f"Outbound SCIM nightly sync: next run at {next_run.isoformat()} "
+                f"(sleeping {sleep_seconds:.0f}s)"
+            )
+            try:
+                await asyncio.sleep(sleep_seconds)
+                await self._run_nightly_sync()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.error(f"Outbound SCIM nightly sync iteration failed: {e}", exc_info=True)
+                # Avoid tight loop on persistent failure.
+                await asyncio.sleep(60)
+
+    async def _run_nightly_sync(self) -> None:
+        """Trigger push_all for every active outbound endpoint."""
+        logger.info("Outbound SCIM nightly sync: starting full sync of all endpoints")
+        try:
+            async with self.db_session_factory() as db:
+                endpoints = await self.endpoint_service.get_active_endpoints(db)
+        except Exception as e:
+            logger.error(f"Outbound SCIM nightly sync: failed to load endpoints: {e}")
+            return
+
+        if not endpoints:
+            logger.info("Outbound SCIM nightly sync: no active endpoints, skipping")
+            return
+
+        for ep in endpoints:
+            try:
+                result = await self.push_all(ep["id"])
+                logger.info(
+                    f"Outbound SCIM nightly sync: endpoint {ep['id']} queued {result}"
+                )
+            except Exception as e:
+                logger.error(
+                    f"Outbound SCIM nightly sync: endpoint {ep['id']} failed to queue: {e}"
+                )
 
     async def _push_all_to_endpoint(self, endpoint: dict, user_ids: list[str], group_ids: list[int]) -> None:
         """Background task: push all users and groups to a single endpoint."""
@@ -355,6 +435,29 @@ class OutboundScimPushService:
                     # Check existing sync state for remote_id
                     sync_state = await self.endpoint_service.get_sync_state(db, endpoint_id, "group", entity_id)
                     remote_id = sync_state["remote_id"] if sync_state else None
+
+                # Pre-sync any members that don't yet have a remote_id at this endpoint.
+                # Without this, unsynced members are silently dropped from the group payload
+                # by _build_scim_group_payload, leaving membership incomplete on the remote.
+                # Endpoints with push_users=false are skipped (we can't sync users there).
+                if endpoint.get("push_users", True):
+                    unsynced_user_ids = [m.id for m in members if not m.remote_id]
+                    if unsynced_user_ids:
+                        logger.info(
+                            f"Outbound SCIM: group {group_id} has {len(unsynced_user_ids)} "
+                            f"unsynced members at endpoint {endpoint_id}; pushing users first"
+                        )
+                        for user_id in unsynced_user_ids:
+                            try:
+                                await self._push_user_to_endpoint(endpoint, user_id, "update")
+                            except Exception as e:
+                                logger.warning(
+                                    f"Outbound SCIM: pre-sync of member user {user_id} for "
+                                    f"group {group_id} at endpoint {endpoint_id} failed: {e}"
+                                )
+                        # Re-fetch members so newly-assigned remote_ids are picked up.
+                        async with self.db_session_factory() as db:
+                            _, members = await self._fetch_group_with_members(db, group_id, endpoint_id)
 
                 # Build SCIM payload
                 payload = self._build_scim_group_payload(group_row, members)

--- a/packages/console-backend/console_backend/services/outbound_scim_push_service.py
+++ b/packages/console-backend/console_backend/services/outbound_scim_push_service.py
@@ -198,29 +198,56 @@ class OutboundScimPushService:
                 await asyncio.sleep(60)
 
     async def _run_nightly_sync(self) -> None:
-        """Trigger push_all for every active outbound endpoint."""
+        """Trigger push_all for every active outbound endpoint.
+
+        Uses a PostgreSQL session-scoped advisory lock to ensure only one
+        console-backend instance queues the nightly sync per run, even when
+        deployed with multiple replicas. The lock only guards the queueing
+        phase; the actual push work runs in detached tasks afterwards.
+        """
+        # Arbitrary constant key identifying the "outbound SCIM nightly sync" lock.
+        # Chosen to be unlikely to collide with other advisory locks in the schema.
+        advisory_lock_key = 7421001
+
         logger.info("Outbound SCIM nightly sync: starting full sync of all endpoints")
         try:
             async with self.db_session_factory() as db:
-                endpoints = await self.endpoint_service.get_active_endpoints(db)
+                result = await db.execute(
+                    text("SELECT pg_try_advisory_lock(:key)"),
+                    {"key": advisory_lock_key},
+                )
+                acquired = bool(result.scalar())
+                if not acquired:
+                    logger.info(
+                        "Outbound SCIM nightly sync: another instance holds the "
+                        "advisory lock, skipping this run"
+                    )
+                    return
+
+                try:
+                    endpoints = await self.endpoint_service.get_active_endpoints(db)
+                    if not endpoints:
+                        logger.info("Outbound SCIM nightly sync: no active endpoints, skipping")
+                        return
+
+                    for ep in endpoints:
+                        try:
+                            result = await self.push_all(ep["id"])
+                            logger.info(
+                                f"Outbound SCIM nightly sync: endpoint {ep['id']} queued {result}"
+                            )
+                        except Exception as e:
+                            logger.error(
+                                f"Outbound SCIM nightly sync: endpoint {ep['id']} failed to queue: {e}"
+                            )
+                finally:
+                    await db.execute(
+                        text("SELECT pg_advisory_unlock(:key)"),
+                        {"key": advisory_lock_key},
+                    )
+                    await db.commit()
         except Exception as e:
-            logger.error(f"Outbound SCIM nightly sync: failed to load endpoints: {e}")
-            return
-
-        if not endpoints:
-            logger.info("Outbound SCIM nightly sync: no active endpoints, skipping")
-            return
-
-        for ep in endpoints:
-            try:
-                result = await self.push_all(ep["id"])
-                logger.info(
-                    f"Outbound SCIM nightly sync: endpoint {ep['id']} queued {result}"
-                )
-            except Exception as e:
-                logger.error(
-                    f"Outbound SCIM nightly sync: endpoint {ep['id']} failed to queue: {e}"
-                )
+            logger.error(f"Outbound SCIM nightly sync: failed: {e}", exc_info=True)
 
     async def _push_all_to_endpoint(self, endpoint: dict, user_ids: list[str], group_ids: list[int]) -> None:
         """Background task: push all users and groups to a single endpoint."""

--- a/packages/console-frontend/src/pages/admin/OutboundScimPage.tsx
+++ b/packages/console-frontend/src/pages/admin/OutboundScimPage.tsx
@@ -8,14 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Switch } from '@/components/ui/switch';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import {
   Dialog,
   DialogContent,
@@ -105,7 +98,13 @@ export function OutboundScimPage() {
   });
 
   const createMutation = useMutation({
-    mutationFn: async (body: { name: string; endpoint_url: string; bearer_token: string; push_users: boolean; push_groups: boolean }) => {
+    mutationFn: async (body: {
+      name: string;
+      endpoint_url: string;
+      bearer_token: string;
+      push_users: boolean;
+      push_groups: boolean;
+    }) => {
       const res = await client.post<OutboundScimEndpointCreated>({ url: API_BASE, body });
       return res.data as OutboundScimEndpointCreated;
     },
@@ -188,7 +187,13 @@ export function OutboundScimPage() {
   };
 
   const handleCreate = () => {
-    createMutation.mutate({ name, endpoint_url: endpointUrl, bearer_token: bearerToken, push_users: pushUsers, push_groups: pushGroups });
+    createMutation.mutate({
+      name,
+      endpoint_url: endpointUrl,
+      bearer_token: bearerToken,
+      push_users: pushUsers,
+      push_groups: pushGroups,
+    });
   };
 
   const openEditDialog = (endpoint: OutboundScimEndpoint) => {
@@ -230,9 +235,7 @@ export function OutboundScimPage() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Outbound SCIM Endpoints</h1>
-          <p className="text-muted-foreground">
-            Push user and group changes to external SCIM 2.0 servers
-          </p>
+          <p className="text-muted-foreground">Push user and group changes to external SCIM 2.0 servers</p>
         </div>
         <Button onClick={() => setCreateDialogOpen(true)}>
           <Plus className="h-4 w-4 mr-2" />
@@ -283,50 +286,40 @@ export function OutboundScimPage() {
                     </div>
                   </TableCell>
                   <TableCell>
-                    <Badge variant={ep.enabled ? 'default' : 'secondary'}>
-                      {ep.enabled ? 'Active' : 'Disabled'}
-                    </Badge>
+                    <Badge variant={ep.enabled ? 'default' : 'secondary'}>{ep.enabled ? 'Active' : 'Disabled'}</Badge>
                   </TableCell>
                   <TableCell className="text-sm">{formatDate(ep.created_at)}</TableCell>
                   <TableCell>
                     <div className="flex gap-1">
                       <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8"
+                        variant="outline"
+                        size="sm"
                         onClick={() => pushAllMutation.mutate(ep.id)}
                         disabled={pushAllMutation.isPending || !ep.enabled}
                         title="Push all users and groups"
                       >
-                        <RefreshCw className="h-4 w-4" />
+                        <RefreshCw className="h-4 w-4" /> Full Sync
                       </Button>
                       <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8"
+                        variant="outline"
+                        size="sm"
                         onClick={() => testMutation.mutate(ep.id)}
                         disabled={testMutation.isPending}
                         title="Test connection"
                       >
-                        <TestTube className="h-4 w-4" />
+                        <TestTube className="h-4 w-4" /> Test
+                      </Button>
+                      <Button variant="outline" size="sm" onClick={() => openEditDialog(ep)} title="Edit">
+                        <Pencil className="h-4 w-4" /> Edit
                       </Button>
                       <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8"
-                        onClick={() => openEditDialog(ep)}
-                        title="Edit"
-                      >
-                        <Pencil className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8 text-destructive hover:text-destructive"
+                        variant="outline"
+                        size="sm"
+                        className="text-destructive hover:text-destructive"
                         onClick={() => setDeleteDialog({ open: true, endpoint: ep })}
                         title="Delete"
                       >
-                        <Trash2 className="h-4 w-4" />
+                        <Trash2 className="h-4 w-4" /> Delete
                       </Button>
                     </div>
                   </TableCell>
@@ -423,19 +416,11 @@ export function OutboundScimPage() {
           <div className="space-y-4 py-4">
             <div className="space-y-2">
               <Label htmlFor="edit-name">Name</Label>
-              <Input
-                id="edit-name"
-                value={editName}
-                onChange={(e) => setEditName(e.target.value)}
-              />
+              <Input id="edit-name" value={editName} onChange={(e) => setEditName(e.target.value)} />
             </div>
             <div className="space-y-2">
               <Label htmlFor="edit-url">SCIM Base URL</Label>
-              <Input
-                id="edit-url"
-                value={editEndpointUrl}
-                onChange={(e) => setEditEndpointUrl(e.target.value)}
-              />
+              <Input id="edit-url" value={editEndpointUrl} onChange={(e) => setEditEndpointUrl(e.target.value)} />
             </div>
             <div className="space-y-2">
               <Label htmlFor="edit-token">Bearer Token (leave empty to keep current)</Label>


### PR DESCRIPTION
Adds a daily background task that runs push_all for every active outbound SCIM endpoint at a configurable UTC hour (default 02:00). Also fixes group pushes to pre-sync any members lacking a remote_id so memberships are no longer silently dropped from the SCIM payload.

closes #

## Checklist
- [x] I have performed a self-review of my code
- [ ] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨
