### PR TITLE
fix: env overrides for scheduler/file-analyzer models

### DIFF
--- a/packages/orchestrator-agent/app/agents/file_analyzer.py
+++ b/packages/orchestrator-agent/app/agents/file_analyzer.py
@@ -65,7 +65,7 @@ FILE_ANALYZER_DESCRIPTION = (
 # Default model for file analysis (true multimodal with audio/video support)
 # Can be overridden via FILE_ANALYZER_MODEL environment variable
 # Note: Must be a model supporting file_url content (gpt-4o, claude-3.5-sonnet, or Gemini models)
-DEFAULT_FILE_ANALYZER_MODEL: ModelType = "gemini-3-flash-preview"
+DEFAULT_FILE_ANALYZER_MODEL: ModelType = os.getenv("FILE_ANALYZER_MODEL", "gemini-3-flash-preview")  # type: ignore
 
 # Regex to extract URLs from text
 # Uses negative lookbehind to exclude trailing punctuation (periods, commas, etc.)

--- a/packages/orchestrator-agent/app/agents/task_scheduler.py
+++ b/packages/orchestrator-agent/app/agents/task_scheduler.py
@@ -65,7 +65,7 @@ TASK_SCHEDULER_DESCRIPTION = (
 
 # Default model for task scheduling (strategic planning)
 # Can be overridden via TASK_SCHEDULER_MODEL environment variable
-DEFAULT_TASK_SCHEDULER_MODEL: ModelType = "claude-sonnet-4.6"
+DEFAULT_TASK_SCHEDULER_MODEL: ModelType = os.getenv("TASK_SCHEDULER_MODEL", "claude-sonnet-4.6")  # type: ignore
 CONSOLE_FRONTEND_URL = os.getenv("CONSOLE_FRONTEND_URL", "http://localhost:5173")
 # System prompt for the task scheduler agent
 TASK_SCHEDULER_SYSTEM_PROMPT = """<role>


### PR DESCRIPTION
I replaced hardcoded values on env variables, with defaults on old values. 

closes #

## Checklist
- [x] I have performed a self-review of my code
- [ ] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨
