### PR TITLE
Fix: fail fast with actionable errors when MCP endpoint returns

### DIFF
--- a/packages/agent-common/agent_common/agents/dynamic_agent.py
+++ b/packages/agent-common/agent_common/agents/dynamic_agent.py
@@ -46,7 +46,11 @@ from langgraph.errors import GraphInterrupt
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.store.postgres.aio import AsyncPostgresStore
 from ringier_a2a_sdk.oauth import OidcOAuth2Client
-from ringier_a2a_sdk.utils.mcp_errors import format_mcp_error, is_retryable_mcp_error
+from ringier_a2a_sdk.utils.mcp_errors import (
+    format_mcp_error,
+    guarded_streamable_http,
+    is_retryable_mcp_error,
+)
 from ringier_a2a_sdk.utils.mcp_progress import on_mcp_progress
 from ringier_a2a_sdk.utils.streaming import (
     StreamBuffer,
@@ -591,7 +595,15 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                     callbacks=Callbacks(on_progress=on_mcp_progress),
                 )
 
-                tools = await client.get_tools()
+                # Best-effort: surface the first connection's URL/slug to the
+                # streamable-HTTP guard so unexpected-content-type failures
+                # log with caller context. ``get_tools()`` discovers across all
+                # connections; per-server enrichment happens in the patched
+                # transport via the contextvar.
+                first_slug = next(iter(connections), None)
+                first_url = getattr(connections[first_slug], "url", None) if first_slug else None
+                async with guarded_streamable_http(url=first_url, server_slug=first_slug):
+                    tools = await client.get_tools()
                 logger.info(f"Discovered {len(tools)} MCP tools for {self.name}")
 
                 tools = [tool for tool in tools if tool.name in mcp_tool_names]
@@ -751,7 +763,8 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                 callbacks=Callbacks(on_progress=on_mcp_progress),
             )
 
-            tools = await client.get_tools()
+            async with guarded_streamable_http(url=self.console_backend_mcp_url, server_slug="console"):
+                tools = await client.get_tools()
             tools = [t for t in tools if t.name in self._CONSOLE_SELF_IMPROVEMENT_TOOLS]
             validated = [_validate_tool_schema(t) for t in tools]
 

--- a/packages/orchestrator-agent/app/core/discovery.py
+++ b/packages/orchestrator-agent/app/core/discovery.py
@@ -18,7 +18,11 @@ from langchain_mcp_adapters.callbacks import Callbacks
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_mcp_adapters.sessions import StreamableHttpConnection
 from ringier_a2a_sdk.oauth import OidcOAuth2Client
-from ringier_a2a_sdk.utils.mcp_errors import format_mcp_error, is_retryable_mcp_error
+from ringier_a2a_sdk.utils.mcp_errors import (
+    format_mcp_error,
+    guarded_streamable_http,
+    is_retryable_mcp_error,
+)
 from ringier_a2a_sdk.utils.mcp_progress import on_mcp_progress
 
 from ..models.config import AgentSettings
@@ -246,9 +250,20 @@ class ToolDiscoveryService:
         last_error = None
         delay = initial_delay
 
+        # Best-effort: pull the URL for this server connection so log enrichment
+        # can name it. The client stores connections keyed by server slug.
+        server_url: str | None = None
+        try:
+            conn = getattr(client, "connections", {}).get(server_name)
+            if conn is not None:
+                server_url = getattr(conn, "url", None)
+        except Exception:
+            server_url = None
+
         for attempt in range(max_retries):
             try:
-                server_tools = await client.get_tools(server_name=server_name)
+                async with guarded_streamable_http(url=server_url, server_slug=server_name):
+                    server_tools = await client.get_tools(server_name=server_name)
                 # Tag tools with server_name metadata
                 for tool in server_tools:
                     if tool.metadata is None:

--- a/packages/ringier-a2a-sdk/ringier_a2a_sdk/agent/langgraph.py
+++ b/packages/ringier-a2a-sdk/ringier_a2a_sdk/agent/langgraph.py
@@ -31,7 +31,11 @@ from langgraph.errors import GraphRecursionError
 from langgraph.graph.state import CompiledStateGraph
 from pydantic import BaseModel, Field
 
-from ringier_a2a_sdk.utils.mcp_errors import format_mcp_error, is_retryable_mcp_error
+from ringier_a2a_sdk.utils.mcp_errors import (
+    format_mcp_error,
+    guarded_streamable_http,
+    is_retryable_mcp_error,
+)
 from ringier_a2a_sdk.utils.mcp_progress import on_mcp_progress
 
 from ..agent.base import BaseAgent
@@ -511,15 +515,18 @@ class LangGraphAgent(BaseAgent):
         last_error = None
         delay = initial_delay
 
+        connection_url = getattr(connection, "url", None)
+
         for attempt in range(max_retries):
             try:
-                tools = await load_mcp_tools(
-                    session=None,
-                    connection=connection,
-                    tool_interceptors=interceptors,
-                    server_name=server_name,
-                    callbacks=callbacks,
-                )
+                async with guarded_streamable_http(url=connection_url, server_slug=server_name):
+                    tools = await load_mcp_tools(
+                        session=None,
+                        connection=connection,
+                        tool_interceptors=interceptors,
+                        server_name=server_name,
+                        callbacks=callbacks,
+                    )
                 if attempt > 0:
                     logger.info(f"Successfully loaded MCP tools from {server_name} on attempt {attempt + 1}")
                 return tools

--- a/packages/ringier-a2a-sdk/ringier_a2a_sdk/utils/mcp_errors.py
+++ b/packages/ringier-a2a-sdk/ringier_a2a_sdk/utils/mcp_errors.py
@@ -1,6 +1,107 @@
-"""MCP error handling utilities for retry logic and user-friendly error messages."""
+"""MCP error handling utilities for retry logic and user-friendly error messages.
+
+This module also installs a process-wide guard around the upstream
+``mcp.client.streamable_http`` transport so that endpoints returning an
+unexpected content type (e.g. an HTML auth redirect or proxy error page)
+fail the affected MCP request synchronously and surface a typed
+:class:`MCPUnexpectedContentTypeError` instead of leaving the JSON-RPC
+request hung until the caller's outer stall timeout fires.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Optional
 
 import httpx
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Typed exception
+# ---------------------------------------------------------------------------
+
+
+class MCPUnexpectedContentTypeError(Exception):
+    """Raised when an MCP endpoint returns a non-MCP content type.
+
+    The upstream ``mcp`` SDK only logs ``Unexpected content type: ...`` and
+    leaves the in-flight JSON-RPC request hanging. Our guard (see
+    :func:`install_streamable_http_guard`) intercepts that path and forwards
+    this typed exception so callers fail fast with full context.
+
+    Attributes:
+        url: The MCP endpoint URL that returned the bad content type.
+        server_slug: Optional MCP server slug, when known by the caller.
+        content_type: The offending ``Content-Type`` header value.
+        body_snippet: Best-effort first ~200 bytes of the response body (or
+            ``None`` if the body was not captured).
+    """
+
+    def __init__(
+        self,
+        url: Optional[str],
+        server_slug: Optional[str],
+        content_type: str,
+        body_snippet: Optional[str] = None,
+    ) -> None:
+        self.url = url
+        self.server_slug = server_slug
+        self.content_type = content_type
+        self.body_snippet = body_snippet
+        super().__init__(_format_unexpected_content_type(url, server_slug, content_type, body_snippet))
+
+
+def _likely_cause_hint(content_type: str, body_snippet: Optional[str]) -> str:
+    ct = (content_type or "").lower()
+    snippet_hint = ""
+    if body_snippet:
+        head = body_snippet.strip().splitlines()[0][:80] if body_snippet.strip() else ""
+        if head:
+            snippet_hint = f' — body started with "{head}"'
+    if "html" in ct:
+        return f"auth redirect, proxy error page, or wrong gateway URL{snippet_hint}"
+    if "text/plain" in ct:
+        return f"endpoint returned plain text instead of JSON/SSE — wrong URL or upstream error page{snippet_hint}"
+    return f"endpoint returned non-MCP content; check URL and authentication{snippet_hint}"
+
+
+def _format_unexpected_content_type(
+    url: Optional[str],
+    server_slug: Optional[str],
+    content_type: str,
+    body_snippet: Optional[str],
+) -> str:
+    parts = [f"MCP endpoint returned unexpected content type '{content_type}'"]
+    if url:
+        parts.append(f"for {url}")
+    if server_slug:
+        parts.append(f"(server slug: {server_slug})")
+    parts.append(f"— likely cause: {_likely_cause_hint(content_type, body_snippet)}")
+    return " ".join(parts)
+
+
+def _find_in_exception_group(error: BaseException, cls: type) -> Optional[BaseException]:
+    """Walk an ExceptionGroup (Python 3.11+) returning the first exception of *cls*, if any."""
+    if isinstance(error, cls):
+        return error
+    if error.__class__.__name__ == "ExceptionGroup":
+        for exc in getattr(error, "exceptions", []) or []:
+            found = _find_in_exception_group(exc, cls)
+            if found is not None:
+                return found
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Classification & formatting helpers
+# ---------------------------------------------------------------------------
 
 
 def is_retryable_mcp_error(error: Exception) -> bool:
@@ -15,6 +116,7 @@ def is_retryable_mcp_error(error: Exception) -> bool:
     Non-retryable errors:
     - HTTP 4xx (client errors, authentication failures)
     - Connection refused (service not running)
+    - :class:`MCPUnexpectedContentTypeError` (endpoint is misconfigured, not transient)
     - Other permanent failures
 
     Args:
@@ -23,6 +125,10 @@ def is_retryable_mcp_error(error: Exception) -> bool:
     Returns:
         True if the error is transient and should be retried
     """
+    # HTML / unexpected-content-type failures are misconfiguration, not transient.
+    if _find_in_exception_group(error, MCPUnexpectedContentTypeError) is not None:
+        return False
+
     # Handle ExceptionGroup (Python 3.11+) from anyio/MCP client
     if hasattr(error, "__class__") and error.__class__.__name__ == "ExceptionGroup":
         exceptions = getattr(error, "exceptions", [error])
@@ -56,6 +162,11 @@ def format_mcp_error(error: Exception) -> str:
     Returns:
         User-friendly error message
     """
+    # Unexpected-content-type takes precedence — even inside an ExceptionGroup.
+    found = _find_in_exception_group(error, MCPUnexpectedContentTypeError)
+    if isinstance(found, MCPUnexpectedContentTypeError):
+        return str(found)
+
     # Handle ExceptionGroup (Python 3.11+) from anyio/MCP client
     if hasattr(error, "__class__") and error.__class__.__name__ == "ExceptionGroup":
         # Extract the first HTTPStatusError from the exception group
@@ -104,3 +215,185 @@ def format_mcp_error(error: Exception) -> str:
 
     # Fallback for other errors
     return f"Failed to connect to MCP server: {type(error).__name__}: {str(error)}"
+
+
+# ---------------------------------------------------------------------------
+# Streamable-HTTP guard: monkey-patch + log dedup
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _GuardContext:
+    """Per-call context used by the streamable-HTTP guard to enrich captures."""
+
+    url: Optional[str] = None
+    server_slug: Optional[str] = None
+    captured: list = field(default_factory=list)
+
+
+_current_guard: contextvars.ContextVar[Optional[_GuardContext]] = contextvars.ContextVar(
+    "_ringier_mcp_streamable_guard", default=None
+)
+
+
+class _UpstreamDedupFilter(logging.Filter):
+    """Collapse repeated 'Unexpected content type' lines from the upstream MCP logger.
+
+    Each connection in ``MultiServerMCPClient`` spins up its own transport, so a
+    single broken endpoint can produce N identical log lines per refresh fan-out.
+    This filter lets the first occurrence through within a rolling window and
+    suppresses identical repeats until the window elapses, at which point a new
+    line is allowed (so a still-broken endpoint stays visible over time).
+    """
+
+    def __init__(self, window_seconds: float = 30.0) -> None:
+        super().__init__()
+        self._window = float(window_seconds)
+        self._seen: dict[str, float] = {}
+        self._lock = threading.Lock()
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: A003 - logging API
+        try:
+            msg = record.getMessage()
+        except Exception:
+            return True
+        if not msg.startswith("Unexpected content type:"):
+            return True
+        now = time.monotonic()
+        with self._lock:
+            last = self._seen.get(msg)
+            if last is None or (now - last) > self._window:
+                self._seen[msg] = now
+                # Prune old entries opportunistically.
+                if len(self._seen) > 64:
+                    cutoff = now - self._window
+                    self._seen = {k: v for k, v in self._seen.items() if v >= cutoff}
+                return True
+        return False
+
+
+_PATCH_INSTALLED_ATTR = "_ringier_streamable_guard_installed"
+_install_lock = threading.Lock()
+_dedup_filter: Optional[_UpstreamDedupFilter] = None
+
+
+def install_streamable_http_guard() -> None:
+    """Idempotently install the streamable-HTTP guard.
+
+    Effects:
+    - Replaces ``StreamableHTTPTransport._handle_unexpected_content_type`` so
+      that an unexpected content type forwards a typed exception into the
+      read stream AND closes the stream — making any in-flight JSON-RPC
+      request fail fast with ``CONNECTION_CLOSED`` instead of hanging.
+    - Attaches a dedup filter to the ``mcp.client.streamable_http`` logger so
+      the upstream warning is not repeated for the same endpoint within a
+      short window.
+    - Adds one structured ERROR log per occurrence to our own logger with
+      the URL, server slug (if known via :func:`guarded_streamable_http`),
+      content type, and a likely-cause hint.
+
+    Safe to call from import-time and from multiple call sites.
+    """
+    global _dedup_filter
+
+    with _install_lock:
+        try:
+            from mcp.client.streamable_http import (  # type: ignore[import-not-found]
+                StreamableHTTPTransport,
+            )
+        except Exception:  # pragma: no cover - mcp not installed
+            return
+
+        if getattr(StreamableHTTPTransport, _PATCH_INSTALLED_ATTR, False):
+            return
+
+        async def _patched_handle_unexpected_content_type(
+            self,  # type: ignore[no-untyped-def]
+            content_type: str,
+            read_stream_writer,
+        ) -> None:
+            url = getattr(self, "url", None)
+            ctx = _current_guard.get()
+            server_slug = ctx.server_slug if ctx is not None else None
+            if ctx is not None and not ctx.url:
+                ctx.url = str(url) if url is not None else None
+
+            exc = MCPUnexpectedContentTypeError(
+                url=str(url) if url is not None else None,
+                server_slug=server_slug,
+                content_type=content_type,
+                body_snippet=None,
+            )
+            if ctx is not None:
+                ctx.captured.append(exc)
+
+            # One structured, actionable log per occurrence (the dedup filter on
+            # the upstream logger suppresses the noisy companion line for repeats).
+            logger.error(
+                "MCP endpoint returned unexpected content type '%s' for %s "
+                "(server_slug=%s) — likely cause: %s",
+                content_type,
+                url,
+                server_slug,
+                _likely_cause_hint(content_type, None),
+            )
+
+            # Forward the typed exception so the session's receive loop sees it,
+            # then close the writer so any pending in-flight requests on this
+            # session immediately receive CONNECTION_CLOSED rather than hanging.
+            with contextlib.suppress(Exception):
+                await read_stream_writer.send(exc)
+            with contextlib.suppress(Exception):
+                await read_stream_writer.aclose()
+
+        StreamableHTTPTransport._handle_unexpected_content_type = (  # type: ignore[assignment]
+            _patched_handle_unexpected_content_type
+        )
+        setattr(StreamableHTTPTransport, _PATCH_INSTALLED_ATTR, True)
+
+        # Attach dedup filter to the upstream logger.
+        if _dedup_filter is None:
+            _dedup_filter = _UpstreamDedupFilter()
+            logging.getLogger("mcp.client.streamable_http").addFilter(_dedup_filter)
+
+
+@contextlib.asynccontextmanager
+async def guarded_streamable_http(
+    url: Optional[str] = None,
+    server_slug: Optional[str] = None,
+):
+    """Async context manager that enriches and surfaces unexpected-content-type errors.
+
+    Wrap MCP discovery / tool-call sites with this manager so that:
+
+    1. The upstream "Unexpected content type" log is enriched with the caller's
+       known ``server_slug`` (the transport only knows the URL).
+    2. If the guard's monkey-patch fired during the block, a typed
+       :class:`MCPUnexpectedContentTypeError` is raised at exit, chaining the
+       generic ``Connection closed`` error the session would otherwise surface.
+
+    The patch itself works without this wrapper — callers that don't wrap will
+    still fail fast with the generic ``Connection closed`` from the session,
+    plus the structured ERROR log from the patch.
+    """
+    install_streamable_http_guard()
+    ctx = _GuardContext(url=url, server_slug=server_slug)
+    token = _current_guard.set(ctx)
+    try:
+        try:
+            yield
+        except BaseException as exc:
+            if ctx.captured:
+                raise ctx.captured[0] from exc
+            raise
+        else:
+            if ctx.captured:
+                raise ctx.captured[0]
+    finally:
+        _current_guard.reset(token)
+
+
+# Auto-install at import time so every MCP call site is protected without
+# requiring the wrapper. Importing this module (already done by every call
+# site that uses format_mcp_error / is_retryable_mcp_error) is enough.
+install_streamable_http_guard()

--- a/packages/ringier-a2a-sdk/tests/test_mcp_errors.py
+++ b/packages/ringier-a2a-sdk/tests/test_mcp_errors.py
@@ -1,0 +1,244 @@
+"""Tests for MCP error classification, formatting, and the streamable-HTTP guard."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import socket
+import threading
+from contextlib import asynccontextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from ringier_a2a_sdk.utils.mcp_errors import (
+    MCPUnexpectedContentTypeError,
+    _UpstreamDedupFilter,
+    format_mcp_error,
+    guarded_streamable_http,
+    install_streamable_http_guard,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers: tiny HTTP server that always responds with text/html.
+# ---------------------------------------------------------------------------
+
+
+class _HtmlOnlyHandler(BaseHTTPRequestHandler):
+    def _serve_html(self) -> None:
+        body = b"<!DOCTYPE html><html><body>Login redirect</body></html>"
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        if length:
+            try:
+                self.rfile.read(length)
+            except Exception:
+                pass
+        self._serve_html()
+
+    def do_GET(self) -> None:  # noqa: N802
+        self._serve_html()
+
+    def log_message(self, format: str, *args) -> None:  # noqa: A002
+        # Silence the default stderr access log during tests.
+        return
+
+
+@asynccontextmanager
+async def _html_server():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    server = HTTPServer(("127.0.0.1", port), _HtmlOnlyHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}/mcp"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+# ---------------------------------------------------------------------------
+# Classification & formatting
+# ---------------------------------------------------------------------------
+
+
+def test_unexpected_content_type_message_includes_url_and_hint():
+    err = MCPUnexpectedContentTypeError(
+        url="https://gw.example/mcp",
+        server_slug="console",
+        content_type="text/html; charset=utf-8",
+        body_snippet="<!DOCTYPE html>\n<html>",
+    )
+    msg = str(err)
+    assert "text/html" in msg
+    assert "https://gw.example/mcp" in msg
+    assert "console" in msg
+    assert "auth redirect" in msg
+    assert "<!DOCTYPE html>" in msg
+
+
+def test_format_mcp_error_handles_unexpected_content_type():
+    err = MCPUnexpectedContentTypeError(
+        url="https://gw.example/mcp",
+        server_slug=None,
+        content_type="text/html",
+    )
+    out = format_mcp_error(err)
+    assert "text/html" in out
+    assert "https://gw.example/mcp" in out
+
+
+def test_format_mcp_error_handles_exception_group_wrapper():
+    inner = MCPUnexpectedContentTypeError(
+        url="https://gw.example/mcp",
+        server_slug="gateway",
+        content_type="text/html",
+    )
+    # Python 3.11+ ExceptionGroup
+    group = ExceptionGroup("mcp failed", [inner])
+    out = format_mcp_error(group)
+    assert "text/html" in out
+    assert "https://gw.example/mcp" in out
+
+
+def test_is_retryable_returns_false_for_unexpected_content_type():
+    from ringier_a2a_sdk.utils.mcp_errors import is_retryable_mcp_error
+
+    err = MCPUnexpectedContentTypeError(
+        url="https://gw.example/mcp",
+        server_slug=None,
+        content_type="text/html",
+    )
+    assert is_retryable_mcp_error(err) is False
+    # And wrapped in an ExceptionGroup (the shape anyio/MCP produces).
+    group = ExceptionGroup("mcp failed", [err])
+    assert is_retryable_mcp_error(group) is False
+
+
+# ---------------------------------------------------------------------------
+# Dedup filter
+# ---------------------------------------------------------------------------
+
+
+def _make_record(msg: str) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="mcp.client.streamable_http",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg=msg,
+        args=(),
+        exc_info=None,
+    )
+
+
+def test_dedup_filter_suppresses_repeats_within_window_and_passes_new_endpoints():
+    f = _UpstreamDedupFilter(window_seconds=60.0)
+    msg_a = "Unexpected content type: text/html; charset=utf-8"
+    msg_b = "Unexpected content type: text/plain"
+
+    # First occurrence for endpoint A passes.
+    assert f.filter(_make_record(msg_a)) is True
+    # Repeats for A within window are suppressed.
+    assert f.filter(_make_record(msg_a)) is False
+    assert f.filter(_make_record(msg_a)) is False
+    # A different endpoint (different log line) passes immediately.
+    assert f.filter(_make_record(msg_b)) is True
+    assert f.filter(_make_record(msg_b)) is False
+
+    # Unrelated log lines are always allowed through.
+    assert f.filter(_make_record("Something else entirely")) is True
+    assert f.filter(_make_record("Something else entirely")) is True
+
+
+def test_dedup_filter_allows_new_occurrence_after_window():
+    f = _UpstreamDedupFilter(window_seconds=0.05)
+    msg = "Unexpected content type: text/html"
+    assert f.filter(_make_record(msg)) is True
+    assert f.filter(_make_record(msg)) is False
+    # Wait past the window.
+    import time
+
+    time.sleep(0.1)
+    assert f.filter(_make_record(msg)) is True
+
+
+# ---------------------------------------------------------------------------
+# Streamable-HTTP guard: end-to-end with a real local HTML server.
+# ---------------------------------------------------------------------------
+
+
+def _find_unexpected_ct(err: BaseException) -> MCPUnexpectedContentTypeError | None:
+    """Walk an exception chain / ExceptionGroup looking for our typed exception."""
+    seen: set[int] = set()
+    stack: list[BaseException] = [err]
+    while stack:
+        cur = stack.pop()
+        if cur is None or id(cur) in seen:
+            continue
+        seen.add(id(cur))
+        if isinstance(cur, MCPUnexpectedContentTypeError):
+            return cur
+        if cur.__class__.__name__ == "ExceptionGroup":
+            stack.extend(getattr(cur, "exceptions", []) or [])
+        if cur.__cause__ is not None:
+            stack.append(cur.__cause__)
+        if cur.__context__ is not None:
+            stack.append(cur.__context__)
+    return None
+
+
+def test_streamable_http_guard_fails_fast_on_html_response():
+    """An MCP endpoint returning text/html must raise within seconds, not hang."""
+    install_streamable_http_guard()
+
+    # Importing here to keep test-time dependency on the upstream mcp client local.
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    async def _run() -> BaseException:
+        async with _html_server() as url:
+
+            async def _attempt() -> None:
+                # Real-world shape: the guard wraps the whole MCP call so that
+                # the patched transport (running in subtasks of streamablehttp_client)
+                # inherits the contextvar set here.
+                async with guarded_streamable_http(url=url, server_slug="test"):
+                    async with streamablehttp_client(url) as (read, write, _):
+                        async with ClientSession(read, write) as session:
+                            await session.initialize()
+
+            try:
+                await asyncio.wait_for(_attempt(), timeout=10.0)
+            except BaseException as exc:  # noqa: BLE001 - test wants the actual exception
+                return exc
+            raise AssertionError("expected the call to raise but it returned cleanly")
+
+    err = asyncio.run(_run())
+    found = _find_unexpected_ct(err)
+    assert found is not None, f"Expected MCPUnexpectedContentTypeError, got {err!r}"
+    assert "text/html" in found.content_type
+    assert found.server_slug == "test"
+    assert found.url and found.url.startswith("http://127.0.0.1:")
+
+
+def test_streamable_http_guard_install_is_idempotent():
+    install_streamable_http_guard()
+    install_streamable_http_guard()
+    install_streamable_http_guard()
+
+    from mcp.client.streamable_http import StreamableHTTPTransport
+
+    assert getattr(StreamableHTTPTransport, "_ringier_streamable_guard_installed", False) is True


### PR DESCRIPTION
when an MCP endpoint returns HTML instead of JSON/SSE, fail fast with an actionable error instead of hanging

## Checklist
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨
