### PR TITLE
fix: sub-agent stream stall timeout with heartbeat

### DIFF
--- a/packages/orchestrator-agent/app/middleware/dynamic_tool_dispatch.py
+++ b/packages/orchestrator-agent/app/middleware/dynamic_tool_dispatch.py
@@ -30,8 +30,10 @@ import asyncio
 import inspect
 import json
 import logging
+import os
 import re
 import textwrap
+import uuid
 from collections.abc import Awaitable, Callable
 from typing import Any, AsyncIterable, Optional, TypedDict, cast
 
@@ -82,6 +84,208 @@ from ..core.steering_state import ActiveSubagentDispatch, clear_active_subagent_
 from ..models.config import GraphRuntimeContext
 
 logger = logging.getLogger(__name__)
+
+
+def _positive_float_env(name: str, default: float) -> float:
+    """Read a positive float from env with a safe default on parse error / non-positive."""
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+# Per-iteration heartbeat tick: how long to wait for the next sub-agent stream item
+# before logging a "still waiting on <agent> after Ns" heartbeat and continuing to wait.
+SUBAGENT_STREAM_TICK_SECONDS = _positive_float_env("SUBAGENT_STREAM_TICK_SECONDS", 30.0)
+
+# Hard cap: total seconds with no new stream item from the sub-agent before the
+# consumer loop gives up and surfaces an ErrorEvent through the existing error path.
+SUBAGENT_STREAM_STALL_TIMEOUT_SECONDS = _positive_float_env(
+    "SUBAGENT_STREAM_STALL_TIMEOUT_SECONDS", 300.0
+)
+
+
+async def _iter_subagent_stream_with_stall_timeout(
+    stream_iter: AsyncIterable[Any],
+    *,
+    subagent_type: str,
+    orchestrator_conversation_id: Optional[str],
+    subagent_thread_id: str,
+    tick_seconds: float = SUBAGENT_STREAM_TICK_SECONDS,
+    hard_cap_seconds: float = SUBAGENT_STREAM_STALL_TIMEOUT_SECONDS,
+) -> AsyncIterable[Any]:
+    """Wrap a sub-agent async stream with a per-item stall timeout.
+
+    Yields each item from `stream_iter` as it arrives. If no item arrives for
+    `tick_seconds`, emits a heartbeat warning log and keeps waiting. If the
+    cumulative wait since the last item exceeds `hard_cap_seconds`, logs a
+    structured stall error, closes the upstream iterator best-effort, yields a
+    single `ErrorEvent` describing the stall, and stops. Never propagates the
+    internal `asyncio.TimeoutError` out of the generator.
+
+    Each invocation generates a short ``dispatch_id`` once and threads it into
+    every log line (entry, heartbeat, stall-error) and into the metadata of any
+    yielded ``ErrorEvent``. This disambiguates concurrent sub-agent dispatches
+    that share the same ``subagent_thread_id`` (the orchestrator fans out
+    parallel ``task`` tool calls), so operators can group log lines by dispatch
+    and downstream alerting can correlate logs to events.
+    """
+    iterator = stream_iter.__aiter__() if hasattr(stream_iter, "__aiter__") else stream_iter
+    loop = asyncio.get_event_loop()
+    stall_started_at = loop.time()
+    item_count = 0
+    stalled_out = False
+    pending: Optional[asyncio.Task] = None
+
+    dispatch_id = uuid.uuid4().hex[:8]
+
+    logger.info(
+        "[STREAMING] Starting sub-agent dispatch %s: agent=%s, "
+        "orchestrator_conversation_id=%s, subagent_thread_id=%s, "
+        "tick=%.1fs, hard_cap=%.1fs",
+        dispatch_id,
+        subagent_type,
+        orchestrator_conversation_id,
+        subagent_thread_id,
+        tick_seconds,
+        hard_cap_seconds,
+    )
+
+    # Drive the upstream async iterator from a SINGLE long-lived task. The
+    # sub-agent stream sets/resets ContextVars (the parent stream context in
+    # graph_utils and the attachments backend) whose ``contextvars.Token``
+    # objects are bound to the exact context that executed ``set()``. Driving
+    # ``__anext__`` from a fresh ``asyncio`` task per item gives each item a
+    # *copied* context, so a later ``reset(token)`` runs in a different context
+    # and raises "Token was created in a different Context". Consuming the whole
+    # stream inside one task keeps every set()/reset() pair in the same context.
+    # The per-item heartbeat/stall logic below then waits on a queue instead of
+    # on ``__anext__`` directly.
+    stream_done = object()
+    queue: "asyncio.Queue[Any]" = asyncio.Queue(maxsize=1)
+    consumer_error: list[BaseException] = []
+
+    async def _drain_stream() -> None:
+        try:
+            async for produced in iterator:
+                await queue.put(produced)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # surfaced to the consumer loop below
+            consumer_error.append(exc)
+        await queue.put(stream_done)
+
+    consumer_task: asyncio.Task = asyncio.ensure_future(_drain_stream())
+
+    try:
+        while True:
+            if pending is None:
+                # Observe the next queued item without cancelling the in-flight
+                # read on a heartbeat tick. The upstream ``__anext__`` runs in
+                # the consumer task above (never cancelled by a tick); only this
+                # queue read is parked across heartbeats. Cancellation of the
+                # in-flight read happens only once the hard cap is exceeded.
+                pending = asyncio.ensure_future(queue.get())
+
+            done, _ = await asyncio.wait({pending}, timeout=tick_seconds)
+
+            if not done:
+                waited = loop.time() - stall_started_at
+                if waited >= hard_cap_seconds:
+                    logger.error(
+                        "[STREAMING] Sub-agent stream stalled: dispatch_id=%s, "
+                        "agent=%s, orchestrator_conversation_id=%s, "
+                        "subagent_thread_id=%s, waited=%.1fs, "
+                        "last_item_count=%d, hard_cap=%.1fs",
+                        dispatch_id,
+                        subagent_type,
+                        orchestrator_conversation_id,
+                        subagent_thread_id,
+                        waited,
+                        item_count,
+                        hard_cap_seconds,
+                    )
+                    stalled_out = True
+                    break
+                logger.warning(
+                    "[STREAMING] Still waiting on sub-agent '%s' after %.1fs "
+                    "(dispatch_id=%s, orchestrator_conversation_id=%s, "
+                    "subagent_thread_id=%s, items_so_far=%d, hard_cap=%.1fs)",
+                    subagent_type,
+                    waited,
+                    dispatch_id,
+                    orchestrator_conversation_id,
+                    subagent_thread_id,
+                    item_count,
+                    hard_cap_seconds,
+                )
+                # Leave `pending` in place across the heartbeat — do NOT cancel it.
+                continue
+
+            # The queue read completed; consume it and prepare for the next item.
+            task = pending
+            pending = None
+            item = task.result()
+            if item is stream_done:
+                # Upstream finished (or raised). Surface a stream exception with
+                # the same propagation semantics as a plain ``async for``.
+                if consumer_error:
+                    raise consumer_error[0]
+                return
+
+            stall_started_at = loop.time()
+            item_count += 1
+            yield item
+    finally:
+        # Stop observing the queue if a read is still parked (heartbeat in
+        # flight when we leave the loop).
+        if pending is not None and not pending.done():
+            pending.cancel()
+            try:
+                await pending
+            except (asyncio.CancelledError, Exception):
+                pass
+        # Cancel the upstream consumer if it is still running (stall hard cap,
+        # generator close, or exception leaving the loop). This cancels the
+        # in-flight ``__anext__``, matching the previous behavior of only
+        # cancelling the read once the hard cap is exceeded.
+        if not consumer_task.done():
+            consumer_task.cancel()
+        try:
+            await consumer_task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    if stalled_out:
+        aclose = getattr(iterator, "aclose", None)
+        if aclose is not None:
+            try:
+                await aclose()
+            except Exception as close_exc:  # pragma: no cover - best effort cleanup
+                logger.debug(
+                    "[STREAMING] Ignoring error while closing stalled sub-agent iterator: %s",
+                    close_exc,
+                )
+        yield ErrorEvent(
+            error=(
+                f"Sub-agent '{subagent_type}' stopped producing output for more than "
+                f"{int(hard_cap_seconds)}s and was aborted by the orchestrator stall timeout."
+            ),
+            data=TaskResponseData(
+                metadata={
+                    "dispatch_id": dispatch_id,
+                    "subagent_type": subagent_type,
+                    "orchestrator_conversation_id": orchestrator_conversation_id,
+                    "subagent_thread_id": subagent_thread_id,
+                    "hard_cap_seconds": hard_cap_seconds,
+                    "stall_reason": "subagent_stream_stall_timeout",
+                }
+            ),
+        )
 
 
 class A2ACompiledSubAgent(TypedDict, total=False):
@@ -1558,7 +1762,21 @@ class DynamicToolDispatchMiddleware(AgentMiddleware[AgentState, GraphRuntimeCont
                 hasattr(agent_state, "resume"),
                 agent_config.get("configurable", {}).get("thread_id", "?"),
             )
-            async for item in runnable.astream(agent_state, agent_config):  # type: ignore[arg-type]
+
+            # Iterate with per-item stall timeout so a silent sub-agent (parked LLM
+            # call, bad MCP content type, unresponsive provider, DB lock) cannot hang
+            # the orchestrator indefinitely. The helper emits heartbeat warnings on
+            # each tick and yields an ErrorEvent through the existing error path
+            # after the hard cap.
+            sub_thread_id = agent_config.get("configurable", {}).get("thread_id", "?")
+            wrapped_stream = _iter_subagent_stream_with_stall_timeout(
+                runnable.astream(agent_state, agent_config),  # type: ignore[arg-type]
+                subagent_type=subagent_type,
+                orchestrator_conversation_id=orchestrator_conversation_id,
+                subagent_thread_id=sub_thread_id,
+            )
+
+            async for item in wrapped_stream:
                 item_count += 1
                 item_type = type(item).__name__
                 logger.info(f"[STREAMING] astream_a2a_agent received item #{item_count}: {item_type}")

--- a/packages/orchestrator-agent/app/middleware/dynamic_tool_dispatch.py
+++ b/packages/orchestrator-agent/app/middleware/dynamic_tool_dispatch.py
@@ -134,7 +134,7 @@ async def _iter_subagent_stream_with_stall_timeout(
     parallel ``task`` tool calls), so operators can group log lines by dispatch
     and downstream alerting can correlate logs to events.
     """
-    iterator = stream_iter.__aiter__() if hasattr(stream_iter, "__aiter__") else stream_iter
+    iterator = aiter(stream_iter)
     loop = asyncio.get_event_loop()
     stall_started_at = loop.time()
     item_count = 0

--- a/packages/orchestrator-agent/tests/test_subagent_stream_stall_timeout.py
+++ b/packages/orchestrator-agent/tests/test_subagent_stream_stall_timeout.py
@@ -1,0 +1,348 @@
+"""Tests for the sub-agent stream stall timeout helper.
+
+Covers the behavior introduced to prevent the orchestrator's sub-agent consumer
+loop from hanging silently when a sub-agent stops producing items (parked LLM
+call, unresponsive provider, MCP content-type error, DB lock, etc.).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import logging
+
+import pytest
+
+from agent_common.a2a.stream_events import ErrorEvent
+from app.middleware.dynamic_tool_dispatch import _iter_subagent_stream_with_stall_timeout
+
+
+class _NeverYields:
+    """Async iterator that never yields and can be closed."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def __aiter__(self) -> "_NeverYields":
+        return self
+
+    async def __anext__(self):
+        # Park forever; the wrap_for timeout in the helper must cancel us.
+        await asyncio.Event().wait()
+        raise AssertionError("should never reach here")  # pragma: no cover
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class _YieldsThenStalls:
+    """Yields the supplied items, then parks forever."""
+
+    def __init__(self, items: list) -> None:
+        self._items = list(items)
+        self.closed = False
+
+    def __aiter__(self) -> "_YieldsThenStalls":
+        return self
+
+    async def __anext__(self):
+        if self._items:
+            return self._items.pop(0)
+        await asyncio.Event().wait()
+        raise AssertionError("should never reach here")  # pragma: no cover
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_stall_timeout_yields_error_event_and_logs_heartbeat(caplog):
+    """A stream that never yields hits the hard cap, logs heartbeat + error,
+    yields exactly one ErrorEvent, and does not leak an exception."""
+    caplog.set_level(logging.DEBUG, logger="app.middleware.dynamic_tool_dispatch")
+    upstream = _NeverYields()
+
+    collected = []
+    async for item in _iter_subagent_stream_with_stall_timeout(
+        upstream,
+        subagent_type="stuck-agent",
+        orchestrator_conversation_id="conv-123",
+        subagent_thread_id="sub-thread-9",
+        tick_seconds=0.05,
+        hard_cap_seconds=0.18,  # ≥ 3 ticks → at least one heartbeat before the cap
+    ):
+        collected.append(item)
+
+    # Exactly one ErrorEvent yielded, with a clear stall message mentioning the agent.
+    assert len(collected) == 1, collected
+    error = collected[0]
+    assert isinstance(error, ErrorEvent)
+    assert "stuck-agent" in error.error
+    assert "stall" in error.error.lower()
+
+    # Heartbeat warning emitted at least once while we waited.
+    heartbeats = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and "Still waiting on sub-agent" in r.getMessage()
+    ]
+    assert heartbeats, "expected at least one heartbeat warning before hard cap"
+    assert any("stuck-agent" in r.getMessage() for r in heartbeats)
+
+    # Hard-cap error log emitted exactly once with diagnostic context.
+    stall_errors = [
+        r for r in caplog.records
+        if r.levelno == logging.ERROR and "Sub-agent stream stalled" in r.getMessage()
+    ]
+    assert len(stall_errors) == 1
+    msg = stall_errors[0].getMessage()
+    assert "stuck-agent" in msg
+    assert "conv-123" in msg
+    assert "sub-thread-9" in msg
+
+    # Upstream iterator was closed (no parked __anext__ left behind).
+    assert upstream.closed is True
+
+
+@pytest.mark.asyncio
+async def test_stall_timeout_passes_items_through_then_stalls():
+    """Items that arrive in time are forwarded unchanged; only a subsequent
+    stall produces an ErrorEvent. The stall window resets after each item."""
+    upstream = _YieldsThenStalls(["a", "b", "c"])
+
+    collected = []
+    async for item in _iter_subagent_stream_with_stall_timeout(
+        upstream,
+        subagent_type="partial-agent",
+        orchestrator_conversation_id=None,
+        subagent_thread_id="?",
+        tick_seconds=0.05,
+        hard_cap_seconds=0.12,
+    ):
+        collected.append(item)
+
+    assert collected[:3] == ["a", "b", "c"]
+    assert isinstance(collected[-1], ErrorEvent)
+    assert "partial-agent" in collected[-1].error
+    assert upstream.closed is True
+
+
+class _CancelSensitiveIterator:
+    """Async iterator whose in-flight ``__anext__`` MUST NOT be cancelled by a
+    heartbeat tick. If the helper cancels the pending task between ticks, the
+    iterator marks itself poisoned and stops yielding — modeling real network
+    / model streams that cannot survive mid-frame cancellation.
+
+    Each value takes ``per_item_seconds`` to arrive. With a tick smaller than
+    that, the helper must observe at least one heartbeat WITHOUT cancelling
+    the in-flight read.
+    """
+
+    def __init__(self, items: list, per_item_seconds: float) -> None:
+        self._items = list(items)
+        self._per_item_seconds = per_item_seconds
+        self.poisoned = False
+        self.cancel_count = 0
+
+    def __aiter__(self) -> "_CancelSensitiveIterator":
+        return self
+
+    async def __anext__(self):
+        if self.poisoned:
+            raise StopAsyncIteration
+        if not self._items:
+            raise StopAsyncIteration
+        try:
+            await asyncio.sleep(self._per_item_seconds)
+        except asyncio.CancelledError:
+            self.cancel_count += 1
+            self.poisoned = True
+            raise
+        return self._items.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_tick_does_not_cancel_in_flight_read(caplog):
+    """A long-latency item that takes longer than one tick to arrive must
+    still be delivered — the heartbeat must not cancel the pending __anext__.
+    Regression guard for cancellation-sensitive streams (real model/network
+    streams that get poisoned by mid-frame cancellation)."""
+    caplog.set_level(logging.WARNING, logger="app.middleware.dynamic_tool_dispatch")
+
+    # Each item takes 0.12s to arrive; tick is 0.05s → at least one heartbeat
+    # before each item lands. Hard cap is well above per-item latency so we
+    # should never actually trip the stall path.
+    upstream = _CancelSensitiveIterator(items=["x", "y"], per_item_seconds=0.12)
+
+    collected = []
+    async for item in _iter_subagent_stream_with_stall_timeout(
+        upstream,
+        subagent_type="slow-but-alive",
+        orchestrator_conversation_id="conv-slow",
+        subagent_thread_id="t-slow",
+        tick_seconds=0.05,
+        hard_cap_seconds=2.0,
+    ):
+        collected.append(item)
+
+    # Both items delivered intact — heartbeat did not poison the stream.
+    assert collected == ["x", "y"]
+    assert upstream.cancel_count == 0
+    assert upstream.poisoned is False
+
+    # And we still observed heartbeat warnings — proving the tick fired but
+    # left the pending read alone.
+    heartbeats = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and "Still waiting on sub-agent" in r.getMessage()
+    ]
+    assert heartbeats, "expected heartbeat warning while waiting for slow item"
+
+
+@pytest.mark.asyncio
+async def test_stall_timeout_completes_cleanly_when_upstream_finishes():
+    """A normal stream that ends via StopAsyncIteration produces no ErrorEvent."""
+
+    async def upstream():
+        for x in (1, 2, 3):
+            yield x
+
+    collected = []
+    async for item in _iter_subagent_stream_with_stall_timeout(
+        upstream(),
+        subagent_type="happy-agent",
+        orchestrator_conversation_id="conv-ok",
+        subagent_thread_id="t-ok",
+        tick_seconds=1.0,
+        hard_cap_seconds=5.0,
+    ):
+        collected.append(item)
+
+    assert collected == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_id_threaded_through_logs_and_error_event(caplog):
+    """The per-dispatch id generated at wrapper construction must appear on
+    the entry log, the heartbeat warning, the stall-error log, and in the
+    metadata of the yielded ErrorEvent."""
+    caplog.set_level(logging.INFO, logger="app.middleware.dynamic_tool_dispatch")
+    upstream = _NeverYields()
+
+    collected = []
+    async for item in _iter_subagent_stream_with_stall_timeout(
+        upstream,
+        subagent_type="stuck-agent",
+        orchestrator_conversation_id="conv-XYZ",
+        subagent_thread_id="t-shared",
+        tick_seconds=0.05,
+        hard_cap_seconds=0.18,
+    ):
+        collected.append(item)
+
+    assert len(collected) == 1
+    error = collected[0]
+    assert isinstance(error, ErrorEvent)
+    dispatch_id = error.data.metadata.get("dispatch_id")
+    assert isinstance(dispatch_id, str) and len(dispatch_id) == 8
+
+    entry_logs = [
+        r for r in caplog.records
+        if r.levelno == logging.INFO and "Starting sub-agent dispatch" in r.getMessage()
+    ]
+    assert any(dispatch_id in r.getMessage() for r in entry_logs), entry_logs
+
+    heartbeats = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and "Still waiting on sub-agent" in r.getMessage()
+    ]
+    assert heartbeats and all(dispatch_id in r.getMessage() for r in heartbeats)
+
+    stall_errors = [
+        r for r in caplog.records
+        if r.levelno == logging.ERROR and "Sub-agent stream stalled" in r.getMessage()
+    ]
+    assert len(stall_errors) == 1
+    assert dispatch_id in stall_errors[0].getMessage()
+
+    md = error.data.metadata
+    assert md.get("subagent_type") == "stuck-agent"
+    assert md.get("orchestrator_conversation_id") == "conv-XYZ"
+    assert md.get("subagent_thread_id") == "t-shared"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_wrappers_for_same_thread_id_get_distinct_dispatch_ids(caplog):
+    """Two concurrent wrappers that share the same subagent_thread_id (the
+    orchestrator fans out parallel `task` calls) must each get a distinct
+    dispatch id so their heartbeat lines can be told apart in the logs."""
+    caplog.set_level(logging.WARNING, logger="app.middleware.dynamic_tool_dispatch")
+
+    upstream_a = _NeverYields()
+    upstream_b = _NeverYields()
+
+    async def drain(upstream):
+        collected = []
+        async for item in _iter_subagent_stream_with_stall_timeout(
+            upstream,
+            subagent_type="general-purpose",
+            orchestrator_conversation_id="conv-same",
+            subagent_thread_id="t-shared",
+            tick_seconds=0.05,
+            hard_cap_seconds=0.18,
+        ):
+            collected.append(item)
+        return collected
+
+    results = await asyncio.gather(drain(upstream_a), drain(upstream_b))
+    id_a = results[0][0].data.metadata["dispatch_id"]
+    id_b = results[1][0].data.metadata["dispatch_id"]
+    assert id_a != id_b
+
+    heartbeat_msgs = [
+        r.getMessage() for r in caplog.records
+        if r.levelno == logging.WARNING and "Still waiting on sub-agent" in r.getMessage()
+    ]
+    assert any(id_a in m for m in heartbeat_msgs)
+    assert any(id_b in m for m in heartbeat_msgs)
+
+
+@pytest.mark.asyncio
+async def test_contextvar_set_reset_across_items_does_not_raise():
+    """Regression: the real sub-agent stream sets a ContextVar at stream start
+    and resets its ``contextvars.Token`` at stream end (graph_utils
+    ``isolate_parent_stream_context`` / ``denest_parent_pregel_context`` and
+    ``attachments_store`` ``current_attachments_backend``). A Token is bound to
+    the exact context that ran ``set()`` and may only be ``reset()`` from that
+    same context.
+
+    Driving ``__anext__`` from a fresh ``asyncio`` task per item gives each item
+    a *copied* context, so ``reset(token)`` runs in a different context and
+    raises ``ValueError: <Token ...> was created in a different Context`` on the
+    first real dispatch. The wrapper must consume the stream inside a single
+    task so every ``set()``/``reset()`` pair shares one context.
+    """
+    cvar: contextvars.ContextVar = contextvars.ContextVar("subagent_stream_cvar")
+
+    async def upstream():
+        # set() on entry (first __anext__), reset() in finally (last __anext__).
+        token = cvar.set("active")
+        try:
+            for value in ("p", "q", "r"):
+                yield value
+        finally:
+            cvar.reset(token)
+
+    collected = []
+    async for item in _iter_subagent_stream_with_stall_timeout(
+        upstream(),
+        subagent_type="ctx-agent",
+        orchestrator_conversation_id="conv-ctx",
+        subagent_thread_id="t-ctx",
+        tick_seconds=1.0,
+        hard_cap_seconds=5.0,
+    ):
+        collected.append(item)
+
+    # No ValueError leaked from the cross-context Token reset, all items intact,
+    # and no ErrorEvent (the stream finished cleanly).
+    assert collected == ["p", "q", "r"]


### PR DESCRIPTION
Problem: The orchestrator consumed a sub-agent's stream with a plain async for. If the sub-agent went silent (stuck LLM call, dead provider, MCP error, DB lock), the loop hung forever with no output and no signal of what was stuck.

How it was fixed: Added a wrapper that puts a per-item stall timeout around the stream. It logs a heartbeat every 30s while waiting (without cancelling the in-flight read), and after a 300s hard cap it closes the stream and emits one ErrorEvent instead of hanging. Both timeouts are env-tunable, and each dispatch gets a unique id threaded through all logs + the error so parallel sub-agent calls can be told apart.


## Checklist
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨
