### PR TITLE
fix: reliable final-response delivery from sub-agents

### DIFF
--- a/packages/orchestrator-agent/app/core/executor.py
+++ b/packages/orchestrator-agent/app/core/executor.py
@@ -579,7 +579,9 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
 
             while True:
                 streaming_artifact_id = str(uuid.uuid4())
-                first_chunk_sent = False  # Track if we've sent the initial artifact
+                first_chunk_sent = False  # Track if we've sent the initial MAIN artifact chunk
+                first_intermediate_chunk_sent = False  # Track if we've sent the initial INTERMEDIATE artifact chunk
+                streamed_chars = 0  # Total chars streamed via the MAIN artifact (code points, not wire bytes; for completion diagnostics)
                 deferred_terminal_item = None
 
                 async for item in self.agent.stream(message_parts, user_config, config=config, resume=resume_value):
@@ -594,6 +596,11 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
                     metadata = item.metadata or {}
                     if metadata.get("streaming_chunk"):
                         is_final = True  # Doesn't matter for streaming chunks
+                        # Track MAIN-artifact bytes only (intermediate sub-agent thoughts
+                        # go to a separate "-thought" artifact and aren't part of the
+                        # main response stream the client renders).
+                        if not metadata.get("intermediate_output") and item.content:
+                            streamed_chars += len(item.content)
                     else:
                         current_state = graph.get_state(config)  # type: ignore
                         if hasattr(current_state, "interrupts") and current_state.interrupts:
@@ -601,15 +608,17 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
                         else:
                             is_final = True
 
-                    # Pass first_chunk_sent flag and update it after each chunk
-                    first_chunk_sent = await self._handle_stream_item(
+                    # Pass per-artifact first_chunk_sent flags and update after each chunk
+                    first_chunk_sent, first_intermediate_chunk_sent = await self._handle_stream_item(
                         item,
                         updater,
                         task,
                         is_final=is_final,
                         streaming_artifact_id=streaming_artifact_id,
                         first_chunk_sent=first_chunk_sent,
+                        first_intermediate_chunk_sent=first_intermediate_chunk_sent,
                         active_extensions=requested_extensions,
+                        streamed_chars=streamed_chars,
                     )
 
                 # Check for steering messages that arrived after the last abefore_model
@@ -710,14 +719,16 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
                             is_final = False
                         else:
                             is_final = True
-                    await self._handle_stream_item(
+                    first_chunk_sent, first_intermediate_chunk_sent = await self._handle_stream_item(
                         deferred_terminal_item,
                         updater,
                         task,
                         is_final=is_final,
                         streaming_artifact_id=streaming_artifact_id,
                         first_chunk_sent=first_chunk_sent,
+                        first_intermediate_chunk_sent=first_intermediate_chunk_sent,
                         active_extensions=requested_extensions,
+                        streamed_chars=streamed_chars,
                     )
                 break  # Done — no re-invocation needed
         except asyncio.CancelledError:
@@ -776,13 +787,18 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
         is_final: bool,
         streaming_artifact_id: str = "",
         first_chunk_sent: bool = False,
+        first_intermediate_chunk_sent: bool = False,
         active_extensions: set[str] | None = None,
-    ) -> bool:
+        streamed_chars: int = 0,
+    ) -> tuple[bool, bool]:
         """Handle a stream item from the agent and update the task accordingly.
 
         Streaming chunks (metadata.streaming_chunk=True) are emitted as
-        TaskArtifactUpdateEvents with append=True for ALL chunks (including first).
-        The backend accumulates all artifact-update messages into a single response.
+        TaskArtifactUpdateEvents. The FIRST chunk for a given artifact_id must
+        be a create (append=False) so the A2A SDK registers the artifact;
+        subsequent chunks use append=True. Main content and intermediate
+        (sub-agent thought) chunks use separate artifact IDs and are therefore
+        tracked independently.
         Status updates and terminal events use TaskStatusUpdateEvents.
 
         Args:
@@ -791,10 +807,11 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
             task: Current task
             is_final: Whether this is the final state
             streaming_artifact_id: Stable artifact ID for streaming chunks
-            first_chunk_sent: Whether we've already sent the first chunk
+            first_chunk_sent: Whether the first main-artifact chunk has been sent
+            first_intermediate_chunk_sent: Whether the first intermediate-artifact chunk has been sent
 
         Returns:
-            Updated first_chunk_sent flag
+            Updated (first_chunk_sent, first_intermediate_chunk_sent) tuple
         """
         # item is an AgentStreamResponse object
         state = item.state
@@ -810,7 +827,7 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
         # Must be handled BEFORE streaming_chunk check.
         if metadata.get("activity_log"):
             if not _ext_active(ACTIVITY_LOG_EXTENSION):
-                return first_chunk_sent  # Client didn't request this extension
+                return first_chunk_sent, first_intermediate_chunk_sent  # Client didn't request this extension
             source = metadata.get("source")
             logger.info(f"[ACTIVITY_LOG] Emitting status update: source={source}, content: {content[:50]}")
             await updater.update_status(
@@ -822,12 +839,12 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
                     source=source,
                 ),
             )
-            return first_chunk_sent  # Don't modify first_chunk_sent flag
+            return first_chunk_sent, first_intermediate_chunk_sent  # Don't modify flags
 
         # --- Work plan items (todo snapshots) → status-update with DataPart extension ---
         if metadata.get("work_plan"):
             if not _ext_active(WORK_PLAN_EXTENSION):
-                return first_chunk_sent  # Client didn't request this extension
+                return first_chunk_sent, first_intermediate_chunk_sent  # Client didn't request this extension
             todos = metadata.get("todos", [])
             logger.info(f"[WORK_PLAN] Emitting work plan with {len(todos)} todos")
             await updater.update_status(
@@ -838,7 +855,7 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
                     task.id,
                 ),
             )
-            return first_chunk_sent  # Don't modify first_chunk_sent flag
+            return first_chunk_sent, first_intermediate_chunk_sent  # Don't modify flags
 
         # --- Streaming content chunks → artifact-append ---
         # NOTE: Using proper A2A artifact-append protocol
@@ -852,20 +869,33 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
             # Main response chunks use streaming_artifact_id; thoughts use a "-thought" suffix.
             # This also ensures first_chunk_sent correctly reflects MAIN CONTENT only, so that
             # include_subagent_output=True can still produce a non-streaming final response.
-            if metadata.get("intermediate_output"):
+            is_intermediate = bool(metadata.get("intermediate_output"))
+            if is_intermediate:
                 effective_artifact_id = streaming_artifact_id + "-thought"
             else:
                 effective_artifact_id = streaming_artifact_id
 
-            append = True  # Always True for all chunks (backend accumulates all artifact-update messages)
+            # A2A protocol: first chunk for an artifact_id MUST be a create
+            # (append=False) so the SDK registers the artifact; subsequent
+            # chunks may append (append=True). Sending append=True for the
+            # very first chunk causes the A2A layer to drop the bytes with:
+            #   "Received append=True for nonexistent artifact index ... Ignoring chunk."
+            # Track main and intermediate artifact creation independently because
+            # they use distinct artifact IDs.
+            if is_intermediate:
+                append = first_intermediate_chunk_sent
+            else:
+                append = first_chunk_sent
+
+            # Determine artifact extensions for intermediate output (sub-agent thoughts)
+            artifact_extensions = [INTERMEDIATE_OUTPUT_EXTENSION] if is_intermediate else None
+            # If intermediate output extension isn't active, suppress entirely (don't leak reasoning to clients)
+            if artifact_extensions and not _ext_active(INTERMEDIATE_OUTPUT_EXTENSION):
+                return first_chunk_sent, first_intermediate_chunk_sent
+
             logger.info(
                 f"[STREAMING] Calling add_artifact: len={len(content)}, append={append}, artifact_id={effective_artifact_id}"
             )
-            # Determine artifact extensions for intermediate output (sub-agent thoughts)
-            artifact_extensions = [INTERMEDIATE_OUTPUT_EXTENSION] if metadata.get("intermediate_output") else None
-            # If intermediate output extension isn't active, suppress entirely (don't leak reasoning to clients)
-            if artifact_extensions and not _ext_active(INTERMEDIATE_OUTPUT_EXTENSION):
-                return first_chunk_sent
             # Keep agent_name in artifact metadata for attribution
             artifact_metadata = {}
             if metadata.get("agent_name"):
@@ -880,13 +910,13 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
             )
             logger.info("[STREAMING] Artifact chunk enqueued")
             # Intermediate-output chunks are supplementary (sub-agent thinking).
-            # They must NOT claim first_chunk_sent — the main response comes later
+            # They must NOT claim first_chunk_sent (main) — the main response comes later
             # either as regular orchestrator streaming tokens or via include_subagent_output.
             # If we set first_chunk_sent=True here the executor would skip emitting the
             # include_subagent_output content and the final answer would never reach the user.
-            if metadata.get("intermediate_output"):
-                return first_chunk_sent
-            return True  # Mark that first chunk has been sent
+            if is_intermediate:
+                return first_chunk_sent, True  # Mark intermediate artifact created
+            return True, first_intermediate_chunk_sent  # Mark main artifact created
 
         # Handle different A2A task states
         if state == TaskState.working and not is_final:
@@ -942,62 +972,115 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
                     context_id=task.context_id,
                     task_id=task.id,
                 )
+                # Close any open streaming artifact before emitting the structured
+                # HITL status. A turn that streamed orchestrator tokens before
+                # hitting a guarded tool would otherwise leave the artifact stream
+                # permanently open on the client. NOTE: unlike the plain-text
+                # branches below, we do NOT set final_answer_source here — HITL is
+                # intentionally not routed through the artifact text-fallback
+                # (clients need the structured message); we only seal the stream.
+                if first_chunk_sent:
+                    await updater.add_artifact(
+                        [Part(root=TextPart(text=""))],
+                        artifact_id=streaming_artifact_id,
+                        append=True,
+                        last_chunk=True,
+                        metadata={},
+                    )
+                await updater.update_status(
+                    TaskState.input_required,
+                    msg,
+                )
             else:
-                # Generic input_required (no HITL extension or not subscribed)
+                # Generic input_required (no HITL extension or not subscribed).
+                #
+                # CONTRACT FOR CLIENTS: Mirror the `completed` path — the terminal
+                # input_required status ALWAYS carries the authoritative
+                # FinalResponseSchema.message in its message body, and (if the
+                # orchestrator streamed token chunks this turn) we close the
+                # streaming artifact cleanly first. This guarantees the user
+                # receives the orchestrator's reply even if intermediate SSE
+                # artifact frames were dropped or the client only renders status
+                # messages. The `final_answer_source: "fallback"` metadata flag
+                # signals well-behaved clients to dedupe against the artifact.
+                final_answer = content if content else "Additional input is required to continue."
                 msg = new_agent_text_message(
-                    content,
+                    final_answer,
                     task.context_id,
                     task.id,
                 )
                 if item.interrupt_reason:
                     msg.metadata = {"interrupt_reason": item.interrupt_reason}
-            await updater.update_status(
-                TaskState.input_required,
-                msg,
-            )
+                await self._close_streaming_artifact_and_respond(
+                    updater,
+                    TaskState.input_required,
+                    msg,
+                    streaming_artifact_id=streaming_artifact_id,
+                    first_chunk_sent=first_chunk_sent,
+                    streamed_chars=streamed_chars,
+                    final_message_len=len(final_answer),
+                    base_metadata=metadata,
+                )
 
         elif state == TaskState.auth_required:
-            # Authentication required - leave task in auth_required state
-            await updater.update_status(
+            # Authentication required - leave task in auth_required state.
+            #
+            # CONTRACT FOR CLIENTS: Mirror the `completed` path — the terminal
+            # auth_required status ALWAYS carries the authoritative
+            # FinalResponseSchema.message in its message body, and (if the
+            # orchestrator streamed token chunks this turn) we close the
+            # streaming artifact cleanly first. The `final_answer_source:
+            # "fallback"` metadata flag signals well-behaved clients to dedupe
+            # against the artifact text they already rendered.
+            final_answer = content if content else "Authentication is required to continue."
+            await self._close_streaming_artifact_and_respond(
+                updater,
                 TaskState.auth_required,
                 new_agent_text_message(
-                    content,
+                    final_answer,
                     task.context_id,
                     task.id,
                 ),
+                streaming_artifact_id=streaming_artifact_id,
+                first_chunk_sent=first_chunk_sent,
+                streamed_chars=streamed_chars,
+                final_message_len=len(final_answer),
+                base_metadata=metadata,
             )
 
         elif state == TaskState.completed and is_final:
-            # Task completed successfully
-            if first_chunk_sent:
-                # We streamed ORCHESTRATOR token chunks (not sub-agent thoughts)
-                # Close the artifact stream and send completion status without message.
-                # The streamed chunks already contain the complete response.
-                logger.info("[STREAMING] Closing artifact stream (orchestrator content already streamed)")
-                await updater.add_artifact(
-                    [Part(root=TextPart(text=""))],
-                    artifact_id=streaming_artifact_id,
-                    append=True,
-                    last_chunk=True,
-                    metadata={},
-                )
-                await updater.update_status(
-                    TaskState.completed,
-                    metadata=metadata or None,
-                )
-            else:
-                # Non-streaming completion: include content in the status message.
-                # This is the orchestrator's FINAL ANSWER - always send it.
-                # Sub-agent outputs were intermediate thoughts; this is authoritative.
-                await updater.update_status(
-                    TaskState.completed,
-                    new_agent_text_message(
-                        content if content else "Task completed successfully",
-                        task.context_id,
-                        task.id,
-                    ),
-                    metadata=metadata or None,
-                )
+            # Task completed successfully.
+            #
+            # CONTRACT FOR CLIENTS: The terminal `completed` status ALWAYS carries the
+            # authoritative final answer in its message body (the validated
+            # FinalResponseSchema.message). This is true for both the streamed and
+            # non-streamed branches. Clients that already rendered the streamed
+            # artifact chunks should treat this terminal message as the source of
+            # truth (dedupe / replace) rather than appending it — the
+            # `final_answer_source: "fallback"` metadata flag on the status update
+            # signals that the same text was also delivered via artifact-append.
+            # This guarantees the user receives the reply even if any intermediate
+            # SSE artifact frame fails to parse on the client side.
+            final_answer = content if content else "Task completed successfully"
+            # Streamed and non-streamed completions converge here: the helper
+            # closes the streaming artifact (only when token chunks were streamed
+            # this turn) and emits the terminal `completed` status carrying the
+            # authoritative final answer, tagged `final_answer_source: "fallback"`
+            # when it duplicates already-streamed artifact text.
+            await self._close_streaming_artifact_and_respond(
+                updater,
+                TaskState.completed,
+                new_agent_text_message(
+                    final_answer,
+                    task.context_id,
+                    task.id,
+                ),
+                streaming_artifact_id=streaming_artifact_id,
+                first_chunk_sent=first_chunk_sent,
+                streamed_chars=streamed_chars,
+                final_message_len=len(final_answer),
+                base_metadata=metadata,
+            )
 
         elif state == TaskState.completed and not is_final:
             logger.info(f"Contradictory completed non-final state, treating as input_required: {content}")
@@ -1019,8 +1102,57 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
             )
             await updater.complete()
 
-        # Return first_chunk_sent unchanged for non-streaming paths
-        return first_chunk_sent
+        # Return flags unchanged for non-streaming paths
+        return first_chunk_sent, first_intermediate_chunk_sent
+
+    async def _close_streaming_artifact_and_respond(
+        self,
+        updater: TaskUpdater,
+        state: TaskState,
+        msg: Message,
+        *,
+        streaming_artifact_id: str,
+        first_chunk_sent: bool,
+        streamed_chars: int,
+        final_message_len: int,
+        base_metadata: dict | None,
+    ) -> None:
+        """Seal an open streaming artifact (if any) and emit a terminal status update.
+
+        Shared by the ``input_required``, ``auth_required`` and ``completed``
+        fallback branches. When the orchestrator streamed token chunks this turn
+        (``first_chunk_sent``), the streaming artifact is closed with a final
+        empty chunk and the status metadata is tagged
+        ``final_answer_source="fallback"`` so well-behaved clients dedupe the
+        terminal message against the artifact text they already rendered.
+
+        Centralising this keeps the artifact-close, the completion log line and
+        the metadata key in one place so a format/key change cannot silently
+        miss one branch.
+        """
+        status_metadata = dict(base_metadata) if base_metadata else {}
+        if first_chunk_sent:
+            await updater.add_artifact(
+                [Part(root=TextPart(text=""))],
+                artifact_id=streaming_artifact_id,
+                append=True,
+                last_chunk=True,
+                metadata={},
+            )
+            logger.info(
+                "[STREAMING] Completion: artifact_id=%s streamed_chars=%d "
+                "final_message_len=%d task_state=%s",
+                streaming_artifact_id,
+                streamed_chars,
+                final_message_len,
+                state,
+            )
+            status_metadata["final_answer_source"] = "fallback"
+        await updater.update_status(
+            state,
+            msg,
+            metadata=status_metadata or None,
+        )
 
     def _validate_request(self, context: RequestContext) -> bool:
         return False

--- a/packages/orchestrator-agent/app/handlers/stream_handler.py
+++ b/packages/orchestrator-agent/app/handlers/stream_handler.py
@@ -248,7 +248,7 @@ class StreamHandler:
             if messages:
                 last_message = messages[-1]
                 content = getattr(last_message, "content", "The agent failed to complete the task.")
-                content = extract_text_from_content(content)[0]
+                content = (extract_text_from_content(content) or [""])[0]
             else:
                 content = "The agent failed to complete the task."
 
@@ -262,7 +262,7 @@ class StreamHandler:
             if messages:
                 last_message = messages[-1]
                 content = getattr(last_message, "content", "Additional input required to complete the task.")
-                content = extract_text_from_content(content)[0]
+                content = (extract_text_from_content(content) or [""])[0]
             else:
                 content = "Additional input required to complete the task."
 
@@ -409,52 +409,59 @@ class StreamHandler:
                 # - FinalResponseSchema (Bedrock structured output)
                 # - Other tools (file operations, etc.)
                 # Only extract from ToolMessages that correspond to "task" tool calls (sub-agents)
+                subagent_content = None
+
                 if isinstance(final_state, dict):
                     messages = final_state.get("messages", [])
                     if messages:
                         # Get current turn messages (after last HumanMessage)
                         current_turn_messages = StreamHandler._extract_current_turn_messages(messages)
 
-                        # Build a map of tool_call_id -> tool_name for filtering
+                        # Build a map of tool_call_id -> tool_call so we can filter
+                        # ToolMessages down to "task" calls (sub-agents) only.
                         tool_call_map = {}
                         for msg in current_turn_messages:
                             if isinstance(msg, AIMessage) and hasattr(msg, "tool_calls") and msg.tool_calls:
                                 for tool_call in msg.tool_calls:
                                     tool_call_map[tool_call.get("id")] = tool_call
 
-                        # Find the most recent "task" ToolMessage (sub-agent response)
-                        subagent_content = None
+                        # Adopt the most-recent "task" ToolMessage whose extracted content
+                        # is actually non-empty. An empty extraction must NOT short-circuit
+                        # the search — keep walking so we surface a usable reply.
                         for msg in reversed(current_turn_messages):
-                            if isinstance(msg, ToolMessage):
-                                tool_call = tool_call_map.get(msg.tool_call_id)
-                                # Filter: only process "task" tool calls (sub-agents)
-                                if tool_call and tool_call.get("name") == "task":
-                                    # Found a sub-agent ToolMessage
-                                    try:
-                                        # Sub-agent content may be JSON-wrapped
-                                        if isinstance(msg.content, str):
-                                            parsed_content = json.loads(msg.content)
-                                            if isinstance(parsed_content, dict):
-                                                subagent_content = parsed_content.get("message", msg.content)
-                                            elif isinstance(parsed_content, list):
-                                                # Content is a list of blocks (e.g., thinking + text)
-                                                subagent_content = extract_text_from_content(parsed_content)[0]
-                                            else:
-                                                subagent_content = msg.content
-                                        elif isinstance(msg.content, list):
-                                            # Content is already a list of blocks
-                                            subagent_content = extract_text_from_content(msg.content)[0]
-                                        else:
-                                            subagent_content = msg.content
-                                    except json.JSONDecodeError:
-                                        subagent_content = msg.content
+                            if not isinstance(msg, ToolMessage):
+                                continue
+                            tool_call = tool_call_map.get(msg.tool_call_id)
+                            # Filter: only process "task" tool calls (sub-agents)
+                            if not (tool_call and tool_call.get("name") == "task"):
+                                continue
 
-                                    logger.info(
-                                        f"[STREAM HANDLER] Found sub-agent ToolMessage (tool_call_id={msg.tool_call_id}, "
-                                        f"subagent={tool_call.get('args', {}).get('subagent_type')}, "
-                                        f"content_length={len(subagent_content) if subagent_content else 0})"
-                                    )
-                                    break
+                            # Extract content (sub-agent content may be JSON-wrapped).
+                            try:
+                                if isinstance(msg.content, str):
+                                    parsed_content = json.loads(msg.content)
+                                    if isinstance(parsed_content, dict):
+                                        extracted = parsed_content.get("message", msg.content)
+                                    elif isinstance(parsed_content, list):
+                                        extracted = (extract_text_from_content(parsed_content) or [""])[0]
+                                    else:
+                                        extracted = msg.content
+                                elif isinstance(msg.content, list):
+                                    extracted = (extract_text_from_content(msg.content) or [""])[0]
+                                else:
+                                    extracted = msg.content
+                            except json.JSONDecodeError:
+                                extracted = msg.content
+
+                            extracted_str = extracted if isinstance(extracted, str) else ""
+                            if extracted_str:
+                                subagent_content = extracted_str
+                                logger.info(
+                                    f"[STREAM HANDLER] Found sub-agent ToolMessage (tool_call_id={msg.tool_call_id}, "
+                                    f"subagent={tool_call.get('args', {}).get('subagent_type')}, "
+                                    f"content_length={len(subagent_content)})"
+                                )
+                                break
 
                         if subagent_content:
                             # Append sub-agent output to message
@@ -470,14 +477,30 @@ class StreamHandler:
                             )
                         else:
                             logger.warning(
-                                "[STREAM HANDLER] include_subagent_output=true but no sub-agent ToolMessage found in current turn "
-                                "(FinalResponseSchema and other tool messages filtered out)"
+                                "[STREAM HANDLER] include_subagent_output=true but no usable sub-agent ToolMessage "
+                                "found in current turn. parsed_message_length=%d",
+                                len(parsed.message),
                             )
                     else:
                         logger.warning("[STREAM HANDLER] include_subagent_output=true but no messages in state")
                 else:
                     logger.warning(
                         f"[STREAM HANDLER] include_subagent_output=true but final_state is not a dict: {type(final_state)}"
+                    )
+
+                # FINAL GUARD: include_subagent_output was requested but the message is
+                # still empty (orchestrator authored "" expecting a sub-agent forward,
+                # and we found nothing usable). Never let an empty `completed` reply
+                # reach the client — emit a short, neutral, user-safe fallback. The
+                # warning above carries the debugging detail; the user message stays
+                # clean (no IDs, no internals).
+                if not message:
+                    message = (
+                        "I wasn't able to put together a response this time. "
+                        "Could you try rephrasing or asking again?"
+                    )
+                    logger.warning(
+                        "[STREAM HANDLER] Substituted fallback message for empty include_subagent_output reply"
                     )
 
             # Build metadata
@@ -524,6 +547,10 @@ class StreamHandler:
                     a2a_tracking = final_state.get("a2a_tracking", {})
                     recently_called = StreamHandler._extract_recently_called_subagents(final_state)
 
+                    # The empty-set invariant is owned by _check_all_agents_blocked: it
+                    # returns (False, None) when no sub-agent ran this turn (e.g. a short
+                    # greeting "hi" → "Hello!"), so we skip the override and trust the
+                    # LLM's completed state below without a separate pre-check here.
                     all_blocked, prioritized_agent = StreamHandler._check_all_agents_blocked(
                         recently_called, a2a_tracking
                     )
@@ -556,7 +583,7 @@ class StreamHandler:
         if messages:
             last_message = messages[-1]
             content = getattr(last_message, "content", str(last_message))
-            content = extract_text_from_content(content)[0]
+            content = (extract_text_from_content(content) or [""])[0]
         else:
             content = "Task completed successfully"
 

--- a/packages/orchestrator-agent/tests/test_agent_executor.py
+++ b/packages/orchestrator-agent/tests/test_agent_executor.py
@@ -150,7 +150,15 @@ class TestAgentExecutorStreamHandling:
         updater.update_status.assert_called_once()
 
     async def test_handle_stream_item_streaming_completion(self, dynamodb_table):
-        """Test that streaming completion sends empty last chunk and clean status (no content duplication)."""
+        """Streaming completion closes the artifact AND embeds the authoritative final answer.
+
+        Regression for the production incident on 2026-05-25 where a downstream A2A client
+        failed to parse a streamed artifact frame and the user never received the reply,
+        because the terminal `completed` status carried no message body. The terminal
+        status must now always carry the validated FinalResponseSchema.message text as a
+        fallback / source-of-truth, tagged with `final_answer_source: "fallback"` so
+        well-behaved clients that already rendered the streamed artifact can dedupe.
+        """
         from app.models.responses import AgentStreamResponse
 
         executor = OrchestratorDeepAgentExecutor()
@@ -178,6 +186,7 @@ class TestAgentExecutorStreamHandling:
             is_final=True,
             streaming_artifact_id="artifact-1",
             first_chunk_sent=True,
+            streamed_bytes=45,
         )
 
         # Last artifact chunk should be empty (just stream close signal)
@@ -189,15 +198,174 @@ class TestAgentExecutorStreamHandling:
         parts = artifact_call[0][0]
         assert parts[0].root.text == ""
 
-        # Completion status should have NO content message (backend handles persistence)
+        # Completion status MUST carry the authoritative final answer as a fallback
         updater.update_status.assert_called_once()
         status_call = updater.update_status.call_args
         assert status_call[0][0] == TaskState.completed
-        # Second positional arg (message) should not be provided — defaults to None
-        assert len(status_call[0]) == 1
+        # Second positional arg is the message carrying the final answer text
+        assert len(status_call[0]) == 2
+        final_msg = status_call[0][1]
+        text_parts = [p.root.text for p in final_msg.parts if hasattr(p.root, "text")]
+        assert "Full response content" in "".join(text_parts)
+        # Metadata flag signals well-behaved clients to dedupe against the artifact stream
+        assert status_call[1]["metadata"]["final_answer_source"] == "fallback"
 
-        # first_chunk_sent should still be True
-        assert result is True
+        # _handle_stream_item now returns (first_chunk_sent, first_intermediate_chunk_sent)
+        assert result == (True, False)
+
+    async def test_handle_stream_item_streaming_completion_empty_content_fallback(self, dynamodb_table):
+        """If the agent yields an empty final content (edge case), the terminal status
+        still carries a non-empty message body so the client never gets a blank reply.
+        """
+        from app.models.responses import AgentStreamResponse
+
+        executor = OrchestratorDeepAgentExecutor()
+
+        updater = Mock()
+        updater.add_artifact = AsyncMock()
+        updater.update_status = AsyncMock()
+
+        task = Mock()
+        task.context_id = "ctx-123"
+        task.id = "task-456"
+
+        item = AgentStreamResponse(state=TaskState.completed, content="")
+
+        await executor._handle_stream_item(
+            item,
+            updater,
+            task,
+            is_final=True,
+            streaming_artifact_id="artifact-1",
+            first_chunk_sent=True,
+        )
+
+        status_call = updater.update_status.call_args
+        assert status_call[0][0] == TaskState.completed
+        final_msg = status_call[0][1]
+        text_parts = [p.root.text for p in final_msg.parts if hasattr(p.root, "text")]
+        assert "".join(text_parts).strip() != ""
+
+    async def test_handle_stream_item_streaming_first_chunk_creates_artifact(self, dynamodb_table):
+        """Regression: the FIRST streaming chunk for an artifact_id must be a create (append=False).
+
+        Production bug: the orchestrator always passed append=True, which made the A2A SDK
+        drop the bytes with `Received append=True for nonexistent artifact index ... Ignoring chunk.`
+        and the final short reply (e.g. "Hello! How can I help you today?") never reached the client.
+        Subsequent chunks for the same artifact must use append=True.
+        """
+        from app.models.responses import AgentStreamResponse
+
+        executor = OrchestratorDeepAgentExecutor()
+
+        updater = Mock()
+        updater.add_artifact = AsyncMock()
+
+        task = Mock()
+        task.context_id = "ctx-123"
+        task.id = "task-456"
+
+        # First chunk: nothing sent yet → must create (append=False)
+        first_item = AgentStreamResponse(
+            state=TaskState.working,
+            content="Hello! ",
+            metadata={"streaming_chunk": True},
+        )
+        result = await executor._handle_stream_item(
+            first_item,
+            updater,
+            task,
+            is_final=True,
+            streaming_artifact_id="artifact-X",
+            first_chunk_sent=False,
+            first_intermediate_chunk_sent=False,
+        )
+        first_call = updater.add_artifact.call_args
+        assert first_call[1]["append"] is False, "First chunk must create the artifact (append=False)"
+        assert first_call[1]["artifact_id"] == "artifact-X"
+        assert result == (True, False)
+
+        # Subsequent chunk: artifact already exists → append=True
+        second_item = AgentStreamResponse(
+            state=TaskState.working,
+            content="How can I help?",
+            metadata={"streaming_chunk": True},
+        )
+        result = await executor._handle_stream_item(
+            second_item,
+            updater,
+            task,
+            is_final=True,
+            streaming_artifact_id="artifact-X",
+            first_chunk_sent=result[0],
+            first_intermediate_chunk_sent=result[1],
+        )
+        second_call = updater.add_artifact.call_args
+        assert second_call[1]["append"] is True, "Subsequent chunks must append=True"
+        assert result == (True, False)
+
+    async def test_handle_stream_item_intermediate_artifact_tracked_separately(self, dynamodb_table):
+        """Intermediate (sub-agent thought) artifact creation is tracked independently
+        from the main artifact, since they use distinct artifact IDs.
+        """
+        from app.core.a2a_extensions import INTERMEDIATE_OUTPUT_EXTENSION
+        from app.models.responses import AgentStreamResponse
+
+        executor = OrchestratorDeepAgentExecutor()
+
+        updater = Mock()
+        updater.add_artifact = AsyncMock()
+
+        task = Mock()
+        task.context_id = "ctx-123"
+        task.id = "task-456"
+
+        # Intermediate-output extension must be active for the chunk to be emitted
+        active = {INTERMEDIATE_OUTPUT_EXTENSION}
+
+        # First intermediate chunk → create (append=False) on "-thought" artifact;
+        # main first_chunk_sent must NOT be flipped (only intermediate flag flips).
+        intermediate_item = AgentStreamResponse(
+            state=TaskState.working,
+            content="thinking...",
+            metadata={"streaming_chunk": True, "intermediate_output": True},
+        )
+        result = await executor._handle_stream_item(
+            intermediate_item,
+            updater,
+            task,
+            is_final=True,
+            streaming_artifact_id="artifact-X",
+            first_chunk_sent=False,
+            first_intermediate_chunk_sent=False,
+            active_extensions=active,
+        )
+        call = updater.add_artifact.call_args
+        assert call[1]["append"] is False, "First intermediate chunk must create the thought artifact"
+        assert call[1]["artifact_id"] == "artifact-X-thought"
+        # Main flag stays False so include_subagent_output / final answer still works
+        assert result == (False, True)
+
+        # First MAIN chunk afterwards → must still be a create on the main artifact
+        main_item = AgentStreamResponse(
+            state=TaskState.working,
+            content="The answer",
+            metadata={"streaming_chunk": True},
+        )
+        result = await executor._handle_stream_item(
+            main_item,
+            updater,
+            task,
+            is_final=True,
+            streaming_artifact_id="artifact-X",
+            first_chunk_sent=result[0],
+            first_intermediate_chunk_sent=result[1],
+            active_extensions=active,
+        )
+        call = updater.add_artifact.call_args
+        assert call[1]["append"] is False, "First main chunk must create the main artifact"
+        assert call[1]["artifact_id"] == "artifact-X"
+        assert result == (True, True)
 
     async def test_handle_stream_item_failed_state(self, dynamodb_table):
         """Test handling failed state stream items."""
@@ -255,6 +423,234 @@ class TestAgentExecutorStreamHandling:
         updater.update_status.assert_called_once()
         call_args = updater.update_status.call_args
         assert call_args[0][0] == TaskState.auth_required
+
+    async def test_handle_stream_item_input_required_carries_final_message(self, dynamodb_table):
+        """Generic (non-HITL) input_required terminal status MUST carry the
+        FinalResponseSchema.message text in its message body so clients receive
+        the orchestrator's reply even if intermediate SSE artifact frames were
+        dropped. Mirrors the `completed` contract introduced in Task #20.
+        """
+        from app.models.responses import AgentStreamResponse
+
+        executor = OrchestratorDeepAgentExecutor()
+
+        updater = Mock()
+        updater.update_status = AsyncMock()
+        updater.add_artifact = AsyncMock()
+
+        task = Mock()
+        task.context_id = "ctx-123"
+        task.id = "task-456"
+
+        item = AgentStreamResponse(
+            state=TaskState.input_required,
+            content="Hi — I'm here. What would you like to do?",
+        )
+
+        await executor._handle_stream_item(
+            item,
+            updater,
+            task,
+            is_final=True,
+            streaming_artifact_id="artifact-1",
+        )
+
+        # No streaming this turn → no artifact close, just the terminal status
+        updater.add_artifact.assert_not_called()
+        updater.update_status.assert_called_once()
+        status_call = updater.update_status.call_args
+        assert status_call[0][0] == TaskState.input_required
+        final_msg = status_call[0][1]
+        text_parts = [p.root.text for p in final_msg.parts if hasattr(p.root, "text")]
+        assert "Hi — I'm here. What would you like to do?" in "".join(text_parts)
+        # Terminal frame must be flushed deterministically.
+        assert status_call[1].get("final") is True
+
+    async def test_handle_stream_item_streaming_input_required_closes_artifact_with_fallback(self, dynamodb_table):
+        """When orchestrator streamed token chunks this turn and then resolves to
+        input_required, the streaming artifact is closed cleanly and the terminal
+        status carries the authoritative final answer tagged
+        `final_answer_source: "fallback"` for client-side deduping.
+        """
+        from app.models.responses import AgentStreamResponse
+
+        executor = OrchestratorDeepAgentExecutor()
+
+        updater = Mock()
+        updater.add_artifact = AsyncMock()
+        updater.update_status = AsyncMock()
+
+        task = Mock()
+        task.context_id = "ctx-123"
+        task.id = "task-456"
+
+        item = AgentStreamResponse(
+            state=TaskState.input_required,
+            content="Which project should I file the ticket under?",
+        )
+
+        await executor._handle_stream_item(
+            item,
+            updater,
+            task,
+            is_final=True,
+            streaming_artifact_id="artifact-IR",
+            first_chunk_sent=True,
+            streamed_bytes=120,
+        )
+
+        # Artifact stream closed with an empty append+last_chunk frame
+        updater.add_artifact.assert_called_once()
+        artifact_call = updater.add_artifact.call_args
+        assert artifact_call[1]["last_chunk"] is True
+        assert artifact_call[1]["append"] is True
+        assert artifact_call[1]["artifact_id"] == "artifact-IR"
+        parts = artifact_call[0][0]
+        assert parts[0].root.text == ""
+
+        # Terminal status carries the final message + fallback metadata + final=True
+        updater.update_status.assert_called_once()
+        status_call = updater.update_status.call_args
+        assert status_call[0][0] == TaskState.input_required
+        final_msg = status_call[0][1]
+        text_parts = [p.root.text for p in final_msg.parts if hasattr(p.root, "text")]
+        assert "Which project should I file the ticket under?" in "".join(text_parts)
+        assert status_call[1]["metadata"]["final_answer_source"] == "fallback"
+        assert status_call[1]["final"] is True
+
+    async def test_handle_stream_item_auth_required_carries_final_message(self, dynamodb_table):
+        """auth_required terminal status MUST carry the FinalResponseSchema.message
+        text in its message body so clients receive the orchestrator's reply even
+        if intermediate SSE artifact frames were dropped. Mirrors `completed`.
+        """
+        from app.models.responses import AgentStreamResponse
+
+        executor = OrchestratorDeepAgentExecutor()
+
+        updater = Mock()
+        updater.update_status = AsyncMock()
+        updater.add_artifact = AsyncMock()
+
+        task = Mock()
+        task.context_id = "ctx-123"
+        task.id = "task-456"
+
+        item = AgentStreamResponse(
+            state=TaskState.auth_required,
+            content="Please sign in to Jira to continue.",
+        )
+
+        await executor._handle_stream_item(
+            item,
+            updater,
+            task,
+            is_final=True,
+            streaming_artifact_id="artifact-1",
+        )
+
+        updater.add_artifact.assert_not_called()
+        updater.update_status.assert_called_once()
+        status_call = updater.update_status.call_args
+        assert status_call[0][0] == TaskState.auth_required
+        final_msg = status_call[0][1]
+        text_parts = [p.root.text for p in final_msg.parts if hasattr(p.root, "text")]
+        assert "Please sign in to Jira to continue." in "".join(text_parts)
+        assert status_call[1].get("final") is True
+
+    async def test_handle_stream_item_streaming_auth_required_closes_artifact_with_fallback(self, dynamodb_table):
+        """When orchestrator streamed token chunks and then resolves to
+        auth_required, the streaming artifact is closed cleanly and the terminal
+        status carries the authoritative final answer tagged
+        `final_answer_source: "fallback"`.
+        """
+        from app.models.responses import AgentStreamResponse
+
+        executor = OrchestratorDeepAgentExecutor()
+
+        updater = Mock()
+        updater.add_artifact = AsyncMock()
+        updater.update_status = AsyncMock()
+
+        task = Mock()
+        task.context_id = "ctx-123"
+        task.id = "task-456"
+
+        item = AgentStreamResponse(
+            state=TaskState.auth_required,
+            content="Please re-authenticate with Google to continue.",
+        )
+
+        await executor._handle_stream_item(
+            item,
+            updater,
+            task,
+            is_final=True,
+            streaming_artifact_id="artifact-AR",
+            first_chunk_sent=True,
+            streamed_bytes=80,
+        )
+
+        updater.add_artifact.assert_called_once()
+        artifact_call = updater.add_artifact.call_args
+        assert artifact_call[1]["last_chunk"] is True
+        assert artifact_call[1]["append"] is True
+        assert artifact_call[1]["artifact_id"] == "artifact-AR"
+        parts = artifact_call[0][0]
+        assert parts[0].root.text == ""
+
+        updater.update_status.assert_called_once()
+        status_call = updater.update_status.call_args
+        assert status_call[0][0] == TaskState.auth_required
+        final_msg = status_call[0][1]
+        text_parts = [p.root.text for p in final_msg.parts if hasattr(p.root, "text")]
+        assert "Please re-authenticate with Google to continue." in "".join(text_parts)
+        assert status_call[1]["metadata"]["final_answer_source"] == "fallback"
+        assert status_call[1]["final"] is True
+
+    async def test_handle_stream_item_input_required_hitl_path_unchanged(self, dynamodb_table):
+        """HITL action_requests interrupts still emit the structured HITL message
+        via new_hitl_interrupt_message (no artifact-fallback, no final_answer_source).
+        """
+        from app.core.a2a_extensions import HUMAN_IN_THE_LOOP_EXTENSION
+        from app.models.responses import AgentStreamResponse
+
+        executor = OrchestratorDeepAgentExecutor()
+
+        updater = Mock()
+        updater.update_status = AsyncMock()
+        updater.add_artifact = AsyncMock()
+
+        task = Mock()
+        task.context_id = "ctx-123"
+        task.id = "task-456"
+
+        item = AgentStreamResponse(
+            state=TaskState.input_required,
+            content="Approve creating Jira ticket?",
+            metadata={
+                "action_requests": [
+                    {"name": "create_jira_ticket", "args": {"summary": "x"}, "id": "call_1"}
+                ],
+            },
+        )
+
+        await executor._handle_stream_item(
+            item,
+            updater,
+            task,
+            is_final=True,
+            streaming_artifact_id="artifact-1",
+            active_extensions={HUMAN_IN_THE_LOOP_EXTENSION},
+        )
+
+        # HITL path: no artifact close, no final_answer_source metadata, no final=True override
+        updater.add_artifact.assert_not_called()
+        updater.update_status.assert_called_once()
+        status_call = updater.update_status.call_args
+        assert status_call[0][0] == TaskState.input_required
+        # HITL branch passes only (state, msg) positionally and no metadata kwarg
+        assert "metadata" not in status_call[1] or status_call[1].get("metadata") is None
+        assert "final" not in status_call[1] or status_call[1].get("final") is not True
 
 
 class TestZeroTrustUserIdExtraction:

--- a/packages/orchestrator-agent/tests/test_executor_extension_filtering.py
+++ b/packages/orchestrator-agent/tests/test_executor_extension_filtering.py
@@ -73,7 +73,7 @@ class TestActivityLogExtensionFiltering:
             active_extensions=None,
         )
         updater.update_status.assert_not_called()
-        assert result is False
+        assert result[0] is False
 
     @pytest.mark.asyncio
     async def test_suppressed_when_other_extensions_requested(self, executor, updater, task):
@@ -91,7 +91,7 @@ class TestActivityLogExtensionFiltering:
             active_extensions={WORK_PLAN_EXTENSION},
         )
         updater.update_status.assert_not_called()
-        assert result is False
+        assert result[0] is False
 
     @pytest.mark.asyncio
     async def test_emitted_when_extension_active(self, executor, updater, task):
@@ -113,7 +113,7 @@ class TestActivityLogExtensionFiltering:
         assert call_args[0][0] == TaskState.working
         msg = call_args[0][1]
         assert ACTIVITY_LOG_EXTENSION in msg.extensions
-        assert result is False  # first_chunk_sent unchanged
+        assert result[0] is False  # first_chunk_sent unchanged
 
     @pytest.mark.asyncio
     async def test_preserves_first_chunk_sent_flag(self, executor, updater, task):
@@ -131,7 +131,7 @@ class TestActivityLogExtensionFiltering:
             first_chunk_sent=True,
             active_extensions={ACTIVITY_LOG_EXTENSION},
         )
-        assert result is True  # preserved
+        assert result[0] is True  # preserved
 
 
 # ===========================================================================
@@ -158,7 +158,7 @@ class TestWorkPlanExtensionFiltering:
             active_extensions=None,
         )
         updater.update_status.assert_not_called()
-        assert result is False
+        assert result[0] is False
 
     @pytest.mark.asyncio
     async def test_suppressed_when_other_extensions_requested(self, executor, updater, task):
@@ -227,7 +227,7 @@ class TestIntermediateOutputExtensionFiltering:
             active_extensions=None,
         )
         updater.add_artifact.assert_not_called()
-        assert result is False  # first_chunk_sent unchanged
+        assert result[0] is False  # first_chunk_sent unchanged
 
     @pytest.mark.asyncio
     async def test_suppressed_when_other_extensions_requested(self, executor, updater, task):
@@ -250,7 +250,7 @@ class TestIntermediateOutputExtensionFiltering:
             active_extensions={ACTIVITY_LOG_EXTENSION, WORK_PLAN_EXTENSION},
         )
         updater.add_artifact.assert_not_called()
-        assert result is False
+        assert result[0] is False
 
     @pytest.mark.asyncio
     async def test_emitted_when_extension_active(self, executor, updater, task):
@@ -278,7 +278,7 @@ class TestIntermediateOutputExtensionFiltering:
         assert call_kwargs["extensions"] == [INTERMEDIATE_OUTPUT_EXTENSION]
         assert call_kwargs["metadata"]["agent_name"] == "research-agent"
         # intermediate output should NOT set first_chunk_sent
-        assert result is False
+        assert result[0] is False
 
     @pytest.mark.asyncio
     async def test_does_not_set_first_chunk_sent(self, executor, updater, task):
@@ -301,7 +301,7 @@ class TestIntermediateOutputExtensionFiltering:
             first_chunk_sent=False,
             active_extensions=ALL_EXTENSIONS,
         )
-        assert result is False  # must remain False
+        assert result[0] is False
 
     @pytest.mark.asyncio
     async def test_preserves_first_chunk_sent_true(self, executor, updater, task):
@@ -324,7 +324,7 @@ class TestIntermediateOutputExtensionFiltering:
             first_chunk_sent=True,
             active_extensions=ALL_EXTENSIONS,
         )
-        assert result is True  # preserved
+        assert result[0] is True  # preserved
 
 
 # ===========================================================================
@@ -355,7 +355,7 @@ class TestMainStreamingChunks:
         call_kwargs = updater.add_artifact.call_args[1]
         assert call_kwargs["artifact_id"] == "art-1"
         assert call_kwargs["extensions"] is None
-        assert result is True  # first_chunk_sent becomes True
+        assert result[0] is True  # first_chunk_sent becomes True
 
     @pytest.mark.asyncio
     async def test_emitted_when_all_extensions_active(self, executor, updater, task):
@@ -374,7 +374,7 @@ class TestMainStreamingChunks:
             active_extensions=ALL_EXTENSIONS,
         )
         updater.add_artifact.assert_awaited_once()
-        assert result is True
+        assert result[0] is True
 
 
 # ===========================================================================
@@ -473,7 +473,7 @@ class TestSlackScenario:
             streaming_artifact_id=artifact_id,
             active_extensions=no_extensions,
         )
-        assert result is True
+        assert result[0] is True
         updater.add_artifact.assert_awaited_once()
         call_kwargs = updater.add_artifact.call_args[1]
         assert call_kwargs["artifact_id"] == artifact_id
@@ -557,7 +557,7 @@ class TestConsoleScenario:
             streaming_artifact_id=artifact_id,
             active_extensions=all_ext,
         )
-        assert result is True
+        assert result[0] is True
         assert updater.add_artifact.await_count == 2
         main_kwargs = updater.add_artifact.call_args[1]
         assert main_kwargs["artifact_id"] == artifact_id

--- a/packages/orchestrator-agent/tests/test_stream_handler.py
+++ b/packages/orchestrator-agent/tests/test_stream_handler.py
@@ -797,6 +797,55 @@ class TestConservativeOverrideLogic:
         assert response.state == TaskState.working
         assert "background" in response.content
 
+    def test_no_subagents_this_turn_does_not_override(self):
+        """Greeting turn (no sub-agent calls) must not be overridden by stale blocked tracking.
+
+        Regression: a sub-agent flagged blocked in an earlier turn (e.g. file-analyzer)
+        leaked into a2a_tracking. On a later, unrelated greeting turn with no tool
+        calls, the override branch incorrectly fired and suppressed the LLM's final
+        "Hello!" reply. The current-turn extraction MUST short-circuit when no sub-agent
+        was actually invoked in the current turn.
+        """
+        from app.models.schemas import FinalResponseSchema
+
+        final_state = {
+            "messages": [
+                # Earlier turn: file-analyzer was called and got blocked
+                HumanMessage(content="Analyze that file"),
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "task",
+                            "args": {"subagent_type": "file-analyzer"},
+                            "id": "call_old",
+                            "type": "tool_call",
+                        }
+                    ],
+                ),
+                ToolMessage(content="Need credentials", tool_call_id="call_old"),
+                AIMessage(content="I need access to analyze that."),
+                # Current turn: simple greeting, no tool calls
+                HumanMessage(content="hi"),
+                AIMessage(content="Hello! How can I help you today?"),
+            ],
+            "structured_response": FinalResponseSchema(
+                task_state=TaskState.completed,
+                message="Hello! How can I help you today?",
+                reasoning="Greeting response",
+            ),
+            # Stale blocked tracking from earlier turn — must NOT trigger override now
+            "a2a_tracking": {
+                "file-analyzer": {"requires_input": True, "is_complete": False},
+            },
+        }
+
+        response = StreamHandler.parse_agent_response(final_state)
+
+        # Must trust LLM and emit the greeting — no override allowed
+        assert response.state == TaskState.completed
+        assert response.content == "Hello! How can I help you today?"
+
     def test_single_agent_blocked_overrides_when_completed(self):
         """Test: Single agent called, LLM says completed, agent blocked → override."""
         from app.models.schemas import FinalResponseSchema
@@ -908,3 +957,114 @@ class TestIncludeSubagentOutput:
 
         assert response.state == TaskState.completed
         assert response.content == "Here's the joke:"
+
+    def test_include_subagent_output_empty_message_no_tool_message_uses_fallback(self):
+        """include_subagent_output=True + empty message + no sub-agent ToolMessage → safe fallback (not empty)."""
+        # Reproduces the production bug: orchestrator picks include_subagent_output=True
+        # and authors message="", but no "task" ToolMessage exists in the current turn.
+        # Client must never see an empty `completed` reply.
+        final_state = {
+            "messages": [
+                HumanMessage(content="Schedule a meeting"),
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "FinalResponseSchema",
+                            "args": {
+                                "task_state": "completed",
+                                "message": "",
+                                "include_subagent_output": True,
+                            },
+                            "id": "call_final_empty",
+                            "type": "tool_call",
+                        }
+                    ],
+                ),
+            ]
+        }
+
+        response = StreamHandler.parse_agent_response(final_state)
+
+        assert response.state == TaskState.completed
+        assert response.content, "Client must never receive empty completed content"
+        # Fallback is short, neutral, and does not leak internal IDs / stack traces
+        assert "call_final" not in response.content
+        assert "ToolMessage" not in response.content
+        assert "tool_call_id" not in response.content
+
+    def test_include_subagent_output_tool_message_with_empty_extracted_content_uses_fallback(self):
+        """include_subagent_output=True + ToolMessage whose extracted content is "" → safe fallback."""
+        # Sub-agent ToolMessage IS present, but its JSON payload has message="" — extraction
+        # produces an empty string. We must still surface a visible reply to the user.
+        final_state = {
+            "messages": [
+                HumanMessage(content="What's on my calendar?"),
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "task",
+                            "args": {"subagent_type": "task-scheduler"},
+                            "id": "call_task_empty",
+                            "type": "tool_call",
+                        }
+                    ],
+                ),
+                ToolMessage(content='{"message": ""}', tool_call_id="call_task_empty"),
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "FinalResponseSchema",
+                            "args": {
+                                "task_state": "completed",
+                                "message": "",
+                                "include_subagent_output": True,
+                            },
+                            "id": "call_final_empty_extracted",
+                            "type": "tool_call",
+                        }
+                    ],
+                ),
+            ]
+        }
+
+        response = StreamHandler.parse_agent_response(final_state)
+
+        assert response.state == TaskState.completed
+        assert response.content, "Client must never receive empty completed content"
+        assert "call_task" not in response.content
+
+    def test_include_subagent_output_false_empty_message_passes_through(self):
+        """include_subagent_output=False + empty message → message passes through unchanged (no fallback injected).
+
+        The fallback is scoped strictly to the include_subagent_output=True path: an explicit
+        empty message with include_subagent_output=False is a different (and unusual) decision
+        by the orchestrator, and we don't second-guess it here.
+        """
+        final_state = {
+            "messages": [
+                HumanMessage(content="hi"),
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "FinalResponseSchema",
+                            "args": {
+                                "task_state": "completed",
+                                "message": "",
+                                "include_subagent_output": False,
+                            },
+                            "id": "call_final_no_include",
+                            "type": "tool_call",
+                        }
+                    ],
+                ),
+            ]
+        }
+
+        response = StreamHandler.parse_agent_response(final_state)
+
+        assert response.state == TaskState.completed
+        assert response.content == ""


### PR DESCRIPTION
Problem: Several paths could send the client an empty completed response:

The first streaming chunk was always sent with append=True, so the A2A SDK dropped it (nonexistent artifact index) and short replies like "Hello!" never arrived.
The terminal completed status carried no message body - if a client failed to parse the streamed artifact frame, the user saw nothing.


## Checklist
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨
