### PR TITLE
fix: Improve voice agent first reply latency

### DIFF
--- a/packages/voice-agent/voice_agent/a2a_agent.py
+++ b/packages/voice-agent/voice_agent/a2a_agent.py
@@ -394,12 +394,19 @@ class VoiceAgent(BaseAgent):
                 )
 
         voice_name = self._active_sessions[session_key]["agent"].voice_name
+        audio_in = self._active_sessions[session_key]["audio_in"]
         event_out = self._active_sessions[session_key]["event_out"]
         yield AgentStreamResponse(
             state=TaskState.TASK_STATE_WORKING,
             content="Voice session initialized",
             metadata={"session_id": session_key, "voice_name": voice_name},
         )
+
+        # Trigger the opening greeting immediately by injecting a text turn.
+        # Without this, Gemini waits silently for user audio to clear VAD,
+        # causing 3-4 s of dead air after the callee answers.
+        await audio_in.put("[call_connected]")
+        logger.debug("Injected greeting trigger for session %s", session_key)
 
         try:
             while True:

--- a/packages/voice-agent/voice_agent/a2a_agent.py
+++ b/packages/voice-agent/voice_agent/a2a_agent.py
@@ -79,6 +79,7 @@ from ringier_a2a_sdk.utils.a2a_part_conversion import a2a_parts_to_content
 from voice_agent.agent import SYSTEM_PROMPT as DEFAULT_SYSTEM_PROMPT
 from voice_agent.agent import GeminiLiveAgent
 from voice_agent.call_bridge import (
+    _CALL_ANSWERED,
     _CALL_FUTURES,
     _PENDING_CALLS,
     OutboundCallRequest,
@@ -659,7 +660,8 @@ class VoiceAgent(BaseAgent):
           8. Yield ``completed`` with the formatted transcript.
         """
         public_url: str = os.environ.get("PUBLIC_URL") or os.environ.get("VOICE_AGENT_BASE_URL", "")
-        timeout: int = int(os.getenv("CALL_TIMEOUT_SECONDS", "60"))
+        connect_timeout: int = int(os.getenv("CALL_CONNECT_TIMEOUT_SECONDS", "60"))
+        duration_timeout: int = int(os.getenv("CALL_DURATION_TIMEOUT_SECONDS", "3600"))
 
         # Validate PUBLIC_URL — Twilio must be able to reach /twilio/voice via this URL.
         # localhost / 127.0.0.1 will cause Twilio to fail silently when the call is answered.
@@ -779,26 +781,59 @@ class VoiceAgent(BaseAgent):
             context_messages=context_messages,
         )
 
-        # Register future — twilio_stream finally block will resolve it
-        future: asyncio.Future = asyncio.get_event_loop().create_future()
+        # Register futures:
+        #   _CALL_ANSWERED — resolved by twilio_stream on the "start" event (callee answered)
+        #   _CALL_FUTURES  — resolved by twilio_stream's finally block (call ended)
+        loop = asyncio.get_event_loop()
+        answered_future: asyncio.Future = loop.create_future()
+        _CALL_ANSWERED[call_sid] = answered_future
+        future: asyncio.Future = loop.create_future()
         _CALL_FUTURES[call_sid] = future
 
-        logger.info("Call %s initiated (timeout=%ds)", call_sid, timeout)
+        logger.info(
+            "Call %s initiated (connect_timeout=%ds, duration_timeout=%ds)",
+            call_sid, connect_timeout, duration_timeout,
+        )
         yield AgentStreamResponse(
             state=TaskState.TASK_STATE_WORKING,
             content=f"Call ringing (call_sid={call_sid}). Waiting for the call to complete...",
             metadata={"type": "call_ringing", "call_sid": call_sid},
         )
 
-        # Wait for the Twilio stream to end
+        # Phase 1 — wait for the callee to answer.
         try:
-            result: dict = await asyncio.wait_for(future, timeout=timeout)
+            await asyncio.wait_for(asyncio.shield(answered_future), timeout=connect_timeout)
+            logger.info("Call %s answered", call_sid)
+            yield AgentStreamResponse(
+                state=TaskState.TASK_STATE_WORKING,
+                content="Call answered.",
+                metadata={"type": "call_answered", "call_sid": call_sid},
+            )
         except asyncio.TimeoutError:
+            _CALL_ANSWERED.pop(call_sid, None)
             _CALL_FUTURES.pop(call_sid, None)
-            logger.warning("Call %s timed out after %ds", call_sid, timeout)
+            logger.warning("Call %s not answered within %ds", call_sid, connect_timeout)
             yield AgentStreamResponse(
                 state=TaskState.TASK_STATE_FAILED,
-                content=f"Call timed out after {timeout}s without completion.",
+                content=f"Call not answered within {connect_timeout}s.",
+            )
+            return
+        except Exception as exc:
+            _CALL_ANSWERED.pop(call_sid, None)
+            _CALL_FUTURES.pop(call_sid, None)
+            logger.exception("Unexpected error waiting for call %s to be answered", call_sid)
+            yield AgentStreamResponse(state=TaskState.TASK_STATE_FAILED, content=f"Call error: {exc}")
+            return
+
+        # Phase 2 — wait for the call to end.
+        try:
+            result: dict = await asyncio.wait_for(future, timeout=duration_timeout)
+        except asyncio.TimeoutError:
+            _CALL_FUTURES.pop(call_sid, None)
+            logger.warning("Call %s exceeded max duration of %ds", call_sid, duration_timeout)
+            yield AgentStreamResponse(
+                state=TaskState.TASK_STATE_FAILED,
+                content=f"Call exceeded maximum duration of {duration_timeout}s.",
             )
             return
         except Exception as exc:

--- a/packages/voice-agent/voice_agent/a2a_agent.py
+++ b/packages/voice-agent/voice_agent/a2a_agent.py
@@ -335,11 +335,11 @@ class VoiceAgent(BaseAgent):
         """Pre-warm a Gemini session while Twilio is ringing the callee.
 
         Fired by ``_stream_phone_call`` *before* ``make_outbound_call()`` is called,
-        using a temporary prewarm_key.  The MCP handshake + Gemini WebSocket
-        connection run concurrently with the Twilio REST call, so the session is
-        ready (or nearly ready) by the time the callee answers.  After
-        ``make_outbound_call()`` returns the real call_sid, the caller re-keys
-        both ``_active_sessions`` and ``_prewarm_tasks`` to that call_sid.
+        using a temporary prewarm_key.  Blocks until MCP tools are initialised and
+        the Gemini Live WebSocket is open so the session is fully ready the instant
+        the callee answers.  After ``make_outbound_call()`` returns the real
+        call_sid, the caller re-keys both ``_active_sessions`` and
+        ``_prewarm_tasks`` to that call_sid.
         """
         await self._create_audio_session(
             session_key=session_key,
@@ -349,6 +349,18 @@ class VoiceAgent(BaseAgent):
             access_token=access_token,
             phone_number=phone_number,
         )
+
+        session = self._active_sessions.get(session_key)
+        if not session:
+            return
+        agent = session["agent"]
+
+        # agent.run() was just scheduled as a task — yield once so it can start
+        # executing and set agent.mcp_status to a Future before we await it.
+        await asyncio.sleep(0)
+
+        if agent.mcp_status is not None:
+            await asyncio.shield(agent.mcp_status)
 
     async def _start_audio_session(
         self,

--- a/packages/voice-agent/voice_agent/a2a_agent.py
+++ b/packages/voice-agent/voice_agent/a2a_agent.py
@@ -61,6 +61,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import uuid
 from enum import Enum
 from typing import AsyncIterable
 
@@ -279,9 +280,11 @@ class VoiceAgent(BaseAgent):
         if session_key in self._active_sessions:
             return
 
-        prompt = (system_prompt or DEFAULT_SYSTEM_PROMPT) + (
-            " IMPORTANT: Keep responses short and conversational. Do NOT use markdown, lists, or special characters."
-        )
+        prompt = (system_prompt or DEFAULT_SYSTEM_PROMPT)
+    
+        if " IMPORTANT: Keep responses short and conversational. Do NOT use markdown, lists, or special characters" not in prompt:
+            prompt += " IMPORTANT: Keep responses short and conversational. Do NOT use markdown, lists, or special characters."
+
         voice = voice_name or "Kore"
 
         mcp_headers: dict[str, str] | None = None
@@ -332,9 +335,12 @@ class VoiceAgent(BaseAgent):
     ) -> None:
         """Pre-warm a Gemini session while Twilio is ringing the callee.
 
-        Fired by ``_stream_phone_call`` right after ``make_outbound_call()`` returns
-        the call_sid. The MCP handshake + Gemini WebSocket connection happen
-        concurrently with Twilio dialling, so the session is ready when answered.
+        Fired by ``_stream_phone_call`` *before* ``make_outbound_call()`` is called,
+        using a temporary prewarm_key.  The MCP handshake + Gemini WebSocket
+        connection run concurrently with the Twilio REST call, so the session is
+        ready (or nearly ready) by the time the callee answers.  After
+        ``make_outbound_call()`` returns the real call_sid, the caller re-keys
+        both ``_active_sessions`` and ``_prewarm_tasks`` to that call_sid.
         """
         await self._create_audio_session(
             session_key=session_key,
@@ -536,8 +542,13 @@ class VoiceAgent(BaseAgent):
             logger.info("No system_prompt source found — will use DEFAULT_SYSTEM_PROMPT.")
 
         if system_prompt:
-            system_prompt += """ IMPORTANT: Keep responses short and conversational. Do NOT use markdown, lists, or special characters.
-            Ignore any phone number in the prompt, and start by introducing yourself and the meaning of your call."""
+            system_prompt += (
+                " IMPORTANT: Keep responses short and conversational."
+                " Do NOT use markdown, lists, or special characters."
+                " Ignore any phone number in the prompt, and start by introducing yourself and the meaning of your call."
+                " Only call tools when the user explicitly asks you to look up or perform a specific task."
+                " Never call tools proactively or during your greeting."
+            )
 
         # ── Resolve phone number ──────────────────────────────────────────────
         # Security: only the authenticated user's own phone number is allowed.
@@ -639,12 +650,15 @@ class VoiceAgent(BaseAgent):
         """Initiate a Twilio phone call and hold the A2A stream open until it ends.
 
         Flow:
-          1. Call make_outbound_call() in a thread executor (sync Twilio REST).
-          2. Register OutboundCallRequest in _PENDING_CALLS so the Twilio Media
+          1. Fire _prewarm_audio_session as a background task (Gemini + MCP
+             connect concurrently with the Twilio REST call below).
+          2. Call make_outbound_call() in a thread executor (sync Twilio REST).
+          3. Re-key the prewarm session from the temporary key to call_sid.
+          4. Register OutboundCallRequest in _PENDING_CALLS so the Twilio Media
              Stream WebSocket picks up system_prompt / voice_name / mcp_tools.
-          3. Register an asyncio.Future in _CALL_FUTURES keyed by call_sid.
-          4. Await the future — resolved by twilio_stream's finally block.
-          5. Yield ``completed`` with the formatted transcript.
+          5. Register an asyncio.Future in _CALL_FUTURES keyed by call_sid.
+          6. Await the future — resolved by twilio_stream's finally block.
+          7. Yield ``completed`` with the formatted transcript.
         """
         public_url: str = os.environ.get("PUBLIC_URL") or os.environ.get("VOICE_AGENT_BASE_URL", "")
         timeout: int = int(os.getenv("CALL_TIMEOUT_SECONDS", "60"))
@@ -672,34 +686,62 @@ class VoiceAgent(BaseAgent):
             metadata={"type": "call_initiating", "phone_number": phone_number},
         )
 
-        # Initiate the call via Twilio REST API (sync → thread executor)
-        try:
-            loop = asyncio.get_event_loop()
-            call_sid: str = await loop.run_in_executor(None, make_outbound_call, phone_number, public_url)
-        except Exception as exc:
-            logger.error("Failed to initiate Twilio call: %s", exc)
-            yield AgentStreamResponse(
-                state=TaskState.TASK_STATE_FAILED,
-                content=f"Call initiation failed: {exc}",
-            )
-            return
-
-        # Pre-warm the Gemini session while Twilio is ringing the callee.
+        # Start pre-warming the Gemini session BEFORE placing the call so that
+        # the MCP handshake + Gemini WebSocket are already established by the
+        # time the callee answers.  We use a temporary key because call_sid is
+        # not yet known; we rename both dicts to call_sid once the call is up.
         # asyncio.create_task inherits the current context so contextvars
         # (user token etc.) are available inside _prewarm_audio_session.
-        # By the time the callee answers, Gemini + MCP are already connected.
+
+        # Merge context_messages into system_prompt here so the Gemini session
+        # is created with the full prompt regardless of whether the call is
+        # answered before or after prewarm completes (prewarmed path ignores
+        # init_config in _start_audio_session).
+        effective_prompt = system_prompt or DEFAULT_SYSTEM_PROMPT
+        if context_messages:
+            context_str = "\n".join(context_messages)
+            effective_prompt = f"{effective_prompt}\n\nContext:\n{context_str}"
+
+        prewarm_key = str(uuid.uuid4())
         prewarm_task = asyncio.create_task(
             self._prewarm_audio_session(
-                session_key=call_sid,
-                system_prompt=system_prompt or DEFAULT_SYSTEM_PROMPT,
+                session_key=prewarm_key,
+                system_prompt=effective_prompt,
                 voice_name=voice_name,
                 mcp_tools=mcp_tools,
                 access_token=access_token,
                 phone_number=phone_number,
             )
         )
+        self._prewarm_tasks[prewarm_key] = prewarm_task
+        logger.info("Fired Gemini pre-warm before dialling (prewarm_key=%s)", prewarm_key)
+
+        # Initiate the call via Twilio REST API (sync → thread executor).
+        # Runs concurrently with the pre-warm started above.
+        try:
+            loop = asyncio.get_event_loop()
+            call_sid: str = await loop.run_in_executor(None, make_outbound_call, phone_number, public_url)
+        except Exception as exc:
+            logger.error("Failed to initiate Twilio call: %s", exc)
+            # Cancel the prewarm that was started speculatively
+            prewarm_task.cancel()
+            self._prewarm_tasks.pop(prewarm_key, None)
+            if prewarm_key in self._active_sessions:
+                await self._end_session(prewarm_key)
+            yield AgentStreamResponse(
+                state=TaskState.TASK_STATE_FAILED,
+                content=f"Call initiation failed: {exc}",
+            )
+            return
+
+        # Rename prewarm entries from the temporary key to the real call_sid
+        # so the rest of the pipeline (MCP check, twilio_stream, _end_session)
+        # can look up the session by call_sid as normal.
+        if prewarm_key in self._active_sessions:
+            self._active_sessions[call_sid] = self._active_sessions.pop(prewarm_key)
+        prewarm_task = self._prewarm_tasks.pop(prewarm_key, prewarm_task)
         self._prewarm_tasks[call_sid] = prewarm_task
-        logger.info("Fired Gemini pre-warm while ringing (call_sid=%s)", call_sid)
+        logger.info("Pre-warm session re-keyed to call_sid=%s", call_sid)
 
         # Wait for the agent's mcp_status future to be resolved.
         # _prewarm_audio_session creates the agent and starts agent.run(), which

--- a/packages/voice-agent/voice_agent/a2a_agent.py
+++ b/packages/voice-agent/voice_agent/a2a_agent.py
@@ -724,7 +724,7 @@ class VoiceAgent(BaseAgent):
         # _prewarm_audio_session creates the agent and starts agent.run(), which
         # sets mcp_status as soon as the MCP handshake succeeds or fails.
         try:
-            await asyncio.wait_for(asyncio.shield(prewarm_task), timeout=10.0)
+            await asyncio.wait_for(asyncio.shield(prewarm_task), timeout=60.0)
         except (asyncio.TimeoutError, Exception) as exc:
             logger.warning("Pre-warm did not complete before call: %s — will cold-start on answer", exc)
 

--- a/packages/voice-agent/voice_agent/a2a_agent.py
+++ b/packages/voice-agent/voice_agent/a2a_agent.py
@@ -84,6 +84,7 @@ from voice_agent.call_bridge import (
     OutboundCallRequest,
     make_outbound_call,
     send_sms,
+    build_effective_prompt
 )
 
 _CONSOLE_BACKEND_URL = os.getenv("CONSOLE_BACKEND_URL", "http://localhost:5001")
@@ -281,9 +282,6 @@ class VoiceAgent(BaseAgent):
             return
 
         prompt = (system_prompt or DEFAULT_SYSTEM_PROMPT)
-    
-        if " IMPORTANT: Keep responses short and conversational. Do NOT use markdown, lists, or special characters" not in prompt:
-            prompt += " IMPORTANT: Keep responses short and conversational. Do NOT use markdown, lists, or special characters."
 
         voice = voice_name or "Kore"
 
@@ -541,15 +539,6 @@ class VoiceAgent(BaseAgent):
             system_prompt = DEFAULT_SYSTEM_PROMPT
             logger.info("No system_prompt source found — will use DEFAULT_SYSTEM_PROMPT.")
 
-        if system_prompt:
-            system_prompt += (
-                " IMPORTANT: Keep responses short and conversational."
-                " Do NOT use markdown, lists, or special characters."
-                " Ignore any phone number in the prompt, and start by introducing yourself and the meaning of your call."
-                " Only call tools when the user explicitly asks you to look up or perform a specific task."
-                " Never call tools proactively or during your greeting."
-            )
-
         # ── Resolve phone number ──────────────────────────────────────────────
         # Security: only the authenticated user's own phone number is allowed.
         #
@@ -650,15 +639,17 @@ class VoiceAgent(BaseAgent):
         """Initiate a Twilio phone call and hold the A2A stream open until it ends.
 
         Flow:
-          1. Fire _prewarm_audio_session as a background task (Gemini + MCP
-             connect concurrently with the Twilio REST call below).
-          2. Call make_outbound_call() in a thread executor (sync Twilio REST).
-          3. Re-key the prewarm session from the temporary key to call_sid.
-          4. Register OutboundCallRequest in _PENDING_CALLS so the Twilio Media
+          1. Pre-warm the Gemini session and await it fully (token exchange +
+             WebSocket connect + MCP handshake) — all before the call starts
+             ringing so the session is ready the instant the callee answers.
+          2. Check MCP status and send SMS if auth failed.
+          3. Call make_outbound_call() in a thread executor (sync Twilio REST).
+          4. Re-key the prewarm session from the temporary key to call_sid.
+          5. Register OutboundCallRequest in _PENDING_CALLS so the Twilio Media
              Stream WebSocket picks up system_prompt / voice_name / mcp_tools.
-          5. Register an asyncio.Future in _CALL_FUTURES keyed by call_sid.
-          6. Await the future — resolved by twilio_stream's finally block.
-          7. Yield ``completed`` with the formatted transcript.
+          6. Register an asyncio.Future in _CALL_FUTURES keyed by call_sid.
+          7. Await the future — resolved by twilio_stream's finally block.
+          8. Yield ``completed`` with the formatted transcript.
         """
         public_url: str = os.environ.get("PUBLIC_URL") or os.environ.get("VOICE_AGENT_BASE_URL", "")
         timeout: int = int(os.getenv("CALL_TIMEOUT_SECONDS", "60"))
@@ -686,22 +677,14 @@ class VoiceAgent(BaseAgent):
             metadata={"type": "call_initiating", "phone_number": phone_number},
         )
 
-        # Start pre-warming the Gemini session BEFORE placing the call so that
-        # the MCP handshake + Gemini WebSocket are already established by the
-        # time the callee answers.  We use a temporary key because call_sid is
-        # not yet known; we rename both dicts to call_sid once the call is up.
+        effective_prompt = build_effective_prompt(system_prompt or DEFAULT_SYSTEM_PROMPT, context_messages)
+
+        # Pre-warm the Gemini session and wait for it to be fully ready before
+        # placing the call.  Any latency here (token exchange, WebSocket connect,
+        # MCP handshake) is invisible to the caller; the same work done after
+        # make_outbound_call() would risk a cold-start if the callee answers fast.
         # asyncio.create_task inherits the current context so contextvars
         # (user token etc.) are available inside _prewarm_audio_session.
-
-        # Merge context_messages into system_prompt here so the Gemini session
-        # is created with the full prompt regardless of whether the call is
-        # answered before or after prewarm completes (prewarmed path ignores
-        # init_config in _start_audio_session).
-        effective_prompt = system_prompt or DEFAULT_SYSTEM_PROMPT
-        if context_messages:
-            context_str = "\n".join(context_messages)
-            effective_prompt = f"{effective_prompt}\n\nContext:\n{context_str}"
-
         prewarm_key = str(uuid.uuid4())
         prewarm_task = asyncio.create_task(
             self._prewarm_audio_session(
@@ -714,59 +697,30 @@ class VoiceAgent(BaseAgent):
             )
         )
         self._prewarm_tasks[prewarm_key] = prewarm_task
-        logger.info("Fired Gemini pre-warm before dialling (prewarm_key=%s)", prewarm_key)
+        logger.info("Pre-warming Gemini session before dialling (prewarm_key=%s)", prewarm_key)
 
-        # Initiate the call via Twilio REST API (sync → thread executor).
-        # Runs concurrently with the pre-warm started above.
-        try:
-            loop = asyncio.get_event_loop()
-            call_sid: str = await loop.run_in_executor(None, make_outbound_call, phone_number, public_url)
-        except Exception as exc:
-            logger.error("Failed to initiate Twilio call: %s", exc)
-            # Cancel the prewarm that was started speculatively
-            prewarm_task.cancel()
-            self._prewarm_tasks.pop(prewarm_key, None)
-            if prewarm_key in self._active_sessions:
-                await self._end_session(prewarm_key)
-            yield AgentStreamResponse(
-                state=TaskState.TASK_STATE_FAILED,
-                content=f"Call initiation failed: {exc}",
-            )
-            return
-
-        # Rename prewarm entries from the temporary key to the real call_sid
-        # so the rest of the pipeline (MCP check, twilio_stream, _end_session)
-        # can look up the session by call_sid as normal.
-        if prewarm_key in self._active_sessions:
-            self._active_sessions[call_sid] = self._active_sessions.pop(prewarm_key)
-        prewarm_task = self._prewarm_tasks.pop(prewarm_key, prewarm_task)
-        self._prewarm_tasks[call_sid] = prewarm_task
-        logger.info("Pre-warm session re-keyed to call_sid=%s", call_sid)
-
-        # Wait for the agent's mcp_status future to be resolved.
+        # Wait for the agent's mcp_status future to be resolved before dialling.
         # _prewarm_audio_session creates the agent and starts agent.run(), which
         # sets mcp_status as soon as the MCP handshake succeeds or fails.
-        # We wait for the prewarm task first (up to 5 s) to ensure the agent
-        # object exists in _active_sessions, then await mcp_status (up to 15 s).
         try:
-            await asyncio.wait_for(asyncio.shield(prewarm_task), timeout=5.0)
+            await asyncio.wait_for(asyncio.shield(prewarm_task), timeout=10.0)
         except (asyncio.TimeoutError, Exception) as exc:
-            logger.debug("Pre-warm not yet done at MCP-status check point: %s", exc)
+            logger.warning("Pre-warm did not complete before call: %s — will cold-start on answer", exc)
 
+        # MCP status check — prewarm has had its full time budget so
+        # mcp_status should already be resolved or close to it.
         mcp_auth_failed = False
-        session = self._active_sessions.get(call_sid)
+        session = self._active_sessions.get(prewarm_key)
         if session:
             agent = session["agent"]
             if agent.mcp_status is not None:
                 try:
                     mcp_ok = await asyncio.wait_for(asyncio.shield(agent.mcp_status), timeout=15.0)
                     mcp_auth_failed = not mcp_ok
-                    logger.info("MCP status for call_sid=%s: %s", call_sid, "ok" if mcp_ok else "failed")
+                    logger.info("MCP status: %s", "ok" if mcp_ok else "failed")
                 except (asyncio.TimeoutError, Exception) as exc:
                     logger.debug("MCP status check timed out or failed: %s", exc)
 
-        # Send SMS if MCP auth failed during pre-warm so the caller knows
-        # their tools are unavailable and can authorize in the browser.
         if mcp_auth_failed:
             sms_body = (
                 "Your AI assistant is calling but couldn't connect to your tools. "
@@ -776,14 +730,37 @@ class VoiceAgent(BaseAgent):
             try:
                 loop = asyncio.get_event_loop()
                 await loop.run_in_executor(None, send_sms, phone_number, sms_body)
-                logger.info("MCP auth failure SMS sent (call_sid=%s)", call_sid)
+                logger.info("MCP auth failure SMS sent")
                 yield AgentStreamResponse(
                     state=TaskState.TASK_STATE_WORKING,
                     content="SMS sent to caller with tool authorization instructions.",
                     metadata={"type": "mcp_auth_sms_sent"},
                 )
             except Exception as sms_exc:
-                logger.warning("Failed to send MCP auth SMS (call_sid=%s): %s", call_sid, sms_exc)
+                logger.warning("Failed to send MCP auth SMS: %s", sms_exc)
+
+        # Initiate the call — Gemini session is ready for when the callee answers.
+        try:
+            loop = asyncio.get_event_loop()
+            call_sid: str = await loop.run_in_executor(None, make_outbound_call, phone_number, public_url)
+        except Exception as exc:
+            logger.error("Failed to initiate Twilio call: %s", exc)
+            self._prewarm_tasks.pop(prewarm_key, None)
+            if prewarm_key in self._active_sessions:
+                await self._end_session(prewarm_key)
+            yield AgentStreamResponse(
+                state=TaskState.TASK_STATE_FAILED,
+                content=f"Call initiation failed: {exc}",
+            )
+            return
+
+        # Re-key from temporary prewarm_key to call_sid.
+        # Prewarm is already complete so the session is guaranteed to be present.
+        if prewarm_key in self._active_sessions:
+            self._active_sessions[call_sid] = self._active_sessions.pop(prewarm_key)
+        prewarm_task = self._prewarm_tasks.pop(prewarm_key, prewarm_task)
+        self._prewarm_tasks[call_sid] = prewarm_task
+        logger.info("Pre-warm session keyed to call_sid=%s", call_sid)
 
         # Register config so twilio_stream picks it up when the call connects.
         _PENDING_CALLS[call_sid] = OutboundCallRequest(
@@ -799,11 +776,7 @@ class VoiceAgent(BaseAgent):
         future: asyncio.Future = asyncio.get_event_loop().create_future()
         _CALL_FUTURES[call_sid] = future
 
-        logger.info(
-            "Call %s initiated (timeout=%ds)",
-            call_sid,
-            timeout,
-        )
+        logger.info("Call %s initiated (timeout=%ds)", call_sid, timeout)
         yield AgentStreamResponse(
             state=TaskState.TASK_STATE_WORKING,
             content=f"Call ringing (call_sid={call_sid}). Waiting for the call to complete...",

--- a/packages/voice-agent/voice_agent/agent.py
+++ b/packages/voice-agent/voice_agent/agent.py
@@ -593,10 +593,7 @@ class GeminiLiveAgent:
             fn = dispatch_map.get(name)
             if fn is not None:
                 try:
-                    if asyncio.iscoroutinefunction(fn):
-                        result = await fn(args)
-                    else:
-                        result = fn(**args)
+                    result = await fn(args)
                 except Exception:
                     logger.exception("Tool %r raised an exception", name)
                     result = f"Tool error: {name} raised an exception"

--- a/packages/voice-agent/voice_agent/agent.py
+++ b/packages/voice-agent/voice_agent/agent.py
@@ -133,7 +133,7 @@ _WRITE_TOOL_INSTRUCTION = (
     "'Shall I proceed?' Wait for a clear yes before calling the tool."
 )
 
-# Keywords that indicate a tool has write/mutate side-effects.
+# Keywords that indicate a tool has write/mutate side-effects (fallback only).
 _WRITE_KEYWORDS = frozenset(
     {
         "create", "update", "delete", "remove", "post", "write", "send", "push",
@@ -147,6 +147,81 @@ def _is_write_tool(name: str, description: str) -> bool:
     """Return True if the tool name or description suggests a write/mutate operation."""
     text = (name + " " + description).lower().replace("_", " ").replace("-", " ")
     return any(kw in text.split() for kw in _WRITE_KEYWORDS)
+
+
+# ── Tool risk scoring ─────────────────────────────────────────────────────────
+
+# Risk score threshold: >= this value → treat tool as write/mutate (require confirmation).
+_WRITE_RISK_THRESHOLD: float = 0.4
+
+# Module-level cache: tool_name → risk score. Persists across sessions within the process.
+_TOOL_RISK_CACHE: dict[str, float] = {}
+
+# Lightweight flash model used only for tool classification (separate from the Live session model).
+_RISK_SCORER_MODEL: str = os.getenv("GEMINI_RISK_SCORER_MODEL", "gemini-3-flash-preview")
+
+_RISK_SCORING_SYSTEM_PROMPT = """\
+You are a security analyst evaluating the risk level of AI agent tool calls.
+Given a tool's name, description, and JSON schema, return a JSON object with exactly two keys:
+  "score": number 0.0-1.0 — inherent risk when called with typical arguments.
+    0.0-0.2: Safe    — read-only queries, status checks, information retrieval
+    0.2-0.4: Low     — filtered reads, access to user's own data
+    0.4-0.6: Moderate — reversible writes to user's own resources
+    0.6-0.8: Elevated — writes to shared resources, external API calls, credential access
+    0.8-1.0: Critical — destructive, irreversible, or security-sensitive operations
+  "reasoning": string — one sentence explanation.
+Return only the JSON object, no extra text.\
+"""
+
+
+async def _llm_score_tool_risk(
+    client: genai.Client,
+    name: str,
+    description: str,
+    input_schema: dict,
+) -> float:
+    """Use Gemini Flash to score a tool's write risk. Returns 0.0–1.0."""
+    schema_str = json.dumps(input_schema, indent=2) if input_schema else "No schema available"
+    user_prompt = (
+        f"Tool name: {name}\n"
+        f"Description: {description or 'No description available'}\n"
+        f"Input schema:\n{schema_str}"
+    )
+    response = await client.aio.models.generate_content(
+        model=_RISK_SCORER_MODEL,
+        contents=user_prompt,
+        config=types.GenerateContentConfig(
+            system_instruction=_RISK_SCORING_SYSTEM_PROMPT,
+            response_mime_type="application/json",
+        ),
+    )
+    data = json.loads(response.text)
+    return float(data["score"])
+
+
+async def _score_tool_risk(
+    client: genai.Client,
+    name: str,
+    description: str,
+    input_schema: dict,
+) -> float:
+    """Return write-risk score for an MCP tool (0.0–1.0).
+
+    Resolution order: module-level cache → LLM scoring → keyword fallback.
+    """
+    cached = _TOOL_RISK_CACHE.get(name)
+    if cached is not None:
+        return cached
+
+    try:
+        score = await _llm_score_tool_risk(client, name, description, input_schema)
+        logger.debug("Tool %r LLM risk score: %.2f", name, score)
+    except Exception:
+        logger.warning("LLM risk scoring failed for %r, using keyword fallback", name, exc_info=True)
+        score = 0.9 if _is_write_tool(name, description) else 0.1
+
+    _TOOL_RISK_CACHE[name] = score
+    return score
 
 
 def build_live_config(
@@ -217,7 +292,7 @@ class GeminiLiveAgent:
         self.mcp_status: asyncio.Future[bool] | None = None
 
     async def _init_mcp_tools(
-        self, mcp_session: ClientSession, event_out: asyncio.Queue[dict]
+        self, mcp_session: ClientSession, event_out: asyncio.Queue[dict], client: genai.Client
     ) -> list[types.FunctionDeclaration]:
         """Discover tools from an already-initialised MCP session.
 
@@ -234,12 +309,11 @@ class GeminiLiveAgent:
         _auth_notified = [False]
 
         # Human-in-the-loop confirmation gate for write tools.
-        # When a write tool is called for the first time in a turn, _exec
-        # returns a CONFIRMATION_REQUIRED message instead of executing.
-        # Gemini then asks the user verbally; if they confirm, Gemini calls
-        # the tool again — that second call executes for real.
-        # The set holds tool names currently awaiting confirmation.
-        _awaiting_confirmation: set[str] = set()
+        # Maps tool_name → the exact args dict that was intercepted.
+        # Only a second call with identical args is treated as confirmed;
+        # a call with different args re-triggers the gate from scratch,
+        # preventing a retry with different arguments from slipping through.
+        _awaiting_confirmation: dict[str, dict] = {}
 
         for tool in tools_result.tools:
             # If a tool filter was specified, skip tools not in the list.
@@ -248,7 +322,8 @@ class GeminiLiveAgent:
                 continue
             raw_schema = dict(tool.inputSchema or {})
             logger.debug("MCP tool schema for %r: %s", tool.name, raw_schema)
-            is_write = _is_write_tool(tool.name, tool.description or "")
+            risk_score = await _score_tool_risk(client, tool.name, tool.description or "", raw_schema)
+            is_risky = risk_score >= _WRITE_RISK_THRESHOLD
             declarations.append(
                 types.FunctionDeclaration(
                     name=tool.name,
@@ -262,21 +337,28 @@ class GeminiLiveAgent:
                 args: dict,
                 *,
                 _name: str = tool.name,
-                _write: bool = is_write,
+                _risky: bool = is_risky,
             ) -> str:
-                if _write:
-                    if _name not in _awaiting_confirmation:
-                        # First call — gate it: ask Gemini to get verbal confirmation.
-                        _awaiting_confirmation.add(_name)
-                        logger.info("Write tool %r intercepted — requesting confirmation", _name)
-                        return (
-                            f"CONFIRMATION_REQUIRED: Before calling {_name}, tell the user "
-                            f"exactly what you are about to do and ask 'Shall I proceed?' "
-                            f"Only call {_name} again once they have clearly said yes."
-                        )
-                    # Second call — user has confirmed; execute and clear the gate.
-                    _awaiting_confirmation.discard(_name)
-                    logger.info("Write tool %r executing after confirmation", _name)
+                if _risky:
+                    confirmation_msg = (
+                        f"CONFIRMATION_REQUIRED: Before calling {_name}, tell the user "
+                        f"exactly what you are about to do and ask 'Shall I proceed?' "
+                        f"Only call {_name} again once they have clearly said yes."
+                    )
+                    pending = _awaiting_confirmation.get(_name)
+                    if pending is None:
+                        # First call — gate it.
+                        _awaiting_confirmation[_name] = args
+                        logger.info("Risky tool %r intercepted — requesting confirmation", _name)
+                        return confirmation_msg
+                    if args != pending:
+                        # Different args — treat as a new attempt, re-gate.
+                        _awaiting_confirmation[_name] = args
+                        logger.info("Risky tool %r re-intercepted with different args", _name)
+                        return confirmation_msg
+                    # Same args — user confirmed; execute and clear the gate.
+                    del _awaiting_confirmation[_name]
+                    logger.info("Tool %r executing after confirmation", _name)
 
                 result = await mcp_session.call_tool(_name, arguments=args)
                 if result.isError:
@@ -316,7 +398,7 @@ class GeminiLiveAgent:
                 return "\n".join(texts) if texts else str(result.content)
 
             self.tool_map[tool.name] = traceable(name=tool.name, run_type="tool")(_exec)
-            logger.info("MCP tool registered: %s (write=%s)", tool.name, is_write)
+            logger.info("MCP tool registered: %s (write=%s, risk=%.2f)", tool.name, is_risky, risk_score)
 
         return declarations
 
@@ -349,7 +431,7 @@ class GeminiLiveAgent:
                 ) as (read, write, _):
                     async with ClientSession(read, write) as mcp_session:
                         await mcp_session.initialize()
-                        declarations = await self._init_mcp_tools(mcp_session, event_out)
+                        declarations = await self._init_mcp_tools(mcp_session, event_out, client)
                         gemini_tools = [types.Tool(function_declarations=declarations)] if declarations else None
                         config = build_live_config(self.voice_name, self.system_prompt, tools=gemini_tools)
                         logger.info(

--- a/packages/voice-agent/voice_agent/agent.py
+++ b/packages/voice-agent/voice_agent/agent.py
@@ -107,8 +107,7 @@ SYSTEM_PROMPT = """
  You are a helpful voice assistant for a product named Nannos.
  In your first response, greet him and introduce yourself as a voice assistant for Nannos,
  and provide assistance as needed. Keep your responses concise and natural — as if speaking out loud.
- Do NOT use markdown, bullet points, numbered lists, or special characters.
- Respond in short, clear sentences."""
+ """
 
 
 # ── Tools ─────────────────────────────────────────────────────────────────────
@@ -119,6 +118,13 @@ _TOOL_MAP: dict[str, object] = {}
 
 
 # ── Live config ───────────────────────────────────────────────────────────────
+
+
+_NO_PROACTIVE_TOOLS_INSTRUCTION = (
+    "\n\nCRITICAL: Your FIRST action must always be to speak a greeting to the user. "
+    "Never call any tools before your first spoken response. "
+    "After the greeting you may use tools freely."
+)
 
 
 def build_live_config(
@@ -134,6 +140,8 @@ def build_live_config(
         tools: List of tools to make available. If None, uses default [get_current_time].
     """
     prompt = system_prompt if system_prompt is not None else SYSTEM_PROMPT
+    if tools:
+        prompt = prompt + _NO_PROACTIVE_TOOLS_INSTRUCTION
     tool_list = tools
 
     return types.LiveConnectConfig(

--- a/packages/voice-agent/voice_agent/agent.py
+++ b/packages/voice-agent/voice_agent/agent.py
@@ -577,6 +577,50 @@ class GeminiLiveAgent:
                 except Exception:
                     pass
 
+        _running_tools: set[str] = set()
+
+        async def _dispatch_tool_call(call_id: str, name: str, args: dict) -> None:
+            """Execute one tool call in the background and send the response.
+
+            Runs as an asyncio.create_task so the receive loop is never blocked
+            by slow MCP calls. Scheduling hints tell Gemini when to surface the
+            result:
+              INTERRUPT — confirmation prompts: speak immediately, interrupting
+                          any in-progress audio.
+              WHEN_IDLE — normal results: wait for a natural pause so the agent
+                          can finish its current sentence first.
+            """
+            fn = dispatch_map.get(name)
+            if fn is not None:
+                try:
+                    if asyncio.iscoroutinefunction(fn):
+                        result = await fn(args)
+                    else:
+                        result = fn(**args)
+                except Exception:
+                    logger.exception("Tool %r raised an exception", name)
+                    result = f"Tool error: {name} raised an exception"
+            else:
+                result = f"Unknown function: {name}"
+                logger.warning("Unknown tool called: %s", name)
+
+            is_confirmation = isinstance(result, str) and "CONFIRMATION_REQUIRED" in result
+            scheduling = "INTERRUPT" if is_confirmation else "WHEN_IDLE"
+            logger.info("Tool %r response ready (scheduling=%s)", name, scheduling)
+            try:
+                await session.send_tool_response(
+                    function_responses=[
+                        types.FunctionResponse(
+                            id=call_id,
+                            name=name,
+                            response={"result": result},
+                            scheduling=scheduling,
+                        )
+                    ]
+                )
+            finally:
+                _running_tools.discard(name)
+
         async def _receive_loop() -> None:
             nonlocal t_first_audio_sent, first_response_logged
             turn = 0
@@ -587,36 +631,31 @@ class GeminiLiveAgent:
                 while True:
                     async for response in session.receive():
                         # ── Tool calls ───────────────────────────────────
-                        # Must respond or Gemini waits indefinitely.
+                        # Dispatch each call as a background task so the
+                        # receive loop is never blocked by slow MCP calls.
                         if response.tool_call:
-                            fn_responses = []
                             for fc in response.tool_call.function_calls:
+                                if fc.name in _running_tools:
+                                    logger.debug(
+                                        "Tool %r still running — ignoring duplicate call (id=%s)",
+                                        fc.name,
+                                        fc.id,
+                                    )
+                                    continue
+                                _running_tools.add(fc.name)
                                 logger.info(
                                     "Tool call: %s(%s) (turn=%d)",
                                     fc.name,
                                     dict(fc.args or {}),
                                     turn,
                                 )
-                                fn = dispatch_map.get(fc.name)
-                                if fn is not None:
-                                    kwargs = dict(fc.args) if fc.args else {}
-                                    if asyncio.iscoroutinefunction(fn):
-                                        result = await fn(kwargs)
-                                    else:
-                                        result = fn(**kwargs)
-                                else:
-                                    result = f"Unknown function: {fc.name}"
-                                    logger.warning("Unknown tool called: %s", fc.name)
-                                fn_responses.append(
-                                    types.FunctionResponse(
-                                        id=fc.id,
-                                        name=fc.name,
-                                        response={"result": result},
+                                asyncio.create_task(
+                                    _dispatch_tool_call(
+                                        fc.id,
+                                        fc.name,
+                                        dict(fc.args or {}),
                                     )
                                 )
-                            await session.send_tool_response(
-                                function_responses=fn_responses
-                            )
                             continue
 
                         sc = response.server_content

--- a/packages/voice-agent/voice_agent/agent.py
+++ b/packages/voice-agent/voice_agent/agent.py
@@ -71,7 +71,9 @@ def build_gemini_client() -> genai.Client:
     gcp_location = os.getenv("GCP_LOCATION", "us-central1")
 
     if not gcp_key:
-        raise RuntimeError("GCP_KEY is not set — add the service account JSON blob to .env")
+        raise RuntimeError(
+            "GCP_KEY is not set — add the service account JSON blob to .env"
+        )
     if not gcp_project:
         raise RuntimeError("GCP_PROJECT_ID is not set — add it to .env")
 
@@ -83,7 +85,9 @@ def build_gemini_client() -> genai.Client:
             scopes=["https://www.googleapis.com/auth/cloud-platform"],
         )
     except (json.JSONDecodeError, ValueError) as exc:
-        raise RuntimeError(f"Failed to parse GCP_KEY as service account JSON: {exc}") from exc
+        raise RuntimeError(
+            f"Failed to parse GCP_KEY as service account JSON: {exc}"
+        ) from exc
 
     logger.info(
         "Building Gemini Vertex AI client (project=%s, location=%s)",
@@ -136,9 +140,28 @@ _WRITE_TOOL_INSTRUCTION = (
 # Keywords that indicate a tool has write/mutate side-effects (fallback only).
 _WRITE_KEYWORDS = frozenset(
     {
-        "create", "update", "delete", "remove", "post", "write", "send", "push",
-        "modify", "edit", "close", "merge", "publish", "commit", "open", "add",
-        "insert", "patch", "put", "submit", "deploy", "release",
+        "create",
+        "update",
+        "delete",
+        "remove",
+        "post",
+        "write",
+        "send",
+        "push",
+        "modify",
+        "edit",
+        "close",
+        "merge",
+        "publish",
+        "commit",
+        "open",
+        "add",
+        "insert",
+        "patch",
+        "put",
+        "submit",
+        "deploy",
+        "release",
     }
 )
 
@@ -158,7 +181,7 @@ _WRITE_RISK_THRESHOLD: float = 0.4
 _TOOL_RISK_CACHE: dict[str, float] = {}
 
 # Lightweight flash model used only for tool classification (separate from the Live session model).
-_RISK_SCORER_MODEL: str = os.getenv("GEMINI_RISK_SCORER_MODEL", "gemini-3-flash-preview")
+_RISK_SCORER_MODEL: str = os.getenv("GEMINI_RISK_SCORER_MODEL", "gemini-2.5-flash")
 
 _RISK_SCORING_SYSTEM_PROMPT = """\
 You are a security analyst evaluating the risk level of AI agent tool calls.
@@ -181,7 +204,9 @@ async def _llm_score_tool_risk(
     input_schema: dict,
 ) -> float:
     """Use Gemini Flash to score a tool's write risk. Returns 0.0–1.0."""
-    schema_str = json.dumps(input_schema, indent=2) if input_schema else "No schema available"
+    schema_str = (
+        json.dumps(input_schema, indent=2) if input_schema else "No schema available"
+    )
     user_prompt = (
         f"Tool name: {name}\n"
         f"Description: {description or 'No description available'}\n"
@@ -217,7 +242,11 @@ async def _score_tool_risk(
         score = await _llm_score_tool_risk(client, name, description, input_schema)
         logger.debug("Tool %r LLM risk score: %.2f", name, score)
     except Exception:
-        logger.warning("LLM risk scoring failed for %r, using keyword fallback", name, exc_info=True)
+        logger.warning(
+            "LLM risk scoring failed for %r, using keyword fallback",
+            name,
+            exc_info=True,
+        )
         score = 0.9 if _is_write_tool(name, description) else 0.1
 
     _TOOL_RISK_CACHE[name] = score
@@ -292,7 +321,10 @@ class GeminiLiveAgent:
         self.mcp_status: asyncio.Future[bool] | None = None
 
     async def _init_mcp_tools(
-        self, mcp_session: ClientSession, event_out: asyncio.Queue[dict], client: genai.Client
+        self,
+        mcp_session: ClientSession,
+        event_out: asyncio.Queue[dict],
+        client: genai.Client,
     ) -> list[types.FunctionDeclaration]:
         """Discover tools from an already-initialised MCP session.
 
@@ -318,11 +350,17 @@ class GeminiLiveAgent:
         for tool in tools_result.tools:
             # If a tool filter was specified, skip tools not in the list.
             if self.mcp_tool_filter and tool.name not in self.mcp_tool_filter:
-                logger.debug("MCP tool %r skipped (not in filter %s)", tool.name, self.mcp_tool_filter)
+                logger.debug(
+                    "MCP tool %r skipped (not in filter %s)",
+                    tool.name,
+                    self.mcp_tool_filter,
+                )
                 continue
             raw_schema = dict(tool.inputSchema or {})
             logger.debug("MCP tool schema for %r: %s", tool.name, raw_schema)
-            risk_score = await _score_tool_risk(client, tool.name, tool.description or "", raw_schema)
+            risk_score = await _score_tool_risk(
+                client, tool.name, tool.description or "", raw_schema
+            )
             is_risky = risk_score >= _WRITE_RISK_THRESHOLD
             declarations.append(
                 types.FunctionDeclaration(
@@ -349,12 +387,16 @@ class GeminiLiveAgent:
                     if pending is None:
                         # First call — gate it.
                         _awaiting_confirmation[_name] = args
-                        logger.info("Risky tool %r intercepted — requesting confirmation", _name)
+                        logger.info(
+                            "Risky tool %r intercepted — requesting confirmation", _name
+                        )
                         return confirmation_msg
                     if args != pending:
                         # Different args — treat as a new attempt, re-gate.
                         _awaiting_confirmation[_name] = args
-                        logger.info("Risky tool %r re-intercepted with different args", _name)
+                        logger.info(
+                            "Risky tool %r re-intercepted with different args", _name
+                        )
                         return confirmation_msg
                     # Same args — user confirmed; execute and clear the gate.
                     del _awaiting_confirmation[_name]
@@ -380,7 +422,9 @@ class GeminiLiveAgent:
                                     await event_out.put(
                                         {
                                             "type": "mcp_auth_failed",
-                                            "message": data.get("message", "Tool requires authorization"),
+                                            "message": data.get(
+                                                "message", "Tool requires authorization"
+                                            ),
                                             "authorize_url": authorize_url,
                                         }
                                     )
@@ -398,7 +442,12 @@ class GeminiLiveAgent:
                 return "\n".join(texts) if texts else str(result.content)
 
             self.tool_map[tool.name] = traceable(name=tool.name, run_type="tool")(_exec)
-            logger.info("MCP tool registered: %s (write=%s, risk=%.2f)", tool.name, is_risky, risk_score)
+            logger.info(
+                "MCP tool registered: %s (write=%s, risk=%.2f)",
+                tool.name,
+                is_risky,
+                risk_score,
+            )
 
         return declarations
 
@@ -431,9 +480,17 @@ class GeminiLiveAgent:
                 ) as (read, write, _):
                     async with ClientSession(read, write) as mcp_session:
                         await mcp_session.initialize()
-                        declarations = await self._init_mcp_tools(mcp_session, event_out, client)
-                        gemini_tools = [types.Tool(function_declarations=declarations)] if declarations else None
-                        config = build_live_config(self.voice_name, self.system_prompt, tools=gemini_tools)
+                        declarations = await self._init_mcp_tools(
+                            mcp_session, event_out, client
+                        )
+                        gemini_tools = (
+                            [types.Tool(function_declarations=declarations)]
+                            if declarations
+                            else None
+                        )
+                        config = build_live_config(
+                            self.voice_name, self.system_prompt, tools=gemini_tools
+                        )
                         logger.info(
                             "MCP gateway connected (url=%s), %d tools registered",
                             self.mcp_gateway_url,
@@ -441,8 +498,12 @@ class GeminiLiveAgent:
                         )
                         if not self.mcp_status.done():
                             self.mcp_status.set_result(True)
-                        async with client.aio.live.connect(model=self.model_id, config=config) as session:
-                            await self._run_session(session, audio_in, event_out, self.tool_map)
+                        async with client.aio.live.connect(
+                            model=self.model_id, config=config
+                        ) as session:
+                            await self._run_session(
+                                session, audio_in, event_out, self.tool_map
+                            )
                 return
             except Exception as exc:
                 logger.warning(
@@ -454,7 +515,9 @@ class GeminiLiveAgent:
                     self.mcp_status.set_result(False)
                 await event_out.put({"type": "mcp_auth_failed", "message": str(exc)})
 
-        async with client.aio.live.connect(model=self.model_id, config=self._config) as session:
+        async with client.aio.live.connect(
+            model=self.model_id, config=self._config
+        ) as session:
             await self._run_session(session, audio_in, event_out, self.tool_map)
 
     async def _run_session(
@@ -500,7 +563,9 @@ class GeminiLiveAgent:
                         logger.debug("send_loop: forwarded %d chunks", chunks_sent)
                     if t_first_audio_sent is None:
                         t_first_audio_sent = time.perf_counter()
-                    await session.send_realtime_input(media=types.Blob(data=chunk, mime_type="audio/pcm;rate=16000"))
+                    await session.send_realtime_input(
+                        media=types.Blob(data=chunk, mime_type="audio/pcm;rate=16000")
+                    )
             except asyncio.CancelledError:
                 raise
             except Exception:
@@ -549,7 +614,9 @@ class GeminiLiveAgent:
                                         response={"result": result},
                                     )
                                 )
-                            await session.send_tool_response(function_responses=fn_responses)
+                            await session.send_tool_response(
+                                function_responses=fn_responses
+                            )
                             continue
 
                         sc = response.server_content
@@ -566,21 +633,41 @@ class GeminiLiveAgent:
                         if sc.model_turn:
                             for part in sc.model_turn.parts:
                                 if part.inline_data and part.inline_data.data:
-                                    if not first_response_logged and t_first_audio_sent is not None:
-                                        lat_ms = (time.perf_counter() - t_first_audio_sent) * 1000
-                                        logger.info("[LATENCY] Gemini first audio: %.0f ms", lat_ms)
+                                    if (
+                                        not first_response_logged
+                                        and t_first_audio_sent is not None
+                                    ):
+                                        lat_ms = (
+                                            time.perf_counter() - t_first_audio_sent
+                                        ) * 1000
+                                        logger.info(
+                                            "[LATENCY] Gemini first audio: %.0f ms",
+                                            lat_ms,
+                                        )
                                         first_response_logged = True
-                                    audio_b64 = base64.b64encode(part.inline_data.data).decode("ascii")
-                                    _event_logger.debug(json.dumps({"type": "audio_chunk"}))
-                                    await event_out.put({"type": "audio_chunk", "audio": audio_b64})
+                                    audio_b64 = base64.b64encode(
+                                        part.inline_data.data
+                                    ).decode("ascii")
+                                    _event_logger.debug(
+                                        json.dumps({"type": "audio_chunk"})
+                                    )
+                                    await event_out.put(
+                                        {"type": "audio_chunk", "audio": audio_b64}
+                                    )
 
                         if sc.input_transcription and sc.input_transcription.text:
-                            ev = {"type": "input_transcript", "text": sc.input_transcription.text}
+                            ev = {
+                                "type": "input_transcript",
+                                "text": sc.input_transcription.text,
+                            }
                             _event_logger.debug(json.dumps(ev))
                             await event_out.put(ev)
 
                         if sc.output_transcription and sc.output_transcription.text:
-                            ev = {"type": "output_transcript", "text": sc.output_transcription.text}
+                            ev = {
+                                "type": "output_transcript",
+                                "text": sc.output_transcription.text,
+                            }
                             _event_logger.debug(json.dumps(ev))
                             await event_out.put(ev)
 
@@ -594,7 +681,9 @@ class GeminiLiveAgent:
                             break  # restart session.receive() for next turn
                     else:
                         # for completed without break → session genuinely closed.
-                        logger.warning("receive_loop: session closed after %d turns", turn)
+                        logger.warning(
+                            "receive_loop: session closed after %d turns", turn
+                        )
                         break
 
             except asyncio.CancelledError:

--- a/packages/voice-agent/voice_agent/agent.py
+++ b/packages/voice-agent/voice_agent/agent.py
@@ -172,6 +172,10 @@ def _is_write_tool(name: str, description: str) -> bool:
     return any(kw in text.split() for kw in _WRITE_KEYWORDS)
 
 
+# Results larger than this are stored in memory and replaced with a stub so they
+# don't inflate the model's context window.
+_LARGE_RESULT_THRESHOLD: int = 15 * 1024  # 15 KB
+
 # ── Tool risk scoring ─────────────────────────────────────────────────────────
 
 # Risk score threshold: >= this value → treat tool as write/mutate (require confirmation).
@@ -281,6 +285,10 @@ def build_live_config(
         input_audio_transcription=types.AudioTranscriptionConfig(),
         output_audio_transcription=types.AudioTranscriptionConfig(),
         tools=tool_list,
+        context_window_compression=types.ContextWindowCompressionConfig(
+            trigger_tokens=128000,
+            sliding_window=types.SlidingWindow(target_tokens=32000),
+        ),
     )
 
 
@@ -346,6 +354,11 @@ class GeminiLiveAgent:
         # a call with different args re-triggers the gate from scratch,
         # preventing a retry with different arguments from slipping through.
         _awaiting_confirmation: dict[str, dict] = {}
+
+        # Per-session store for large tool results.
+        # _result_counter wrapped in a list so _exec closures can increment it.
+        _stored_results: dict[str, str] = {}
+        _result_counter = [0]
 
         for tool in tools_result.tools:
             # If a tool filter was specified, skip tools not in the list.
@@ -439,7 +452,25 @@ class GeminiLiveAgent:
                             pass
                     return f"Tool error: {result.content}"
                 texts = [c.text for c in result.content if hasattr(c, "text")]
-                return "\n".join(texts) if texts else str(result.content)
+                full_text = "\n".join(texts) if texts else str(result.content)
+                if len(full_text) > _LARGE_RESULT_THRESHOLD:
+                    result_id = f"result_{_result_counter[0]}"
+                    _result_counter[0] += 1
+                    _stored_results[result_id] = full_text
+                    size_kb = len(full_text) / 1024
+                    line_count = full_text.count("\n") + 1
+                    preview = full_text[:200].replace("\n", " ")
+                    logger.info(
+                        "Large result from %r stored as %s (%.0fKB, %d lines)",
+                        _name, result_id, size_kb, line_count,
+                    )
+                    return (
+                        f"Result too large to include directly ({size_kb:.0f}KB, {line_count} lines). "
+                        f"Stored as {result_id}. Preview: {preview!r}. "
+                        f"Use search_stored_result(result_id='{result_id}', pattern='...') to search, "
+                        f"or read_stored_result_range(result_id='{result_id}', start_line=1, end_line=50) to read."
+                    )
+                return full_text
 
             self.tool_map[tool.name] = traceable(name=tool.name, run_type="tool")(_exec)
             logger.info(
@@ -448,6 +479,77 @@ class GeminiLiveAgent:
                 is_risky,
                 risk_score,
             )
+
+        # ── Local result-storage tools ────────────────────────────────────────
+        # These are registered as FunctionDeclarations alongside the MCP tools
+        # but are handled entirely in-process — no MCP round-trip, no risk scoring.
+
+        async def search_stored_result(args: dict) -> str:
+            result_id = args.get("result_id", "")
+            pattern = args.get("pattern", "")
+            text = _stored_results.get(result_id)
+            if text is None:
+                return f"No stored result with id '{result_id}'."
+            lines = text.splitlines()
+            matches = [(i + 1, line) for i, line in enumerate(lines) if pattern.lower() in line.lower()]
+            if not matches:
+                return f"No lines matching '{pattern}' in {result_id} ({len(lines)} lines total)."
+            shown = matches[:50]
+            result_lines = [f"L{n}: {line}" for n, line in shown]
+            suffix = f"\n… ({len(matches) - 50} more matches not shown)" if len(matches) > 50 else ""
+            return "\n".join(result_lines) + suffix
+
+        async def read_stored_result_range(args: dict) -> str:
+            result_id = args.get("result_id", "")
+            start_line = int(args.get("start_line", 1))
+            end_line = int(args.get("end_line", 50))
+            text = _stored_results.get(result_id)
+            if text is None:
+                return f"No stored result with id '{result_id}'."
+            lines = text.splitlines()
+            total = len(lines)
+            start = max(0, start_line - 1)
+            end = min(total, end_line)
+            chunk = "\n".join(f"L{start + i + 1}: {line}" for i, line in enumerate(lines[start:end]))
+            return f"Lines {start_line}–{end} of {total} total:\n{chunk}"
+
+        declarations.append(
+            types.FunctionDeclaration(
+                name="search_stored_result",
+                description=(
+                    "Search a large tool result that was too big to return directly. "
+                    "Returns up to 50 matching lines with line numbers."
+                ),
+                parameters_json_schema={
+                    "type": "object",
+                    "properties": {
+                        "result_id": {"type": "string", "description": "ID returned in the stub, e.g. result_0"},
+                        "pattern": {"type": "string", "description": "Case-insensitive text to search for"},
+                    },
+                    "required": ["result_id", "pattern"],
+                },
+            )
+        )
+        declarations.append(
+            types.FunctionDeclaration(
+                name="read_stored_result_range",
+                description=(
+                    "Read a line range from a large tool result that was too big to return directly."
+                ),
+                parameters_json_schema={
+                    "type": "object",
+                    "properties": {
+                        "result_id": {"type": "string", "description": "ID returned in the stub, e.g. result_0"},
+                        "start_line": {"type": "integer", "description": "First line to read (1-indexed)"},
+                        "end_line": {"type": "integer", "description": "Last line to read inclusive (1-indexed)"},
+                    },
+                    "required": ["result_id", "start_line", "end_line"],
+                },
+            )
+        )
+        self.tool_map["search_stored_result"] = search_stored_result
+        self.tool_map["read_stored_result_range"] = read_stored_result_range
+        logger.info("Local result-storage tools registered (search_stored_result, read_stored_result_range)")
 
         return declarations
 

--- a/packages/voice-agent/voice_agent/agent.py
+++ b/packages/voice-agent/voice_agent/agent.py
@@ -126,6 +126,28 @@ _NO_PROACTIVE_TOOLS_INSTRUCTION = (
     "After the greeting you may use tools freely."
 )
 
+_WRITE_TOOL_INSTRUCTION = (
+    "\n\nFor any tool that creates, modifies, deletes, or sends data — such as creating "
+    "issues, posting messages, committing code, or sending emails — you MUST first ask "
+    "the user for explicit verbal confirmation. Say what you are about to do and ask "
+    "'Shall I proceed?' Wait for a clear yes before calling the tool."
+)
+
+# Keywords that indicate a tool has write/mutate side-effects.
+_WRITE_KEYWORDS = frozenset(
+    {
+        "create", "update", "delete", "remove", "post", "write", "send", "push",
+        "modify", "edit", "close", "merge", "publish", "commit", "open", "add",
+        "insert", "patch", "put", "submit", "deploy", "release",
+    }
+)
+
+
+def _is_write_tool(name: str, description: str) -> bool:
+    """Return True if the tool name or description suggests a write/mutate operation."""
+    text = (name + " " + description).lower().replace("_", " ").replace("-", " ")
+    return any(kw in text.split() for kw in _WRITE_KEYWORDS)
+
 
 def build_live_config(
     voice_name: str = VOICE_NAME,
@@ -141,7 +163,7 @@ def build_live_config(
     """
     prompt = system_prompt if system_prompt is not None else SYSTEM_PROMPT
     if tools:
-        prompt = prompt + _NO_PROACTIVE_TOOLS_INSTRUCTION
+        prompt = prompt + _NO_PROACTIVE_TOOLS_INSTRUCTION + _WRITE_TOOL_INSTRUCTION
     tool_list = tools
 
     return types.LiveConnectConfig(
@@ -211,6 +233,14 @@ class GeminiLiveAgent:
         # Wrapped in a list so closures can mutate it.
         _auth_notified = [False]
 
+        # Human-in-the-loop confirmation gate for write tools.
+        # When a write tool is called for the first time in a turn, _exec
+        # returns a CONFIRMATION_REQUIRED message instead of executing.
+        # Gemini then asks the user verbally; if they confirm, Gemini calls
+        # the tool again — that second call executes for real.
+        # The set holds tool names currently awaiting confirmation.
+        _awaiting_confirmation: set[str] = set()
+
         for tool in tools_result.tools:
             # If a tool filter was specified, skip tools not in the list.
             if self.mcp_tool_filter and tool.name not in self.mcp_tool_filter:
@@ -218,6 +248,7 @@ class GeminiLiveAgent:
                 continue
             raw_schema = dict(tool.inputSchema or {})
             logger.debug("MCP tool schema for %r: %s", tool.name, raw_schema)
+            is_write = _is_write_tool(tool.name, tool.description or "")
             declarations.append(
                 types.FunctionDeclaration(
                     name=tool.name,
@@ -226,8 +257,27 @@ class GeminiLiveAgent:
                 )
             )
 
-            # Capture tool.name in default arg to avoid late-binding closure issues.
-            async def _exec(args: dict, *, _name: str = tool.name) -> str:
+            # Capture loop variables in default args to avoid late-binding closure issues.
+            async def _exec(
+                args: dict,
+                *,
+                _name: str = tool.name,
+                _write: bool = is_write,
+            ) -> str:
+                if _write:
+                    if _name not in _awaiting_confirmation:
+                        # First call — gate it: ask Gemini to get verbal confirmation.
+                        _awaiting_confirmation.add(_name)
+                        logger.info("Write tool %r intercepted — requesting confirmation", _name)
+                        return (
+                            f"CONFIRMATION_REQUIRED: Before calling {_name}, tell the user "
+                            f"exactly what you are about to do and ask 'Shall I proceed?' "
+                            f"Only call {_name} again once they have clearly said yes."
+                        )
+                    # Second call — user has confirmed; execute and clear the gate.
+                    _awaiting_confirmation.discard(_name)
+                    logger.info("Write tool %r executing after confirmation", _name)
+
                 result = await mcp_session.call_tool(_name, arguments=args)
                 if result.isError:
                     # Check whether the gateway returned a need-credentials error.
@@ -266,7 +316,7 @@ class GeminiLiveAgent:
                 return "\n".join(texts) if texts else str(result.content)
 
             self.tool_map[tool.name] = traceable(name=tool.name, run_type="tool")(_exec)
-            logger.debug("MCP tool registered: %s", tool.name)
+            logger.info("MCP tool registered: %s (write=%s)", tool.name, is_write)
 
         return declarations
 

--- a/packages/voice-agent/voice_agent/agent.py
+++ b/packages/voice-agent/voice_agent/agent.py
@@ -593,7 +593,32 @@ class GeminiLiveAgent:
             fn = dispatch_map.get(name)
             if fn is not None:
                 try:
-                    result = await fn(args)
+                    task = asyncio.ensure_future(fn(args))
+                    try:
+                        result = await asyncio.wait_for(
+                            asyncio.shield(task), timeout=2.0
+                        )
+                    except asyncio.TimeoutError:
+                        logger.info(
+                            "Tool %r still running after 1s — notifying model", name
+                        )
+                        await session.send_client_content(
+                            turns=[
+                                types.Content(
+                                    role="user",
+                                    parts=[
+                                        types.Part(
+                                            text=(
+                                                f"repeat this in natural way: The tool '{name}' is still executing. "
+                                                "Briefly let the user know you're working on it."
+                                            )
+                                        )
+                                    ],
+                                )
+                            ],
+                            turn_complete=True,
+                        )
+                        result = await task
                 except Exception:
                     logger.exception("Tool %r raised an exception", name)
                     result = f"Tool error: {name} raised an exception"
@@ -601,7 +626,9 @@ class GeminiLiveAgent:
                 result = f"Unknown function: {name}"
                 logger.warning("Unknown tool called: %s", name)
 
-            is_confirmation = isinstance(result, str) and "CONFIRMATION_REQUIRED" in result
+            is_confirmation = (
+                isinstance(result, str) and "CONFIRMATION_REQUIRED" in result
+            )
             scheduling = "INTERRUPT" if is_confirmation else "WHEN_IDLE"
             logger.info("Tool %r response ready (scheduling=%s)", name, scheduling)
             try:

--- a/packages/voice-agent/voice_agent/call_bridge.py
+++ b/packages/voice-agent/voice_agent/call_bridge.py
@@ -52,6 +52,21 @@ _PENDING_CALLS: dict[str, OutboundCallRequest] = {}
 _CALL_FUTURES: dict[str, asyncio.Future] = {}
 
 
+def build_effective_prompt(base_prompt: str, context_messages: list[str]) -> str:
+    """Merge context_messages into base_prompt as system context."""
+    base_prompt += (
+        " IMPORTANT: Keep responses short and conversational."
+        " Do NOT use markdown, lists, or special characters."
+        " Ignore any phone number in the prompt, and start by introducing yourself and the meaning of your call."
+    )
+
+    if not context_messages:
+        return base_prompt
+    context_str = "\n".join(context_messages)
+    logger.info("Merged %d context messages into system prompt", len(context_messages))
+    return f"{base_prompt}\n\nContext:\n{context_str}"
+
+
 def make_outbound_call(to_number: str, public_url: str) -> str:
     """Use the Twilio Programmable Voice REST API to dial ``to_number``.
 

--- a/packages/voice-agent/voice_agent/call_bridge.py
+++ b/packages/voice-agent/voice_agent/call_bridge.py
@@ -51,6 +51,11 @@ _PENDING_CALLS: dict[str, OutboundCallRequest] = {}
 # twilio_stream's finally block in twilio_transport.py.
 _CALL_FUTURES: dict[str, asyncio.Future] = {}
 
+# Maps call_sid → asyncio.Future that resolves when the callee answers
+# (i.e. when Twilio sends the "start" Media Stream event).
+# Used to split the timeout into a ringing phase and a call-duration phase.
+_CALL_ANSWERED: dict[str, asyncio.Future] = {}
+
 
 def build_effective_prompt(base_prompt: str, context_messages: list[str]) -> str:
     """Merge context_messages into base_prompt as system context."""

--- a/packages/voice-agent/voice_agent/twilio_transport.py
+++ b/packages/voice-agent/voice_agent/twilio_transport.py
@@ -56,6 +56,7 @@ from fastapi.responses import Response
 
 from voice_agent.a2a_agent import VoiceAgent
 from voice_agent.call_bridge import (
+    _CALL_ANSWERED,
     _CALL_FUTURES,
     _PENDING_CALLS,
     build_effective_prompt
@@ -173,6 +174,11 @@ async def twilio_stream(websocket: WebSocket) -> None:
                         )
                         init_query = json.dumps({})  # Use defaults
 
+
+                    # Signal _stream_phone_call that the callee answered.
+                    answered_future = _CALL_ANSWERED.pop(state["call_sid"], None)
+                    if answered_future and not answered_future.done():
+                        answered_future.set_result(True)
 
                     # Start A2A agent streaming (non-blocking).
                     nonlocal agent_output_task

--- a/packages/voice-agent/voice_agent/twilio_transport.py
+++ b/packages/voice-agent/voice_agent/twilio_transport.py
@@ -58,6 +58,7 @@ from voice_agent.a2a_agent import VoiceAgent
 from voice_agent.call_bridge import (
     _CALL_FUTURES,
     _PENDING_CALLS,
+    build_effective_prompt
 )
 
 logger = logging.getLogger(__name__)
@@ -154,12 +155,7 @@ async def twilio_stream(websocket: WebSocket) -> None:
                             state["stream_sid"],
                             state["call_sid"],
                         )
-                        # Merge context_messages into system_prompt (not as user input, but as system instructions)
-                        system_prompt = call_config.system_prompt
-                        if call_config.context_messages:
-                            context_str = "\n".join(call_config.context_messages)
-                            system_prompt = f"{system_prompt}\n\nContext:\n{context_str}"
-                            logger.info("Merged %d context messages into system prompt", len(call_config.context_messages))
+                        system_prompt = build_effective_prompt(call_config.system_prompt, call_config.context_messages)
                         
                         init_query = json.dumps(
                             {

--- a/packages/voice-agent/voice_agent/twilio_transport.py
+++ b/packages/voice-agent/voice_agent/twilio_transport.py
@@ -154,9 +154,16 @@ async def twilio_stream(websocket: WebSocket) -> None:
                             state["stream_sid"],
                             state["call_sid"],
                         )
+                        # Merge context_messages into system_prompt (not as user input, but as system instructions)
+                        system_prompt = call_config.system_prompt
+                        if call_config.context_messages:
+                            context_str = "\n".join(call_config.context_messages)
+                            system_prompt = f"{system_prompt}\n\nContext:\n{context_str}"
+                            logger.info("Merged %d context messages into system prompt", len(call_config.context_messages))
+                        
                         init_query = json.dumps(
                             {
-                                "system_prompt": call_config.system_prompt,
+                                "system_prompt": system_prompt,
                                 "voice_name": call_config.voice_name or "Kore",
                                 "mcp_tools": call_config.mcp_tools or [],
                                 "access_token": call_config.access_token,
@@ -171,22 +178,11 @@ async def twilio_stream(websocket: WebSocket) -> None:
                         init_query = json.dumps({})  # Use defaults
 
 
-                    # Start A2A agent streaming (non-blocking)
+                    # Start A2A agent streaming (non-blocking).
                     nonlocal agent_output_task
                     agent_output_task = asyncio.create_task(
                         _agent_to_twilio(state["session_key"], init_query)
                     )
-
-                    # Inject context messages as human turns after the session starts.
-                    # These are TextParts from the scheduler payload, injected via
-                    # inject_text() → audio_in queue → session.send_client_content().
-                    # We yield control once so _start_audio_session registers the
-                    # session in _active_sessions before we try to inject.
-                    if call_config and call_config.context_messages:
-                        await asyncio.sleep(0)  # yield to let _start_audio_session register the session
-                        for cm in call_config.context_messages:
-                            await _voice_agent.inject_text(state["session_key"], cm)
-                            logger.info("Injected context message into session %s: %s", state["session_key"], cm[:80])
 
                 elif event == "media":
                     if not state["session_key"]:


### PR DESCRIPTION
Several fixes to the voice agent:
Adds risk score for the tooling and verbal confirmation to prevent unwanted actions.
Adds initial wake up text to have a faster first response from the agent.
Refactor initialization order to properly warmup the gemini instance before calling and simplify session keying.


## Checklist
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨
