### PR TITLE
fix: implement checkpoint-based attachment reconstruction

### DIFF
--- a/packages/agent-common/agent_common/agents/dynamic_agent.py
+++ b/packages/agent-common/agent_common/agents/dynamic_agent.py
@@ -29,13 +29,14 @@ from __future__ import annotations
 import logging
 import os
 from collections.abc import AsyncIterable, Callable
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
 from deepagents import CompiledSubAgent
 from deepagents.backends import StateBackend
 from deepagents.backends.composite import CompositeBackend
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessageChunk
+from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import BaseTool
 from langchain_core.utils.function_calling import convert_to_openai_tool
 from langchain_mcp_adapters.callbacks import Callbacks
@@ -70,6 +71,11 @@ from agent_common.a2a.structured_response import (
     A2A_PROTOCOL_ADDENDUM,
     StructuredResponseMixin,
     get_response_format,
+)
+from agent_common.backends.attachments_store import (
+    build_attachments_backend_from_blocks,
+    collect_attachment_blocks_from_messages,
+    set_current_attachments_backend,
 )
 from agent_common.core.graph_utils import (
     build_sub_agent_graph,
@@ -1164,6 +1170,7 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
 
         _is_hitl_resume = isinstance(input_data, LGCommand)
 
+        human_message = None
         if not _is_hitl_resume:
             # Prepare input with multi-modal support (handles content blocks)
             human_message = await self._prepare_human_message_input(input_data)
@@ -1185,11 +1192,30 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
             # Ensure tools/skills/prompt are resolved and default agent is built (lazy init)
             await self._ensure_agent()
 
-            # Build an ephemeral /attachments/ backend from this turn's message so
-            # skills/sandbox commands can access attached files on disk. Skipped on
-            # HITL resume (Command) since there is no fresh message to parse.
+            # Build the /attachments/ backend by merging the current message's blocks
+            # with any blocks found in the last 20 checkpoint messages.
+            # The current message is appended as the newest entry so its blocks win
+            # on filename collisions while still preserving files from prior turns.
+            # On HITL resume there is no fresh message — checkpoint only.
             base_backend_factory = self._cached_effective_backend_factory or StateBackend()
-            attachments_backend = None if _is_hitl_resume else self._build_attachments_backend(input_data)
+            # self._agent is None for sandbox agents (_ensure_agent skips building it;
+            # the sandbox graph is built later per-invocation).  Any compiled graph for
+            # this agent can read the thread's checkpoint, so we fall back to building
+            # a temporary non-sandbox graph solely for the aget_state call.
+            _graph_for_state = self._agent or self._build_graph(
+                self._cached_effective_backend_factory or StateBackend()
+            )
+            checkpoint_state = await _graph_for_state.aget_state(cast(RunnableConfig, config))
+            checkpoint_msgs = list(checkpoint_state.values.get("messages") or [])
+            msgs_to_scan = checkpoint_msgs if human_message is None else checkpoint_msgs + [human_message]
+            all_blocks = collect_attachment_blocks_from_messages(msgs_to_scan)
+            attachments_backend = build_attachments_backend_from_blocks(all_blocks)
+            if attachments_backend is not None:
+                logger.info(
+                    "Mounting %d attachment(s) at /attachments/ for '%s'",
+                    len(attachments_backend._attachments),
+                    self.name,
+                )
             invocation_backend_factory = self._compose_backend_with_attachments(
                 base_backend_factory, attachments_backend
             )
@@ -1198,8 +1224,6 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
             # outside the FilesystemMiddleware backend (e.g. semantic_search_file)
             # can reach the attached files. Reset in the finally block.
             if attachments_backend is not None:
-                from agent_common.backends.attachments_store import set_current_attachments_backend
-
                 _attachments_token = set_current_attachments_backend(attachments_backend)
 
             # If sandbox enabled, build a per-invocation graph with sandbox backend
@@ -1269,7 +1293,7 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                 else:
                     agent = self._agent
 
-            agent_input = input_data if _is_hitl_resume else {"messages": [human_message]}
+            agent_input = input_data if human_message is None else {"messages": [human_message]}
 
             # CRITICAL: Dynamic agent graphs are standalone, not subgraphs.
             # checkpoint_ns must be "" for standalone graphs (same pattern as GPAgentRunnable).

--- a/packages/agent-common/agent_common/backends/attachments_store.py
+++ b/packages/agent-common/agent_common/backends/attachments_store.py
@@ -353,6 +353,62 @@ def get_current_attachments_backend() -> AttachmentsStoreBackend | None:
     return _current_attachments_backend.get()
 
 
+# ---------------------------------------------------------------------------
+# Checkpoint-based attachment reconstruction
+# ---------------------------------------------------------------------------
+
+_MAX_ATTACHMENT_HISTORY_MESSAGES = 20
+
+
+def collect_attachment_blocks_from_messages(
+    messages: list,
+    max_messages: int = _MAX_ATTACHMENT_HISTORY_MESSAGES,
+) -> list[dict]:
+    """Collect file blocks from the most recent *max_messages* checkpoint messages.
+
+    Walks messages newest-first and accumulates blocks from every turn, stopping
+    after *max_messages* have been scanned.  Filenames are de-duplicated — the
+    most recent occurrence wins.
+
+    Two storage formats are handled transparently:
+
+    - ``additional_kwargs["file_blocks"]`` — orchestrator style (blocks are
+      excluded from the LLM-visible text but kept in the checkpoint).
+    - Multimodal ``content`` list — sub-agent style (blocks are passed directly
+      to the model as content blocks).
+    """
+    all_blocks: list[dict] = []
+    seen: set[str] = set()
+
+    for i, msg in enumerate(reversed(messages)):
+        if i >= max_messages:
+            break
+
+        # Orchestrator style: blocks stored outside the LLM-visible content.
+        kwargs = getattr(msg, "additional_kwargs", {}) or {}
+        prior_blocks: list[dict] | None = kwargs.get("file_blocks")
+
+        # Sub-agent style: blocks embedded in a multimodal content list.
+        if not prior_blocks:
+            content = getattr(msg, "content", None)
+            if isinstance(content, list):
+                prior_blocks = [
+                    b for b in content
+                    if isinstance(b, dict) and b.get("type") in ("image", "audio", "video", "file")
+                ] or None
+
+        if not prior_blocks:
+            continue
+
+        for block in prior_blocks:
+            key = block.get("filename") or block.get("name") or block.get("url", "")
+            if key not in seen:
+                all_blocks.append(block)
+                seen.add(key)
+
+    return all_blocks
+
+
 class ContextScopedAttachmentsBackend(BackendProtocol):
     """Stateless ``/attachments/`` backend that delegates to the current turn's backend.
 

--- a/packages/agent-common/tests/test_collect_attachment_blocks.py
+++ b/packages/agent-common/tests/test_collect_attachment_blocks.py
@@ -1,0 +1,210 @@
+"""Tests for collect_attachment_blocks_from_messages."""
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from agent_common.backends.attachments_store import collect_attachment_blocks_from_messages
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FILE_BLOCK = {"type": "file", "url": "https://s3.example/doc.txt", "mime_type": "text/plain", "filename": "doc.txt"}
+_IMAGE_BLOCK = {"type": "image", "url": "https://s3.example/photo.png", "mime_type": "image/png", "filename": "photo.png"}
+_SHEET_BLOCK = {"type": "file", "url": "https://s3.example/sheet.csv", "mime_type": "text/csv", "filename": "sheet.csv"}
+
+
+def _orc_msg(blocks: list[dict], text: str = "hi") -> HumanMessage:
+    """Orchestrator-style HumanMessage: blocks in additional_kwargs, plain text content."""
+    return HumanMessage(content=text, additional_kwargs={"file_blocks": blocks})
+
+
+def _agent_msg(blocks: list[dict], text: str = "hi") -> HumanMessage:
+    """Sub-agent-style HumanMessage: blocks embedded in a multimodal content list."""
+    content = [{"type": "text", "text": text}, *blocks]
+    return HumanMessage(content=content)
+
+
+def _text_msg(text: str = "follow-up") -> HumanMessage:
+    """Plain text message with no file blocks."""
+    return HumanMessage(content=text)
+
+
+# ---------------------------------------------------------------------------
+# Basic collection
+# ---------------------------------------------------------------------------
+
+
+def test_collects_orchestrator_style_blocks():
+    msgs = [_orc_msg([_FILE_BLOCK])]
+    assert collect_attachment_blocks_from_messages(msgs) == [_FILE_BLOCK]
+
+
+def test_collects_agent_style_blocks():
+    msgs = [_agent_msg([_IMAGE_BLOCK])]
+    result = collect_attachment_blocks_from_messages(msgs)
+    assert result == [_IMAGE_BLOCK]
+
+
+def test_returns_empty_for_no_blocks():
+    msgs = [_text_msg(), AIMessage(content="ok"), _text_msg()]
+    assert collect_attachment_blocks_from_messages(msgs) == []
+
+
+def test_returns_empty_for_empty_message_list():
+    assert collect_attachment_blocks_from_messages([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Accumulation across turns
+# ---------------------------------------------------------------------------
+
+
+def test_accumulates_blocks_across_turns():
+    """Files from multiple turns are all collected."""
+    msgs = [
+        _orc_msg([_FILE_BLOCK]),   # turn 1
+        _text_msg(),                # turn 2 — no files
+        _orc_msg([_SHEET_BLOCK]),  # turn 3
+    ]
+    result = collect_attachment_blocks_from_messages(msgs)
+    assert _FILE_BLOCK in result
+    assert _SHEET_BLOCK in result
+
+
+def test_most_recent_wins_on_filename_collision():
+    """When the same filename appears in two turns, the newer version is kept."""
+    old_block = {"type": "file", "url": "https://s3.example/v1/doc.txt", "filename": "doc.txt"}
+    new_block = {"type": "file", "url": "https://s3.example/v2/doc.txt", "filename": "doc.txt"}
+    msgs = [
+        _orc_msg([old_block]),  # turn 1
+        _orc_msg([new_block]),  # turn 2 — re-uploaded same filename
+    ]
+    result = collect_attachment_blocks_from_messages(msgs)
+    assert len(result) == 1
+    assert result[0]["url"] == "https://s3.example/v2/doc.txt"
+
+
+def test_non_file_content_blocks_ignored():
+    """Text and other non-file content blocks in a multimodal message are skipped."""
+    content = [
+        {"type": "text", "text": "here is a file"},
+        _IMAGE_BLOCK,
+    ]
+    msgs = [HumanMessage(content=content)]
+    result = collect_attachment_blocks_from_messages(msgs)
+    assert result == [_IMAGE_BLOCK]
+
+
+# ---------------------------------------------------------------------------
+# Message count limit
+# ---------------------------------------------------------------------------
+
+
+def test_respects_max_messages_limit():
+    """Stops scanning after max_messages regardless of remaining content."""
+    # 25 messages, each with a distinct file; limit=20 → only 20 newest collected
+    msgs = [_orc_msg([{"type": "file", "url": f"https://s3.example/f{i}.txt", "filename": f"f{i}.txt"}]) for i in range(25)]
+    result = collect_attachment_blocks_from_messages(msgs, max_messages=20)
+    assert len(result) == 20
+    # The 20 newest (indices 5-24) should be present; the 5 oldest (0-4) should not
+    collected_names = {b["filename"] for b in result}
+    for i in range(5, 25):
+        assert f"f{i}.txt" in collected_names
+    for i in range(5):
+        assert f"f{i}.txt" not in collected_names
+
+
+def test_default_limit_is_20():
+    msgs = [_orc_msg([{"type": "file", "url": f"https://s3.example/f{i}.txt", "filename": f"f{i}.txt"}]) for i in range(25)]
+    assert len(collect_attachment_blocks_from_messages(msgs)) == 20
+
+
+# ---------------------------------------------------------------------------
+# Mixed message types (non-HumanMessage rows don't crash)
+# ---------------------------------------------------------------------------
+
+
+def test_ignores_ai_and_tool_messages():
+    msgs = [
+        _orc_msg([_FILE_BLOCK]),
+        AIMessage(content="thinking…"),
+        ToolMessage(content="result", tool_call_id="t1"),
+        _text_msg(),
+    ]
+    result = collect_attachment_blocks_from_messages(msgs)
+    assert result == [_FILE_BLOCK]
+
+
+# ---------------------------------------------------------------------------
+# HITL / multi-turn scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_hitl_resume_finds_blocks_from_interrupted_turn():
+    """Simulates a checkpoint where the interrupted turn's message has file_blocks."""
+    msgs = [
+        _orc_msg([_FILE_BLOCK], text="please analyse this"),
+        AIMessage(content="", tool_calls=[{"name": "risky_tool", "args": {}, "id": "tc1", "type": "tool_call"}]),
+        # graph interrupted here — no further messages yet
+    ]
+    result = collect_attachment_blocks_from_messages(msgs)
+    assert result == [_FILE_BLOCK]
+
+
+def test_multi_turn_follow_up_inherits_prior_blocks():
+    """A follow-up message with no blocks still sees the prior turn's files."""
+    msgs = [
+        _orc_msg([_FILE_BLOCK], text="here is a file"),
+        AIMessage(content="Got it."),
+        _text_msg("what is on page 2?"),  # current turn — no new blocks
+    ]
+    # The current message is the last in the list; we pass all messages.
+    result = collect_attachment_blocks_from_messages(msgs)
+    assert result == [_FILE_BLOCK]
+
+
+def test_multi_turn_new_file_takes_precedence_over_old():
+    """A new file uploaded in a later turn wins over an older file with the same name."""
+    old = {"type": "file", "url": "https://s3.example/v1/report.pdf", "filename": "report.pdf"}
+    new = {"type": "file", "url": "https://s3.example/v2/report.pdf", "filename": "report.pdf"}
+    msgs = [
+        _orc_msg([old], text="old version"),
+        AIMessage(content="ok"),
+        _orc_msg([new], text="updated version"),
+        AIMessage(content="got it"),
+        _text_msg("what changed?"),
+    ]
+    result = collect_attachment_blocks_from_messages(msgs)
+    assert len(result) == 1
+    assert result[0]["url"] == "https://s3.example/v2/report.pdf"
+
+
+def test_current_message_with_new_file_merges_with_prior_files():
+    """When appended as the final message, the current turn's file joins prior files."""
+    prior_block = {"type": "file", "url": "https://s3.example/notes.txt", "filename": "notes.txt"}
+    new_block = {"type": "file", "url": "https://s3.example/sheet.csv", "filename": "sheet.csv"}
+
+    checkpoint_msgs = [
+        _orc_msg([prior_block], text="here are my notes"),
+        AIMessage(content="got it"),
+    ]
+    current_msg = _orc_msg([new_block], text="now compare with this sheet")
+
+    result = collect_attachment_blocks_from_messages(checkpoint_msgs + [current_msg])
+    filenames = {b["filename"] for b in result}
+    assert filenames == {"notes.txt", "sheet.csv"}
+
+
+def test_current_message_new_file_wins_collision_with_prior():
+    """Re-uploading the same filename: the current message's version wins."""
+    old = {"type": "file", "url": "https://s3.example/v1/doc.txt", "filename": "doc.txt"}
+    new = {"type": "file", "url": "https://s3.example/v2/doc.txt", "filename": "doc.txt"}
+
+    checkpoint_msgs = [_orc_msg([old], text="old doc")]
+    current_msg = _orc_msg([new], text="updated doc")
+
+    result = collect_attachment_blocks_from_messages(checkpoint_msgs + [current_msg])
+    assert len(result) == 1
+    assert result[0]["url"] == "https://s3.example/v2/doc.txt"

--- a/packages/orchestrator-agent/app/core/agent.py
+++ b/packages/orchestrator-agent/app/core/agent.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 from a2a.types import Part, TaskState
 from agent_common.backends.attachments_store import (
     build_attachments_backend_from_blocks,
+    collect_attachment_blocks_from_messages,
     reset_current_attachments_backend,
     set_current_attachments_backend,
 )
@@ -330,9 +331,21 @@ class OrchestratorDeepAgent:
 
         # Determine input based on whether we're resuming or starting fresh
         if resume is not None:
-            # Resume from interrupt with the provided resume value
+            # Resume from interrupt with the provided resume value.
+            # Reconstruct the attachments backend from the checkpointed HumanMessage's
+            # additional_kwargs["file_blocks"] — stored there on the first turn so
+            # this works across nodes without any separate persistence layer.
             input_data = Command(resume=resume)
             logger.info(f"Resume input data: Command(resume={resume})")
+            checkpoint_state = await graph.aget_state(config)
+            blocks = collect_attachment_blocks_from_messages(checkpoint_state.values.get("messages") or [])
+            attachments_backend = build_attachments_backend_from_blocks(blocks)
+            if attachments_backend is not None:
+                logger.info(
+                    "Restored %d attachment(s) at /attachments/ for orchestrator HITL resume",
+                    len(attachments_backend._attachments),
+                )
+                _attachments_token = set_current_attachments_backend(attachments_backend)
         else:
             # Build text content from parts
             # Files are described as references - orchestrator decides via tools whether to:
@@ -353,12 +366,35 @@ class OrchestratorDeepAgent:
             # forwarding to sub-agents (bypasses the LLM entirely)
             runtime_context.pending_file_blocks = pending_file_blocks
 
+            # Serialize file blocks into additional_kwargs so they survive in the
+            # checkpoint (stripped by the model serialization layer — LLM never sees them).
+            # NOTE: we intentionally do NOT include file content in the message text
+            # visible to the orchestrator's LLM. Sub-agents handle file analysis via
+            # the /attachments/ virtual filesystem and their own multimodal inputs.
+            serialized_blocks = [
+                b if isinstance(b, dict) else b.model_dump()
+                for b in pending_file_blocks
+            ]
+            current_msg = HumanMessage(
+                content=text_content,
+                additional_kwargs={"file_blocks": serialized_blocks} if serialized_blocks else {},
+            )
+
             # Mount the conversation's attachments at /attachments/ for THIS turn.
-            # The orchestrator graph is shared/cached per model, so the content
-            # cannot be baked into the backend — it is exposed via a context
-            # variable that the mounted ``ContextScopedAttachmentsBackend`` proxy
-            # and ``semantic_search_file`` read from. Reset in the finally block.
-            attachments_backend = build_attachments_backend_from_blocks(pending_file_blocks)
+            # The compiled graph is shared/cached per model — its CompositeBackend
+            # routes cannot be mutated per turn (unlike DynamicLocalAgentRunnable,
+            # which rebuilds its graph when attachments are present).
+            # A ContextScopedAttachmentsBackend proxy reads from the ContextVar
+            # registered here.  Reset in the finally block.
+            #
+            # Attachments are conversation-scoped: merge the current message's blocks
+            # with any blocks from the last 20 checkpoint messages.  The current
+            # message is appended as newest so its files win on filename collisions
+            # while still preserving attachments from prior turns.
+            checkpoint_state = await graph.aget_state(config)
+            checkpoint_msgs = list(checkpoint_state.values.get("messages") or [])
+            all_blocks = collect_attachment_blocks_from_messages(checkpoint_msgs + [current_msg])
+            attachments_backend = build_attachments_backend_from_blocks(all_blocks)
             if attachments_backend is not None:
                 logger.info(
                     "Mounting %d attachment(s) at /attachments/ for the orchestrator turn",
@@ -367,11 +403,7 @@ class OrchestratorDeepAgent:
                 _attachments_token = set_current_attachments_backend(attachments_backend)
                 config.setdefault("metadata", {})["has_attachments"] = True
 
-            # NOTE: we intentionally do NOT include file content in the input to the orchestrator's graph.
-            # It will be a sub-agent responsibility to read the file content if needed, using the tools available to it.
-            # This keeps the orchestrator's graph focused on orchestration and delegation.
-            # The file-analyzer sub-agent can always be used in case the sub-agent input modalities are insufficient
-            input_data = {"messages": [HumanMessage(content=text_content)]}
+            input_data = {"messages": [current_msg]}
         try:
             # Use streaming with memory for multi-turn conversation support
             chunk_count = 0


### PR DESCRIPTION
enables attachment backend reconstruction across multiple turns

closes #

## Checklist
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨
