### PR TITLE
fix: update sub-agent permissions

### DIFF
--- a/packages/agent-creator/uv.lock
+++ b/packages/agent-creator/uv.lock
@@ -2097,7 +2097,7 @@ wheels = [
 
 [[package]]
 name = "ringier-a2a-sdk"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "../ringier-a2a-sdk" }
 dependencies = [
     { name = "a2a-sdk" },

--- a/packages/agent-runner/uv.lock
+++ b/packages/agent-runner/uv.lock
@@ -2661,7 +2661,7 @@ wheels = [
 
 [[package]]
 name = "ringier-a2a-sdk"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "../ringier-a2a-sdk" }
 dependencies = [
     { name = "a2a-sdk" },

--- a/packages/console-backend/console_backend/routers/sub_agent_router.py
+++ b/packages/console-backend/console_backend/routers/sub_agent_router.py
@@ -585,11 +585,14 @@ async def revert_to_version(
     """Revert a local sub-agent to a previous configuration version.
 
     Creates a new version with the reverted configuration.
-    Only owner can revert. Only works for local sub-agents.
+    Owner, admin, or users with write access can revert. Only works for local sub-agents.
     """
     sub_agent_service = get_sub_agent_service(request)
     try:
-        sub_agent = await sub_agent_service.revert_to_version(db, sub_agent_id, version, actor=user)
+        effective_admin = is_admin_mode(request, user)
+        sub_agent = await sub_agent_service.revert_to_version(
+            db, sub_agent_id, version, actor=user, is_admin=effective_admin
+        )
         if not sub_agent:
             raise HTTPException(status_code=404, detail="Sub-agent not found")
         return sub_agent
@@ -615,13 +618,14 @@ async def submit_version_for_approval(
 ) -> SubAgent:
     """Submit a specific version for admin approval.
 
-    Only the owner can submit. Version must be in 'draft' or 'rejected' status.
+    Owner, admin, or users with write access can submit. Version must be in 'draft' or 'rejected' status.
     Requires a change_summary describing what changed in this version.
     """
     sub_agent_service = get_sub_agent_service(request)
     try:
+        effective_admin = is_admin_mode(request, user)
         sub_agent = await sub_agent_service.submit_version_for_approval(
-            db, sub_agent_id, version, data.change_summary, actor=user
+            db, sub_agent_id, version, data.change_summary, actor=user, is_admin=effective_admin
         )
         if not sub_agent:
             raise HTTPException(status_code=404, detail="Sub-agent not found")
@@ -647,13 +651,16 @@ async def delete_version(
 ) -> dict:
     """Delete a specific version (soft-delete).
 
-    Only the owner can delete versions.
+    Owner, admin, or users with write access can delete versions.
     Only draft, pending_approval, or rejected versions can be deleted.
     Approved versions cannot be deleted to preserve release history.
     """
     sub_agent_service = get_sub_agent_service(request)
     try:
-        deleted = await sub_agent_service.delete_version(db, sub_agent_id, version, actor=user)
+        effective_admin = is_admin_mode(request, user)
+        deleted = await sub_agent_service.delete_version(
+            db, sub_agent_id, version, actor=user, is_admin=effective_admin
+        )
         if not deleted:
             raise HTTPException(status_code=404, detail="Version not found")
         return {"success": True, "message": f"Version {version} deleted successfully"}
@@ -731,12 +738,15 @@ async def set_default_version(
 ) -> SubAgent:
     """Set an approved version as the default version.
 
-    Only the owner can set the default version.
+    Owner, admin, or users with write access can set the default version.
     The version must be in 'approved' status.
     """
     sub_agent_service = get_sub_agent_service(request)
     try:
-        sub_agent = await sub_agent_service.set_default_version(db, sub_agent_id, data.version, actor=user)
+        effective_admin = is_admin_mode(request, user)
+        sub_agent = await sub_agent_service.set_default_version(
+            db, sub_agent_id, data.version, actor=user, is_admin=effective_admin
+        )
         if not sub_agent:
             raise HTTPException(status_code=404, detail="Sub-agent not found")
         return sub_agent

--- a/packages/console-backend/console_backend/services/sub_agent_service.py
+++ b/packages/console-backend/console_backend/services/sub_agent_service.py
@@ -1105,6 +1105,7 @@ class SubAgentService:
         sub_agent_id: int,
         version: int,
         actor: User,
+        is_admin: bool = False,
     ) -> bool:
         """Soft-delete a specific version.
 
@@ -1121,20 +1122,20 @@ class SubAgentService:
             True if deleted, False if version not found
 
         Raises:
-            PermissionError: If user is not the owner
+            PermissionError: If user lacks write access (and is not an admin)
             ValueError: If version is approved (cannot delete approved versions)
         """
         existing = await self.get_sub_agent_by_id(db, sub_agent_id, version=version)
-        can_delete = self.check_user_permission(
-            db, sub_agent_id, actor.id, required_permission="write", sub_agent=existing
-        )
-        if not can_delete:
-            raise PermissionError("You don't have permission to delete this version")
         if not existing:
             return False
 
-        if existing.owner_user_id != actor.id:
-            raise PermissionError("Only the owner can delete versions")
+        # Owner, admin, or group members with write access can delete versions
+        if not is_admin:
+            can_delete = await self.check_user_permission(
+                db, sub_agent_id, actor.id, required_permission="write", sub_agent=existing
+            )
+            if not can_delete:
+                raise PermissionError("You don't have permission to delete this version")
 
         if not existing.config_version:
             return False
@@ -1824,6 +1825,7 @@ class SubAgentService:
         version: int,
         change_summary: str,
         actor: User,
+        is_admin: bool = False,
     ) -> SubAgent | None:
         """Submit a specific version for approval.
 
@@ -1839,10 +1841,13 @@ class SubAgentService:
         if not existing:
             return None
 
-        # Check if user has write permission (owner or group write access)
-        has_write_permission = await self.check_user_permission(db, sub_agent_id, actor.id, "write", sub_agent=existing)
-        if not has_write_permission:
-            raise PermissionError("You don't have permission to submit this sub-agent for approval")
+        # Check if user has write permission (owner, admin, or group write access)
+        if not is_admin:
+            has_write_permission = await self.check_user_permission(
+                db, sub_agent_id, actor.id, "write", sub_agent=existing
+            )
+            if not has_write_permission:
+                raise PermissionError("You don't have permission to submit this sub-agent for approval")
 
         if not existing.config_version:
             raise ValueError(f"Version {version} not found")
@@ -1900,14 +1905,20 @@ class SubAgentService:
         sub_agent_id: int,
         version: int,
         actor: User,
+        is_admin: bool = False,
     ) -> SubAgent | None:
         """Set an approved version as the default version."""
         existing = await self.get_sub_agent_by_id(db, sub_agent_id, version=version)
         if not existing:
             return None
 
-        if existing.owner_user_id != actor.id:
-            raise PermissionError("Only the owner can set the default version")
+        # Owner, admin, or group members with write access can set the default version
+        if not is_admin:
+            has_write_permission = await self.check_user_permission(
+                db, sub_agent_id, actor.id, "write", sub_agent=existing
+            )
+            if not has_write_permission:
+                raise PermissionError("You don't have permission to set the default version")
 
         if not existing.config_version:
             raise ValueError(f"Version {version} not found")
@@ -2138,14 +2149,20 @@ class SubAgentService:
         sub_agent_id: int,
         version: int,
         actor: User,
+        is_admin: bool = False,
     ) -> SubAgent | None:
         """Revert to a previous version by creating a new version with its config."""
         existing = await self.get_sub_agent_by_id(db, sub_agent_id)
         if not existing:
             return None
 
-        if existing.owner_user_id != actor.id:
-            raise PermissionError("Only the owner can revert versions")
+        # Owner, admin, or group members with write access can create a draft from a version
+        if not is_admin:
+            has_write_permission = await self.check_user_permission(
+                db, sub_agent_id, actor.id, "write", sub_agent=existing
+            )
+            if not has_write_permission:
+                raise PermissionError("You don't have permission to revert versions")
 
         # Fetch the target version
         target = await self.get_sub_agent_by_id(db, sub_agent_id, version=version)

--- a/packages/console-backend/tests/test_sub_agent_service.py
+++ b/packages/console-backend/tests/test_sub_agent_service.py
@@ -54,6 +54,45 @@ async def _create_sub_agent(
     return await subagent_service.create_sub_agent(session, data, user)
 
 
+async def _grant_group_write_access(
+    session: AsyncSession,
+    sub_agent_id: int,
+    user: User,
+    group_name: str = "Write Group",
+) -> int:
+    """Create a group, add `user` as a write member, and grant the group write access on the sub-agent."""
+    from sqlalchemy import text
+
+    group_id = (
+        await session.execute(
+            text("""
+                INSERT INTO user_groups (name, description, created_at, updated_at)
+                VALUES (:name, 'Test group', NOW(), NOW())
+                RETURNING id
+            """),
+            {"name": group_name},
+        )
+    ).scalar_one()
+
+    await session.execute(
+        text("""
+            INSERT INTO user_group_members (user_group_id, user_id, group_role, created_at)
+            VALUES (:group_id, :user_id, 'write', NOW())
+        """),
+        {"group_id": group_id, "user_id": user.id},
+    )
+
+    await session.execute(
+        text("""
+            INSERT INTO sub_agent_permissions (sub_agent_id, user_group_id, permissions, created_at)
+            VALUES (:sub_agent_id, :group_id, ARRAY['write'], NOW())
+        """),
+        {"sub_agent_id": sub_agent_id, "group_id": group_id},
+    )
+    await session.commit()
+    return group_id
+
+
 class TestSubAgentVersionCreation:
     """Test version creation and hash generation."""
 
@@ -695,6 +734,48 @@ class TestVersionSubmissionWorkflow:
             )
 
     @pytest.mark.asyncio
+    async def test_admin_can_submit_version_for_approval(
+        self, pg_session: AsyncSession, sub_agent_service: SubAgentService, test_user_db: User, test_admin_user_db: User
+    ):
+        """Test that an admin can submit a version for approval on a sub-agent they don't own."""
+        service = sub_agent_service
+        owner = test_user_db
+        admin = test_admin_user_db
+        agent = await _create_sub_agent(pg_session, owner, "Agent", sub_agent_service)
+
+        result = await service.submit_version_for_approval(
+            pg_session, agent.id, 1, "Admin submission", actor=admin, is_admin=True
+        )
+
+        assert result is not None
+        assert result.config_version is not None
+        assert result.config_version.status == SubAgentStatus.PENDING_APPROVAL
+
+    @pytest.mark.asyncio
+    async def test_group_write_user_can_submit_version_for_approval(
+        self,
+        pg_session: AsyncSession,
+        sub_agent_service: SubAgentService,
+        test_user_db: User,
+        test_approver_user_db: User,
+    ):
+        """Test that a non-owner with group write access can submit a version for approval."""
+        service = sub_agent_service
+        owner = test_user_db
+        writer = test_approver_user_db
+        agent = await _create_sub_agent(pg_session, owner, "Agent", sub_agent_service)
+
+        await _grant_group_write_access(pg_session, agent.id, writer)
+
+        result = await service.submit_version_for_approval(
+            pg_session, agent.id, 1, "Writer submission", actor=writer
+        )
+
+        assert result is not None
+        assert result.config_version is not None
+        assert result.config_version.status == SubAgentStatus.PENDING_APPROVAL
+
+    @pytest.mark.asyncio
     async def test_cannot_submit_pending_version(
         self, pg_session: AsyncSession, sub_agent_service: SubAgentService, test_user_db: User
     ):
@@ -990,8 +1071,58 @@ class TestVersionReversion:
         agent = await _create_sub_agent(pg_session, owner, "Agent", sub_agent_service)
 
         # Try to revert as non-owner
-        with pytest.raises(PermissionError, match="Only the owner can revert"):
+        with pytest.raises(PermissionError, match="don't have permission to revert"):
             await service.revert_to_version(pg_session, agent.id, 1, actor=other)
+
+    @pytest.mark.asyncio
+    async def test_admin_can_revert_version(
+        self, pg_session: AsyncSession, sub_agent_service: SubAgentService, test_user_db: User, test_admin_user_db: User
+    ):
+        """Test that an admin can revert a version on a sub-agent they don't own."""
+        service = sub_agent_service
+        owner = test_user_db
+        admin = test_admin_user_db
+        agent = await _create_sub_agent(pg_session, owner, "Agent", sub_agent_service)
+
+        # Create version 2 so there is something to revert from
+        await service.update_sub_agent(
+            pg_session, agent.id, SubAgentUpdate(system_prompt="V2 prompt" * 100), actor=owner
+        )
+
+        # Admin reverts to version 1
+        result = await service.revert_to_version(pg_session, agent.id, 1, actor=admin, is_admin=True)
+
+        assert result is not None
+        assert result.config_version is not None
+        assert result.config_version.status == SubAgentStatus.DRAFT
+
+    @pytest.mark.asyncio
+    async def test_group_write_user_can_revert_version(
+        self,
+        pg_session: AsyncSession,
+        sub_agent_service: SubAgentService,
+        test_user_db: User,
+        test_approver_user_db: User,
+    ):
+        """Test that a non-owner with group write access can revert a version."""
+        service = sub_agent_service
+        owner = test_user_db
+        writer = test_approver_user_db
+        agent = await _create_sub_agent(pg_session, owner, "Agent", sub_agent_service)
+
+        # Create version 2 so there is something to revert from
+        await service.update_sub_agent(
+            pg_session, agent.id, SubAgentUpdate(system_prompt="V2 prompt" * 100), actor=owner
+        )
+
+        await _grant_group_write_access(pg_session, agent.id, writer)
+
+        # Group-write user reverts to version 1
+        result = await service.revert_to_version(pg_session, agent.id, 1, actor=writer)
+
+        assert result is not None
+        assert result.config_version is not None
+        assert result.config_version.status == SubAgentStatus.DRAFT
 
     @pytest.mark.asyncio
     async def test_cannot_revert_to_nonexistent_version(
@@ -1111,8 +1242,70 @@ class TestDefaultVersionManagement:
         await service.approve_version(pg_session, agent.id, 1, True, actor=admin)
 
         # Try to set default as non-owner
-        with pytest.raises(PermissionError, match="Only the owner can set the default version"):
+        with pytest.raises(PermissionError, match="don't have permission to set the default version"):
             await service.set_default_version(pg_session, agent.id, 1, actor=other)
+
+    @pytest.mark.asyncio
+    async def test_admin_can_set_default_version(
+        self, pg_session: AsyncSession, sub_agent_service: SubAgentService, test_user_db: User, test_admin_user_db: User
+    ):
+        """Test that an admin can set the default version on a sub-agent they don't own."""
+        service = sub_agent_service
+        owner = test_user_db
+        admin = test_admin_user_db
+        agent = await _create_sub_agent(pg_session, owner, "Agent", sub_agent_service)
+
+        # Approve version 1
+        await service.submit_for_approval(pg_session, agent.id, "V1", actor=owner)
+        await service.approve_version(pg_session, agent.id, 1, True, actor=admin)
+
+        # Create and approve version 2 (so v1 is not already the only/default option)
+        await service.update_sub_agent(
+            pg_session, agent.id, SubAgentUpdate(system_prompt="V2 prompt" * 100, description="Version 2"), actor=owner
+        )
+        await service.submit_for_approval(pg_session, agent.id, "V2", actor=owner)
+        await service.approve_version(pg_session, agent.id, 2, True, actor=admin)
+
+        # Admin sets version 1 as default
+        result = await service.set_default_version(pg_session, agent.id, 1, actor=admin, is_admin=True)
+
+        assert result is not None
+        assert result.default_version == 1
+
+    @pytest.mark.asyncio
+    async def test_group_write_user_can_set_default_version(
+        self,
+        pg_session: AsyncSession,
+        sub_agent_service: SubAgentService,
+        test_user_db: User,
+        test_admin_user_db: User,
+        test_approver_user_db: User,
+    ):
+        """Test that a non-owner with group write access can set the default version."""
+        service = sub_agent_service
+        owner = test_user_db
+        admin = test_admin_user_db
+        writer = test_approver_user_db
+        agent = await _create_sub_agent(pg_session, owner, "Agent", sub_agent_service)
+
+        # Approve version 1
+        await service.submit_for_approval(pg_session, agent.id, "V1", actor=owner)
+        await service.approve_version(pg_session, agent.id, 1, True, actor=admin)
+
+        # Create and approve version 2
+        await service.update_sub_agent(
+            pg_session, agent.id, SubAgentUpdate(system_prompt="V2 prompt" * 100, description="Version 2"), actor=owner
+        )
+        await service.submit_for_approval(pg_session, agent.id, "V2", actor=owner)
+        await service.approve_version(pg_session, agent.id, 2, True, actor=admin)
+
+        await _grant_group_write_access(pg_session, agent.id, writer)
+
+        # Group-write user sets version 1 as default
+        result = await service.set_default_version(pg_session, agent.id, 1, actor=writer)
+
+        assert result is not None
+        assert result.default_version == 1
 
 
 class TestVersionDeletion:
@@ -1240,8 +1433,54 @@ class TestVersionDeletion:
         )
 
         # Try to delete as non-owner
-        with pytest.raises(PermissionError, match="Only the owner can delete versions"):
+        with pytest.raises(PermissionError, match="don't have permission to delete this version"):
             await service.delete_version(pg_session, agent.id, 2, actor=other)
+
+    @pytest.mark.asyncio
+    async def test_admin_can_delete_version(
+        self, pg_session: AsyncSession, sub_agent_service: SubAgentService, test_user_db: User, test_admin_user_db: User
+    ):
+        """Test that an admin can delete a version on a sub-agent they don't own."""
+        service = sub_agent_service
+        owner = test_user_db
+        admin = test_admin_user_db
+        agent = await _create_sub_agent(pg_session, owner, "Agent", sub_agent_service)
+
+        # Create version 2 (draft)
+        await service.update_sub_agent(
+            pg_session, agent.id, SubAgentUpdate(system_prompt="V2 prompt" * 100, description="Version 2"), actor=owner
+        )
+
+        # Admin deletes version 2
+        result = await service.delete_version(pg_session, agent.id, 2, actor=admin, is_admin=True)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_group_write_user_can_delete_version(
+        self,
+        pg_session: AsyncSession,
+        sub_agent_service: SubAgentService,
+        test_user_db: User,
+        test_approver_user_db: User,
+    ):
+        """Test that a non-owner with group write access can delete a version."""
+        service = sub_agent_service
+        owner = test_user_db
+        writer = test_approver_user_db
+        agent = await _create_sub_agent(pg_session, owner, "Agent", sub_agent_service)
+
+        # Create version 2 (draft)
+        await service.update_sub_agent(
+            pg_session, agent.id, SubAgentUpdate(system_prompt="V2 prompt" * 100, description="Version 2"), actor=owner
+        )
+
+        await _grant_group_write_access(pg_session, agent.id, writer)
+
+        # Group-write user deletes version 2
+        result = await service.delete_version(pg_session, agent.id, 2, actor=writer)
+
+        assert result is True
 
     @pytest.mark.asyncio
     async def test_delete_rejected_version(

--- a/packages/console-backend/uv.lock
+++ b/packages/console-backend/uv.lock
@@ -3162,7 +3162,7 @@ wheels = [
 
 [[package]]
 name = "ringier-a2a-sdk"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "../ringier-a2a-sdk" }
 dependencies = [
     { name = "a2a-sdk" },

--- a/packages/console-frontend/src/components/subagents/VersionSidebar.tsx
+++ b/packages/console-frontend/src/components/subagents/VersionSidebar.tsx
@@ -58,6 +58,7 @@ interface VersionSidebarProps {
   versions: SubAgentConfigVersion[];
   isOwner: boolean;
   isAdmin: boolean;
+  hasWriteAccess?: boolean;
   isCollapsed?: boolean;
   onCollapsedChange?: (collapsed: boolean) => void;
   onRefresh?: () => void;
@@ -69,7 +70,8 @@ export function VersionSidebar({
   subAgent,
   versions,
   isOwner,
-  isAdmin: _isAdmin,
+  isAdmin,
+  hasWriteAccess = false,
   isCollapsed = false,
   onCollapsedChange,
   onRefresh,
@@ -268,16 +270,20 @@ export function VersionSidebar({
                 const isApproved = status === 'approved';
                 const isDraft = status === 'draft';
                 const isRejected = status === 'rejected';
-                const canSetDefault = isOwner && isApproved && !isDefault;
-                const canSubmit = isOwner && (isDraft || isRejected);
-                const canRevert = isOwner && !isCurrent;
+                // Owners and admins (in admin mode) can manage versions.
+                // Group members with write access can also create/submit drafts.
+                const canManage = isOwner || isAdmin;
+                const canWrite = canManage || hasWriteAccess;
+                const canSetDefault = canWrite && isApproved && !isDefault;
+                const canSubmit = canWrite && (isDraft || isRejected);
+                const canRevert = canWrite && !isCurrent;
                 const canCompare = version.version > 1 || (defaultVersion !== undefined && defaultVersion !== version.version);
                 // Check if there's actually a previous version available in the list
                 const sortedVersions = [...allVersions].sort((a, b) => a.version - b.version);
                 const currentVersionIndex = sortedVersions.findIndex((v) => v.version === version.version);
                 const hasPreviousVersion = currentVersionIndex > 0;
                 // Can delete non-approved versions (except if it's the only version)
-                const canDelete = isOwner && !isApproved && versions.length > 1;
+                const canDelete = canManage && !isApproved && versions.length > 1;
 
                 return (
                   <div

--- a/packages/console-frontend/src/pages/SubAgentDetailPage.tsx
+++ b/packages/console-frontend/src/pages/SubAgentDetailPage.tsx
@@ -2481,6 +2481,7 @@ export function SubAgentDetailPage() {
             versions={versionHistory}
             isOwner={isOwner}
             isAdmin={adminMode}
+            hasWriteAccess={hasGroupWriteAccess}
             isCollapsed={versionSidebarCollapsed}
             onCollapsedChange={(collapsed) => {
               setVersionSidebarCollapsed(collapsed);

--- a/packages/voice-agent/uv.lock
+++ b/packages/voice-agent/uv.lock
@@ -1765,7 +1765,7 @@ wheels = [
 
 [[package]]
 name = "ringier-a2a-sdk"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "../ringier-a2a-sdk" }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
update sub-agent permissions to allow admins and users with write access to manage versions


## Checklist
- [x] I have performed a self-review of my code
- [ ] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨
