### PR TITLE
feat(ptc): runtime tool discovery + stable prompt for the GP agent

### DIFF
--- a/packages/agent-common/AGENTS.md
+++ b/packages/agent-common/AGENTS.md
@@ -158,6 +158,18 @@ The `/skills/` virtual filesystem is **read-only** for agents. All mutations go 
 
 **CRITICAL**: `checkpoint_ns` must be `""` for standalone graphs (DynamicLocalAgentRunnable graphs are standalone, not subgraphs). Thread isolation is provided by unique `thread_id` patterns like `"{context_id}::dynamic-{name}"`.
 
+### PTC Tool Exposure (core/graph_utils.py, ptc_signatures.py, ptc_discovery.py)
+
+When `CODE_INTERPRETER_PTC` is enabled, the model calls tools by writing JavaScript in the sandboxed `eval` REPL (`tools.<name>({...})`) instead of one native tool call per step. `_PTCToleranceCodeInterpreterMiddleware` subclasses `langchain_quickjs`'s `CodeInterpreterMiddleware`. Non-obvious decisions:
+
+1. **Expose ≠ render.** *Exposing* a tool (installing its callable `globalThis.tools` bridge) is separate from *rendering* its signature into the system prompt. When the exposed MCP catalog exceeds `PTC_INLINE_RENDER_THRESHOLD` (default 40 — the large-catalog GP agent), `_prepare_for_call` installs the **full** catalog as bridges but renders only the **stable core**: base tools (no `server_name` metadata: filesystem + orchestrator static tools) plus the `search`/`describe` helpers. The volatile MCP catalog stays callable-but-unrendered. This keeps the rendered block invariant across turns, restoring prompt caching. Small, fixed sub-agent toolsets (under threshold) render every exposed tool inline.
+
+2. **Runtime discovery (ptc_discovery.py).** In core-only mode the model finds tools via two read-only, **unguarded** `StructuredTool`s pinned into the namespace: `tools.search({query})` (keyword/token ranking over name+description) and `tools.describe({name})` (full typed signature). They close over the per-turn exposed catalog and never execute a side-effecting tool, so they must never trip the HITL guard.
+
+3. **Own signature renderer (ptc_signatures.py).** The upstream `render_ptc_prompt` is no longer used. Our renderer resolves `$ref`/`$defs` (upstream degrades nested args to `unknown`), handles **dict `args_schema`** (MCP tools carry a raw JSON-schema dict, not a Pydantic model), and renders **no-param tools** as `()` rather than a misleading `input: Record<string, unknown>` (reserved strictly for the schema-truly-unavailable case). Used by both `describe` and the inline render path, so the type-hint fix applies everywhere a signature is shown.
+
+4. **`wrap_tool_for_ptc` preserves `.metadata`** (notably `server_name`) so the base-vs-MCP split in (1) works on the *wrapped* instances exposed inside `eval`.
+
 ## Critical Design Decisions
 
 ### Console Self-Improvement Tools Are Independent of MCP Whitelist

--- a/packages/agent-common/agent_common/core/graph_utils.py
+++ b/packages/agent-common/agent_common/core/graph_utils.py
@@ -57,7 +57,7 @@ from langchain_aws.middleware.prompt_caching import BedrockPromptCachingMiddlewa
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import ToolMessage
 from langchain_quickjs import CodeInterpreterMiddleware
-from langchain_quickjs.middleware import REPLState
+from langchain_quickjs.middleware import REPLState, _resolve_thread_id
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.config import get_config
 from langgraph.graph.state import CompiledStateGraph
@@ -75,6 +75,12 @@ from agent_common.middleware.conversation_context_tools_middleware import (
     ConversationContextToolsMiddleware,
 )
 from agent_common.middleware.loop_detection_middleware import RepeatedToolCallMiddleware
+from agent_common.core.ptc_discovery import (
+    PTC_DESCRIBE_TOOL_NAME,
+    PTC_SEARCH_TOOL_NAME,
+    build_discovery_tools,
+)
+from agent_common.core.ptc_signatures import render_tools_namespace
 from agent_common.middleware.ptc_guard import (
     PTC_CODE_INTERPRETER_TOOL_NAME,
     begin_ptc_turn,
@@ -307,6 +313,30 @@ _PTC_EXCLUDED_TOOL_NAMES: frozenset[str] = frozenset(
 # Must equal the field name on ``_PTCExposureState``.
 PTC_EXPOSED_TOOL_NAMES_STATE_KEY = "ptc_exposed_tool_names"
 
+# When the number of MCP catalog tools (those carrying ``server_name`` metadata)
+# exposed via PTC exceeds this threshold, the middleware switches to *core-only*
+# rendering: it still exposes (installs bridges for) every tool, but renders only the
+# stable, user-invariant core into the system prompt (filesystem/base tools plus the
+# ``search``/``describe`` discovery tools) and instructs the model to find the rest at
+# runtime. This keeps the prompt invariant across turns (restoring prompt caching) for
+# the large-catalog GP agent, while small, fixed sub-agent toolsets stay fully rendered
+# inline. Override via env for tuning.
+PTC_INLINE_RENDER_THRESHOLD = int(os.getenv("PTC_INLINE_RENDER_THRESHOLD", "40"))
+
+# Appended to the PTC prompt in core-only mode. Tells the model that only the core
+# tools above are listed and the rest must be discovered at runtime via the pinned
+# ``search`` / ``describe`` helpers (which are themselves rendered above).
+_PTC_DISCOVERY_INSTRUCTION = (
+    "Only the core tools above are listed. Many more tools are available but NOT listed "
+    "here (to keep this prompt stable). Discover them at runtime:\n"
+    f"- `await tools.{PTC_SEARCH_TOOL_NAME}({{ query: '...' }})` — find tools by intent; "
+    "returns `{ name, description }` matches.\n"
+    f"- `await tools.{PTC_DESCRIBE_TOOL_NAME}({{ name: '...' }})` — get the exact "
+    "signature for a tool before calling it.\n"
+    f"Always `{PTC_SEARCH_TOOL_NAME}`/`{PTC_DESCRIBE_TOOL_NAME}` a tool you don't see "
+    "above before calling it — calling an unknown `tools.<name>` throws."
+)
+
 # Max characters of a tool result kept inline before the code-interpreter
 # middleware evicts it to a file. Override via env for tuning. Default: 20k chars.
 PTC_MAX_RESULT_CHARS = int(os.getenv("PTC_MAX_RESULT_CHARS", "20000"))
@@ -348,6 +378,16 @@ def _code_interpreter_ptc_enabled() -> bool:
         "off",
         "",
     }
+
+
+def code_interpreter_ptc_enabled() -> bool:
+    """Public wrapper around :func:`_code_interpreter_ptc_enabled`.
+
+    Used by callers outside this module (e.g. the orchestrator's GP wiring) to decide
+    PTC-conditional behaviour such as gating ``ToolsetSelectorMiddleware`` off when PTC
+    runtime tool discovery (``tools.search``/``tools.describe``) supersedes it.
+    """
+    return _code_interpreter_ptc_enabled()
 
 
 class _PTCToleranceCodeInterpreterMiddleware(CodeInterpreterMiddleware):
@@ -553,7 +593,42 @@ class _PTCToleranceCodeInterpreterMiddleware(CodeInterpreterMiddleware):
                     continue
                 _consider(tool)
 
+        # Large catalog (the GP agent): the prompt renders only the stable core, so
+        # pin the read-only ``search``/``describe`` discovery tools into the exposed
+        # set (callable + rendered) so the model can find the unrendered catalog at
+        # runtime. They close over the catalog collected above. Small, fixed sub-agent
+        # toolsets stay fully rendered inline and need no discovery helpers.
+        if self._is_core_only(collected):
+            collected.extend(build_discovery_tools(collected))
+
         return collected
+
+    @staticmethod
+    def _mcp_tool_count(tools: list[BaseTool]) -> int:
+        """Count exposed tools carrying ``server_name`` metadata (MCP catalog tools)."""
+        return sum(1 for t in tools if isinstance(t, BaseTool) and (t.metadata or {}).get("server_name"))
+
+    def _is_core_only(self, tools: list[BaseTool]) -> bool:
+        """Whether to render only the stable core (vs. every exposed tool) this turn.
+
+        Triggered when the exposed MCP catalog exceeds
+        ``PTC_INLINE_RENDER_THRESHOLD`` — i.e. the large-catalog GP agent. Sub-agents
+        and the orchestrator (small / no MCP catalog) render every exposed tool inline.
+        """
+        return self._mcp_tool_count(tools) > PTC_INLINE_RENDER_THRESHOLD
+
+    def _render_partition(self, exposed: list[BaseTool]) -> tuple[list[BaseTool], str]:
+        """Split the exposed set into (tools_to_render, discovery_note).
+
+        In core-only mode render only the stable, user-invariant core — base tools
+        (no ``server_name``: filesystem + orchestrator static tools) plus the pinned
+        ``search``/``describe`` helpers — and append the discovery instruction. The
+        MCP catalog stays exposed-but-unrendered. Otherwise render everything.
+        """
+        if self._is_core_only(exposed):
+            render_set = [t for t in exposed if not (getattr(t, "metadata", None) or {}).get("server_name")]
+            return render_set, _PTC_DISCOVERY_INSTRUCTION
+        return list(exposed), ""
 
     @staticmethod
     def _checkpointed_exposure(request: Any) -> set[str] | None:
@@ -569,6 +644,34 @@ class _PTCToleranceCodeInterpreterMiddleware(CodeInterpreterMiddleware):
         if not names:
             return None
         return set(names)
+
+    def _prepare_for_call(self, request: Any) -> str:
+        """Install the full exposed set as bridges, but render only the core.
+
+        Overrides the upstream ``_prepare_for_call`` (which renders *every* exposed
+        tool) to decouple **exposing** a tool (installing its callable
+        ``globalThis.tools`` bridge) from **rendering** its signature into the prompt.
+        Every tool in ``self._ptc`` (set by ``_ptc_prompt_and_hidden`` to this turn's
+        exposed set) is installed so it is callable; only ``_render_partition``'s core
+        subset is written into the prompt, with ``$ref``-resolved signatures via our
+        own renderer (also fixing nested-arg type hints on the sub-agent inline path).
+        """
+        if self._ptc is None:
+            return self._base_system_prompt
+        exposed = [t for t in self._ptc if isinstance(t, BaseTool) and t.name != self._tool_name]
+        thread_id = _resolve_thread_id(self._fallback_thread_id)
+        repl = self._registry.get(thread_id)
+        repl.install_tools(exposed)
+        self._ptc_tools_by_thread[thread_id] = tuple(exposed)
+        render_set, discovery_note = self._render_partition(exposed)
+        # Cache the rendered body by the set of *rendered* names (+ a discovery marker).
+        # In core-only mode this set is user-invariant and stable across turns, so the
+        # returned block is identical turn-to-turn — restoring prompt caching.
+        cache_key = frozenset(t.name for t in render_set) | ({"__discovery__"} if discovery_note else frozenset())
+        if self._ptc_prompt_cache is None or self._ptc_prompt_cache[0] != cache_key:
+            body = render_tools_namespace(render_set, tool_name=self._tool_name, discovery_note=discovery_note)
+            self._ptc_prompt_cache = (cache_key, body)
+        return self._base_system_prompt + self._ptc_prompt_cache[1]
 
     def _ptc_prompt_and_hidden(self, request: Any) -> tuple[str, set[str]]:
         """Build the PTC prompt and the set of tool names exposed this turn.

--- a/packages/agent-common/agent_common/core/ptc_discovery.py
+++ b/packages/agent-common/agent_common/core/ptc_discovery.py
@@ -1,0 +1,161 @@
+"""Runtime tool-discovery tools for the PTC ``eval`` namespace.
+
+When the GP agent carries a large MCP catalog, listing every tool's signature in the
+system prompt is what broke prompt caching (the rendered block varied per turn). The
+redesign keeps every tool *callable* (its ``globalThis.tools`` bridge is installed) but
+renders only a stable core into the prompt. The volatile catalog is found at runtime via
+two read-only helpers pinned into the namespace:
+
+* ``tools.search({query})`` — keyword/token ranking over tool name + description,
+  returning ``{name, description}`` for the best matches (``name`` is the camelCase
+  identifier the model calls as ``tools.<name>``);
+* ``tools.describe({name})`` — the full ``$ref``-resolved TypeScript signature for one
+  tool.
+
+Both are plain ``StructuredTool``s (NOT risk-guarded via ``wrap_tool_for_ptc``): they
+only read metadata and never execute a side-effecting tool, so they must never trip the
+HITL approval flow. They close over the per-turn exposed catalog.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Annotated, Any
+
+from langchain_core.tools import BaseTool, StructuredTool
+from langchain_quickjs._prompt import is_valid_js_identifier, to_camel_case
+from pydantic import BaseModel, Field
+
+from agent_common.core.ptc_signatures import render_signature_block
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+# Names of the discovery tools as exposed in the ``tools`` namespace.
+PTC_SEARCH_TOOL_NAME = "search"
+PTC_DESCRIBE_TOOL_NAME = "describe"
+
+_DISCOVERY_TOOL_NAMES = frozenset({PTC_SEARCH_TOOL_NAME, PTC_DESCRIBE_TOOL_NAME})
+
+# How many matches ``search`` returns by default.
+_DEFAULT_TOP_K = 10
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+class _SearchArgs(BaseModel):
+    query: Annotated[str, Field(description="Natural-language intent, e.g. 'list commits in a repo'.")]
+
+
+class _DescribeArgs(BaseModel):
+    name: Annotated[str, Field(description="The tool name as called in `tools.<name>` (camelCase).")]
+
+
+def _tokenize(text: str) -> list[str]:
+    return _TOKEN_RE.findall(text.lower())
+
+
+def _first_line(description: str | None) -> str:
+    if not description:
+        return ""
+    stripped = description.strip()
+    return stripped.splitlines()[0] if stripped else ""
+
+
+def _build_entries(catalog: Sequence[BaseTool]) -> list[dict[str, Any]]:
+    """Precompute searchable entries from the exposed catalog.
+
+    Skips the discovery tools themselves and any tool whose camelCase name is not a
+    valid JS identifier (it could not be called as ``tools.<name>`` anyway).
+    """
+    entries: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for tool in catalog:
+        if tool.name in _DISCOVERY_TOOL_NAMES or tool.name in seen:
+            continue
+        camel = to_camel_case(tool.name)
+        if not is_valid_js_identifier(camel):
+            continue
+        seen.add(tool.name)
+        desc = _first_line(tool.description)
+        entries.append(
+            {
+                "camel": camel,
+                "name": tool.name,
+                "desc": desc,
+                "name_haystack": f"{camel} {tool.name}".lower(),
+                "haystack": f"{camel} {tool.name} {desc}".lower(),
+                "tool": tool,
+            }
+        )
+    return entries
+
+
+def _score(entry: dict[str, Any], tokens: list[str]) -> int:
+    """Token-overlap score: name/identifier hits weigh more than description hits."""
+    score = 0
+    for tok in tokens:
+        if tok in entry["name_haystack"]:
+            score += 2
+        elif tok in entry["haystack"]:
+            score += 1
+    return score
+
+
+def build_discovery_tools(
+    catalog: Sequence[BaseTool],
+    *,
+    top_k: int = _DEFAULT_TOP_K,
+) -> list[BaseTool]:
+    """Build the ``search`` and ``describe`` tools bound to ``catalog``.
+
+    Returned tools are plain (unguarded) ``StructuredTool``s suitable for the PTC
+    exposed set. They are read-only and introspect ``catalog`` only.
+    """
+    entries = _build_entries(catalog)
+    by_camel = {e["camel"]: e for e in entries}
+    by_name = {e["name"]: e for e in entries}
+
+    async def _search(query: str) -> list[dict[str, str]]:
+        tokens = _tokenize(query)
+        if not tokens:
+            return []
+        scored = [(e, _score(e, tokens)) for e in entries]
+        hits = sorted(
+            (pair for pair in scored if pair[1] > 0),
+            key=lambda pair: pair[1],
+            reverse=True,
+        )[:top_k]
+        return [{"name": e["camel"], "description": e["desc"]} for e, _ in hits]
+
+    async def _describe(name: str) -> str:
+        entry = by_camel.get(name) or by_name.get(name) or by_camel.get(to_camel_case(name))
+        if entry is None:
+            return (
+                f"No tool named '{name}'. Use tools.search({{ query: '...' }}) "
+                "to find the right tool name first."
+            )
+        return render_signature_block(entry["tool"])
+
+    search_tool = StructuredTool.from_function(
+        coroutine=_search,
+        name=PTC_SEARCH_TOOL_NAME,
+        description=(
+            "Find agent tools by intent. Returns up to "
+            f"{top_k} matches as {{ name, description }} ranked by relevance; `name` is "
+            "the identifier to call as `tools.<name>(...)`. Use this to discover tools "
+            "that are not listed in this prompt, then `describe` the one you want."
+        ),
+        args_schema=_SearchArgs,
+    )
+    describe_tool = StructuredTool.from_function(
+        coroutine=_describe,
+        name=PTC_DESCRIBE_TOOL_NAME,
+        description=(
+            "Return the full TypeScript signature (argument shape, with nested object "
+            "types resolved) for one tool by name. Call this before invoking any tool "
+            "that is not already listed in this prompt, so you pass the correct arguments."
+        ),
+        args_schema=_DescribeArgs,
+    )
+    return [search_tool, describe_tool]

--- a/packages/agent-common/agent_common/core/ptc_signatures.py
+++ b/packages/agent-common/agent_common/core/ptc_signatures.py
@@ -1,0 +1,229 @@
+"""TypeScript-signature rendering for PTC tools, with ``$ref``/``$defs`` resolution.
+
+``langchain_quickjs._prompt`` renders tool signatures but its ``_json_schema_to_ts``
+is *shallow*: nested Pydantic models / ``TypedDict``s appear in the JSON Schema as
+``$ref`` into ``$defs`` and degrade to ``unknown`` / ``Record<string, unknown>``. That
+is why complex tools (e.g. GitHub) are called with the wrong argument shape.
+
+This module reimplements the renderer with ``$ref`` resolution (recursion-guarded) so
+nested object args render as real TypeScript types. It is the single renderer used by
+both ``tools.describe`` (GP discovery path) and the sub-agent inline rendering path —
+so the type-hint fix applies wherever PTC signatures are shown.
+
+The surrounding ``tools`` namespace preamble mirrors the upstream prompt so the model's
+usage guidance (Promise.all, pipelining, single-program batching) is preserved.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from langchain_quickjs._prompt import to_camel_case
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from langchain_core.tools import BaseTool
+
+# Guard against pathological/recursive ``$ref`` chains. A self-referential model
+# (e.g. a tree node) would otherwise expand forever; past this depth we emit the
+# referenced type name instead of expanding it further.
+_MAX_REF_DEPTH = 6
+
+
+def _resolve_ref(prop: dict[str, Any], defs: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
+    """Resolve a ``{"$ref": "#/$defs/Name"}`` node against ``defs``.
+
+    Returns ``(resolved_schema, ref_name)``. When the ref cannot be resolved the
+    original node is returned with ``ref_name=None`` so the caller falls back to
+    ``unknown``.
+    """
+    ref = prop.get("$ref")
+    if not isinstance(ref, str):
+        return prop, None
+    # Refs are of the form "#/$defs/Name" or "#/definitions/Name".
+    name = ref.rsplit("/", 1)[-1]
+    target = defs.get(name)
+    if isinstance(target, dict):
+        return target, name
+    return prop, None
+
+
+def json_schema_to_ts(
+    prop: dict[str, Any],
+    defs: dict[str, Any],
+    *,
+    _depth: int = 0,
+    _seen: frozenset[str] = frozenset(),
+) -> str:
+    """JSON-Schema → TS type, resolving ``$ref`` against ``defs``.
+
+    Handles ``$ref`` (recursion-guarded), ``enum``, ``anyOf``/``oneOf``, arrays,
+    nested objects, and the scalar types. Unknown shapes fall back to ``unknown``.
+    """
+    if not isinstance(prop, dict):
+        return "unknown"
+
+    if "$ref" in prop:
+        resolved, name = _resolve_ref(prop, defs)
+        if name is None:
+            return "unknown"
+        if name in _seen or _depth >= _MAX_REF_DEPTH:
+            # Cycle or too deep — emit the type name rather than expand further.
+            return name
+        return json_schema_to_ts(resolved, defs, _depth=_depth + 1, _seen=_seen | {name})
+
+    if "enum" in prop:
+        return " | ".join(json.dumps(v) for v in prop["enum"])
+
+    for union_key in ("anyOf", "oneOf"):
+        if union_key in prop:
+            parts = [
+                json_schema_to_ts(part, defs, _depth=_depth, _seen=_seen) for part in prop[union_key]
+            ]
+            # Dedup while preserving order (e.g. ``string | null``).
+            return " | ".join(dict.fromkeys(parts)) or "unknown"
+
+    t = prop.get("type")
+    if t == "string":
+        return "string"
+    if t in {"integer", "number"}:
+        return "number"
+    if t == "boolean":
+        return "boolean"
+    if t == "null":
+        return "null"
+    if t == "array":
+        items = prop.get("items")
+        inner = json_schema_to_ts(items, defs, _depth=_depth, _seen=_seen) if isinstance(items, dict) else "unknown"
+        return f"{inner}[]"
+    if t == "object" or "properties" in prop:
+        sub_props = prop.get("properties")
+        if isinstance(sub_props, dict) and sub_props:
+            required = set(prop.get("required", []))
+            fields = [
+                f"{k}{'' if k in required else '?'}: {json_schema_to_ts(v, defs, _depth=_depth, _seen=_seen)}"
+                for k, v in sub_props.items()
+            ]
+            return "{ " + "; ".join(fields) + " }"
+        return "Record<string, unknown>"
+    return "unknown"
+
+
+def _safe_json_schema(tool: BaseTool) -> dict[str, Any] | None:
+    """Return the tool's argument JSON Schema, or ``None`` if unavailable.
+
+    Handles both shapes a ``BaseTool`` may carry on ``args_schema``:
+
+    * a **Pydantic model** (native tools) — call ``model_json_schema()``;
+    * a **raw JSON-schema dict** (MCP tools, via langchain-mcp-adapters) — use it
+      directly. The upstream renderer only handled the model case, so MCP tools
+      (e.g. GitHub) degraded to ``Record<string, unknown>``.
+
+    ``BaseTool.get_input_schema()`` is intentionally NOT used as a fallback: when
+    ``args_schema`` is a dict it returns a generic wrapper schema (an ``anyOf`` of
+    string / object / ``ToolCall``), not the tool's real arguments.
+    """
+    try:
+        schema = tool.args_schema
+        if schema is None:
+            return None
+        # MCP-style tools: ``args_schema`` is already the JSON schema.
+        if isinstance(schema, dict):
+            return schema
+        # Native tools: ``args_schema`` is a Pydantic model class/instance.
+        model_json_schema = getattr(schema, "model_json_schema", None)
+        if callable(model_json_schema):
+            return model_json_schema()
+    except Exception:  # noqa: BLE001 — prompt rendering is best-effort
+        return None
+    return None
+
+
+def render_signature(camel_name: str, schema: dict[str, Any] | None) -> str:
+    """Render one ``async function`` signature with ``$ref``-resolved arg types.
+
+    Three shapes:
+    - **no schema available** (``None``) → ``input: Record<string, unknown>`` (we
+      genuinely don't know the arguments);
+    - **schema present, no parameters** (empty/absent ``properties``) → ``()`` — the
+      tool takes no arguments (e.g. ``githubGetMe``). The PTC bridge coerces a
+      zero-arg call to ``{}``, so ``await tools.foo()`` is valid;
+    - **schema with parameters** → a typed object argument.
+    """
+    return_clause = "Promise<unknown>"
+    if schema is None:
+        return f"async function {camel_name}(input: Record<string, unknown>): {return_clause}"
+    props = schema.get("properties") if isinstance(schema, dict) else None
+    no_arg_signature = f"async function {camel_name}(): {return_clause}"
+    if not isinstance(props, dict) or not props:
+        return no_arg_signature
+    defs: dict[str, Any] = {}
+    for defs_key in ("$defs", "definitions"):
+        if isinstance(schema.get(defs_key), dict):
+            defs = {**defs, **schema[defs_key]}
+    required = set(schema.get("required", []))
+    fields = []
+    for key, prop in props.items():
+        optional = "" if key in required else "?"
+        type_str = json_schema_to_ts(prop, defs)
+        desc = prop.get("description") if isinstance(prop, dict) else None
+        prefix = f"/**\n   *{desc}\n   */ " if desc else ""
+        fields.append(f"  {prefix}{key}{optional}: {type_str};")
+    body = "\n".join(fields)
+    if not body:
+        return no_arg_signature
+    return f"async function {camel_name}(input: {{\n{body}\n}}): {return_clause}"
+
+
+def render_signature_block(tool: BaseTool) -> str:
+    """Render ``/** description */\\n<signature>`` for a single tool."""
+    camel = to_camel_case(tool.name)
+    schema = _safe_json_schema(tool)
+    description = (tool.description or "").strip().splitlines()[0] if tool.description else ""
+    signature = render_signature(camel, schema)
+    return f"/** {description} */\n{signature}"
+
+
+_NAMESPACE_PREAMBLE = (
+    "\n\n"
+    "### API Reference — `tools` namespace\n\n"
+    "Agent tools are exposed on `globalThis.tools` (also reachable as `tools`). Each "
+    "takes a single object argument and returns a Promise that resolves to the tool's "
+    "native value (strings, numbers, arrays, objects, `null`) — you do NOT need to "
+    "`JSON.parse` results.\n\n"
+    "Invocation pattern: `await tools.<name>({ ... })`.\n\n"
+    "- Use `await` to get tool results; combine with `Promise.all` for independent "
+    "calls so they run concurrently.\n"
+    "- If the task needs multiple tool calls, prefer one `{tool_name}` invocation that "
+    "performs all of them rather than splitting the work across calls — each round-trip "
+    "costs a model turn.\n"
+    "- Pipeline dependent calls within a single program: if one tool's result feeds "
+    "another, chain them instead of returning the intermediate value to the model.\n"
+)
+
+
+def render_tools_namespace(
+    tools: Sequence[BaseTool],
+    *,
+    tool_name: str = "eval",
+    discovery_note: str = "",
+) -> str:
+    """Render the full ``tools`` namespace prompt block.
+
+    ``tools`` are rendered with full ``$ref``-resolved signatures. ``discovery_note``
+    (optional) is appended after the preamble to instruct the model that additional,
+    unlisted tools are reachable via ``tools.search`` / ``tools.describe``.
+    """
+    if not tools and not discovery_note:
+        return ""
+    preamble = _NAMESPACE_PREAMBLE.replace("{tool_name}", tool_name)
+    blocks = [render_signature_block(tool) for tool in tools]
+    body = "\n\n".join(blocks)
+    parts = [preamble]
+    if discovery_note:
+        parts.append("\n" + discovery_note + "\n")
+    if body:
+        parts.append("\n```typescript\n" + body + "\n```")
+    return "".join(parts)

--- a/packages/agent-common/agent_common/middleware/ptc_guard.py
+++ b/packages/agent-common/agent_common/middleware/ptc_guard.py
@@ -442,6 +442,10 @@ def wrap_tool_for_ptc(
         name=tool_name,
         description=inner.description,
         args_schema=inner.args_schema,
+        # Preserve the inner tool's metadata (notably ``server_name``) so downstream
+        # consumers can still distinguish MCP tools from base tools on the *wrapped*
+        # instance — e.g. the PTC middleware's core-vs-catalog render split.
+        metadata=inner.metadata,
     )
 
 

--- a/packages/agent-common/tests/test_ptc_core_render.py
+++ b/packages/agent-common/tests/test_ptc_core_render.py
@@ -1,0 +1,132 @@
+"""PTC core-only rendering: expose the full catalog, render only the stable core.
+
+When the exposed MCP catalog is large (the GP agent), the middleware must:
+- keep every tool *exposed* (callable bridge) — expose != render;
+- render only base/core tools + the ``search``/``describe`` discovery helpers into the
+  prompt, with a discovery instruction, so the prompt is stable across turns;
+- leave small, fixed sub-agent toolsets fully rendered inline (no discovery helpers).
+
+Also verifies the enabling change: ``wrap_tool_for_ptc`` preserves ``server_name``
+metadata so the core-vs-catalog split works on the *wrapped* instances.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from langchain_core.tools import StructuredTool
+
+import agent_common.core.graph_utils as gu
+from agent_common.core.ptc_discovery import PTC_DESCRIBE_TOOL_NAME, PTC_SEARCH_TOOL_NAME
+from agent_common.core.ptc_signatures import render_tools_namespace
+from agent_common.middleware.ptc_guard import wrap_tool_for_ptc
+
+
+@pytest.fixture(autouse=True)
+def _ptc_enabled(monkeypatch):
+    monkeypatch.setenv("CODE_INTERPRETER_PTC", "1")
+    # Lower the threshold so a handful of MCP tools triggers core-only mode.
+    monkeypatch.setattr(gu, "PTC_INLINE_RENDER_THRESHOLD", 3)
+
+
+def _base_tool(name: str) -> StructuredTool:
+    async def _fn() -> str:
+        return "ok"
+
+    return StructuredTool.from_function(coroutine=_fn, name=name, description=f"{name} description")
+
+
+def _mcp_tool(name: str, server: str = "github") -> StructuredTool:
+    async def _fn() -> str:
+        return "ok"
+
+    return StructuredTool.from_function(
+        coroutine=_fn, name=name, description=f"{name} description", metadata={"server_name": server}
+    )
+
+
+def _mw():
+    return gu._PTCToleranceCodeInterpreterMiddleware(
+        static_ptc_tools=[_base_tool("read_file")],
+        broaden_baseline_tools=[],
+        ptc_enabled=True,
+        broaden_exposure=True,
+        backend_supports_execution=False,
+    )
+
+
+def _req(**kwargs):
+    return SimpleNamespace(**kwargs)
+
+
+def test_wrap_tool_for_ptc_preserves_server_name_metadata():
+    wrapped = wrap_tool_for_ptc(_mcp_tool("github_list_commits"), risk_scorer=None)
+    assert (wrapped.metadata or {}).get("server_name") == "github"
+
+
+def test_core_only_exposes_full_catalog_plus_discovery_tools():
+    """Over threshold: every MCP tool stays exposed AND search/describe are added."""
+    mw = _mw()
+    catalog = [_mcp_tool(f"mcp_{i}") for i in range(5)]
+    collected = mw._collect_ptc_tools(_req(tools=catalog, state={}))
+    names = {t.name for t in collected}
+    # Expose != render: all MCP tools remain callable.
+    assert {f"mcp_{i}" for i in range(5)} <= names
+    assert "read_file" in names
+    # Discovery helpers pinned in.
+    assert PTC_SEARCH_TOOL_NAME in names
+    assert PTC_DESCRIBE_TOOL_NAME in names
+
+
+def test_core_only_renders_core_only_with_discovery_note():
+    mw = _mw()
+    catalog = [_mcp_tool(f"mcp_{i}") for i in range(5)]
+    collected = mw._collect_ptc_tools(_req(tools=catalog, state={}))
+    render_set, note = mw._render_partition(collected)
+    render_names = {t.name for t in render_set}
+    # The volatile MCP catalog is exposed but NOT rendered.
+    assert not any(n.startswith("mcp_") for n in render_names), render_names
+    # The stable core IS rendered.
+    assert "read_file" in render_names
+    assert {PTC_SEARCH_TOOL_NAME, PTC_DESCRIBE_TOOL_NAME} <= render_names
+    # Discovery instruction is present.
+    assert note
+    assert PTC_SEARCH_TOOL_NAME in note and PTC_DESCRIBE_TOOL_NAME in note
+
+
+def test_small_catalog_renders_all_inline_without_discovery():
+    """Under threshold (sub-agent): render everything, no discovery helpers."""
+    mw = _mw()
+    catalog = [_mcp_tool("mcp_a"), _mcp_tool("mcp_b")]  # 2 <= threshold(3)
+    collected = mw._collect_ptc_tools(_req(tools=catalog, state={}))
+    names = {t.name for t in collected}
+    assert PTC_SEARCH_TOOL_NAME not in names
+    assert PTC_DESCRIBE_TOOL_NAME not in names
+    render_set, note = mw._render_partition(collected)
+    render_names = {t.name for t in render_set}
+    # Everything rendered inline, no discovery note.
+    assert {"mcp_a", "mcp_b", "read_file"} <= render_names
+    assert note == ""
+
+
+def test_rendered_block_excludes_catalog_signatures():
+    """The rendered prompt body must not contain unrendered MCP tool signatures."""
+    mw = _mw()
+    catalog = [_mcp_tool(f"mcp_tool_{i}") for i in range(5)]
+    collected = mw._collect_ptc_tools(_req(tools=catalog, state={}))
+    render_set, note = mw._render_partition(collected)
+    body = render_tools_namespace(render_set, tool_name="eval", discovery_note=note)
+    assert "mcpTool" not in body  # no camelCased MCP signatures leaked
+    assert "async function search" in body
+    assert "async function describe" in body
+
+
+def test_render_partition_stable_across_turns_with_different_catalog():
+    """Core render set is identical when only the (unrendered) MCP catalog changes."""
+    mw = _mw()
+    turn1 = mw._collect_ptc_tools(_req(tools=[_mcp_tool(f"a_{i}") for i in range(5)], state={}))
+    turn2 = mw._collect_ptc_tools(_req(tools=[_mcp_tool(f"b_{i}") for i in range(6)], state={}))
+    set1 = {t.name for t in mw._render_partition(turn1)[0]}
+    set2 = {t.name for t in mw._render_partition(turn2)[0]}
+    assert set1 == set2, f"core render set drifted across turns: {set1} vs {set2}"

--- a/packages/agent-common/tests/test_ptc_core_render_e2e.py
+++ b/packages/agent-common/tests/test_ptc_core_render_e2e.py
@@ -1,0 +1,133 @@
+"""End-to-end: expose != render through a real ``eval`` REPL in core-only mode.
+
+Confirms the central redesign property: when the catalog is large, MCP tools are NOT
+rendered into the prompt but remain *callable* via ``tools.<name>``, and the pinned
+``tools.search`` / ``tools.describe`` helpers work inside ``eval``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import deque
+from typing import Any, Optional
+
+from langchain.agents.factory import create_agent
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+import agent_common.core.graph_utils as gu
+
+
+class _CommitArgs(BaseModel):
+    owner: str = Field(description="Repo owner")
+    repo: str
+
+
+class _ScriptedModel(BaseChatModel):
+    responses: deque = deque()
+    seen_system: list = []
+
+    @property
+    def _llm_type(self) -> str:
+        return "scripted"
+
+    def bind_tools(self, tools: list, **kwargs: Any) -> "_ScriptedModel":
+        return self
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: Optional[list[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        self.seen_system.append(messages[0].content if messages else "")
+        return ChatResult(generations=[ChatGeneration(message=self.responses.popleft())])
+
+
+def _mcp_tool(name: str) -> StructuredTool:
+    async def _fn(owner: str, repo: str) -> str:
+        return f"{name}:{owner}/{repo}"
+
+    return StructuredTool.from_function(
+        coroutine=_fn, name=name, description=f"{name} description.", args_schema=_CommitArgs,
+        metadata={"server_name": "github"},
+    )
+
+
+def _last_eval_message(result: dict) -> str:
+    for msg in reversed(result["messages"]):
+        if getattr(msg, "name", None) == "eval":
+            return str(msg.content)
+    return ""
+
+
+def _eval_json(result: dict) -> dict:
+    """Extract the JSON payload from the bridge's ``<result>...</result>`` wrapper."""
+    content = _last_eval_message(result)
+    match = re.search(r"<result>(.*)</result>", content, re.DOTALL)
+    return json.loads(match.group(1) if match else content)
+
+
+async def test_unrendered_mcp_tool_callable_and_discovery_works(monkeypatch):
+    monkeypatch.setenv("CODE_INTERPRETER_PTC", "1")
+    monkeypatch.setattr(gu, "PTC_INLINE_RENDER_THRESHOLD", 2)
+
+    catalog = [
+        _mcp_tool("github_list_commits"),
+        _mcp_tool("github_list_issues"),
+        _mcp_tool("github_get_repo"),
+        _mcp_tool("github_list_branches"),
+        _mcp_tool("github_create_issue"),
+    ]
+    mw = gu._PTCToleranceCodeInterpreterMiddleware(
+        static_ptc_tools=[],
+        broaden_baseline_tools=[],
+        ptc_enabled=True,
+        broaden_exposure=True,
+        backend_supports_execution=False,
+        mode="call",
+    )
+
+    code = (
+        "const direct = await tools.githubListCommits({owner: 'o', repo: 'r'});"
+        "const hits = await tools.search({query: 'list issues'});"
+        "const sig = await tools.describe({name: 'githubListIssues'});"
+        "JSON.stringify({direct, hitNames: hits.map(h => h.name), sig})"
+    )
+    model = _ScriptedModel()
+    model.seen_system = []
+    model.responses = deque(
+        [
+            AIMessage(content="", id="ai-1", tool_calls=[{"id": "c1", "name": "eval", "args": {"code": code}}]),
+            AIMessage(content="done", id="ai-2"),
+        ]
+    )
+    agent = create_agent(model=model, tools=catalog, middleware=[mw])
+    result = await agent.ainvoke({"messages": [HumanMessage("go")]})
+
+    payload = _eval_json(result)
+    # Expose != render: an unrendered MCP tool is still callable via tools.<name>.
+    assert payload["direct"] == "github_list_commits:o/r"
+    # search finds tools by intent and returns callable camelCase names.
+    assert "githubListIssues" in payload["hitNames"]
+    # describe returns the resolved signature for a tool not listed in the prompt.
+    assert "async function githubListIssues" in payload["sig"]
+    assert "owner: string" in payload["sig"]
+
+    # The system prompt must NOT contain the MCP catalog signatures, but MUST advertise
+    # discovery + the search/describe helpers. System content may be a list of blocks.
+    raw_system = model.seen_system[0]
+    if isinstance(raw_system, list):
+        system_prompt = "\n".join(b.get("text", "") for b in raw_system if isinstance(b, dict))
+    else:
+        system_prompt = str(raw_system)
+    assert "async function githubListCommits" not in system_prompt
+    assert "async function search" in system_prompt
+    assert "async function describe" in system_prompt
+    assert "tools.search" in system_prompt

--- a/packages/agent-common/tests/test_ptc_discovery.py
+++ b/packages/agent-common/tests/test_ptc_discovery.py
@@ -1,0 +1,93 @@
+"""tools.search / tools.describe: runtime discovery over the exposed catalog."""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from agent_common.core.ptc_discovery import (
+    PTC_DESCRIBE_TOOL_NAME,
+    PTC_SEARCH_TOOL_NAME,
+    build_discovery_tools,
+)
+
+
+class _Args(BaseModel):
+    owner: str = Field(description="Repo owner")
+    repo: str
+
+
+def _fn(**kwargs):  # noqa: ANN003, ANN202
+    return None
+
+
+def _tool(name: str, description: str):
+    return StructuredTool.from_function(func=_fn, name=name, description=description, args_schema=_Args)
+
+
+@pytest.fixture
+def catalog():
+    return [
+        _tool("github_list_commits", "List commits of a branch in a GitHub repository."),
+        _tool("github_list_issues", "List issues in a GitHub repository."),
+        _tool("slack_post_message", "Post a message to a Slack channel."),
+    ]
+
+
+def _tools(catalog):
+    search, describe = build_discovery_tools(catalog)
+    assert search.name == PTC_SEARCH_TOOL_NAME
+    assert describe.name == PTC_DESCRIBE_TOOL_NAME
+    return search, describe
+
+
+async def test_search_ranks_by_intent(catalog):
+    search, _ = _tools(catalog)
+    hits = await search.arun({"query": "list commits in a repo"})
+    assert hits[0]["name"] == "githubListCommits"
+    assert all(set(h) == {"name", "description"} for h in hits)
+
+
+async def test_search_returns_camelcase_callable_names(catalog):
+    search, _ = _tools(catalog)
+    hits = await search.arun({"query": "slack message"})
+    assert hits[0]["name"] == "slackPostMessage"
+
+
+async def test_search_no_match_returns_empty(catalog):
+    search, _ = _tools(catalog)
+    assert await search.arun({"query": "quantum teleportation"}) == []
+
+
+async def test_describe_accepts_camelcase_and_resolves_signature(catalog):
+    _, describe = _tools(catalog)
+    sig = await describe.arun({"name": "githubListCommits"})
+    assert "async function githubListCommits" in sig
+    assert "owner: string" in sig
+
+
+async def test_describe_accepts_snake_case_too(catalog):
+    _, describe = _tools(catalog)
+    sig = await describe.arun({"name": "github_list_commits"})
+    assert "async function githubListCommits" in sig
+
+
+async def test_describe_unknown_tool_hints_search(catalog):
+    _, describe = _tools(catalog)
+    msg = await describe.arun({"name": "doesNotExist"})
+    assert "No tool named" in msg
+    assert PTC_SEARCH_TOOL_NAME in msg
+
+
+def test_discovery_tools_excluded_from_their_own_catalog(catalog):
+    """search/describe must not surface themselves as searchable entries."""
+    search, describe = build_discovery_tools(catalog)
+    # Rebuild including the discovery tools in the catalog; they should still be skipped.
+    search2, _ = build_discovery_tools([*catalog, search, describe])
+    import asyncio
+
+    hits = asyncio.run(search2.arun({"query": "search describe"}))
+    names = {h["name"] for h in hits}
+    assert PTC_SEARCH_TOOL_NAME not in names
+    assert PTC_DESCRIBE_TOOL_NAME not in names

--- a/packages/agent-common/tests/test_ptc_signatures.py
+++ b/packages/agent-common/tests/test_ptc_signatures.py
@@ -1,0 +1,144 @@
+"""The PTC signature renderer must resolve ``$ref``/``$defs`` (the type-hint fix).
+
+The upstream ``langchain_quickjs`` renderer degrades nested Pydantic models /
+``TypedDict``s to ``unknown`` / ``Record<string, unknown>`` because they appear in the
+JSON Schema as ``$ref`` into ``$defs``. Our renderer must expand them so complex tools
+(e.g. GitHub) get a correct argument shape.
+"""
+
+from __future__ import annotations
+
+from typing import List, Literal, Optional
+
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from agent_common.core.ptc_signatures import json_schema_to_ts, render_signature_block
+
+
+def _fn(**kwargs):  # noqa: ANN003, ANN202
+    return None
+
+
+def _tool(name: str, args_schema, description: str = "desc"):
+    return StructuredTool.from_function(func=_fn, name=name, description=description, args_schema=args_schema)
+
+
+def test_nested_model_ref_is_resolved_not_unknown():
+    class Author(BaseModel):
+        name: str
+        date: str
+
+    class Commit(BaseModel):
+        message: str
+        author: Author
+
+    class Args(BaseModel):
+        commits: List[Commit]
+
+    sig = render_signature_block(_tool("x", Args))
+    assert "unknown" not in sig.split("Promise<", 1)[0], sig
+    assert "message: string" in sig
+    assert "author: { name: string; date: string }" in sig
+    assert "commits: { message: string; author: { name: string; date: string } }[]" in sig
+
+
+def test_enum_and_optional_and_literal():
+    class Args(BaseModel):
+        owner: str = Field(description="Repo owner")
+        state: Literal["open", "closed", "all"] = "open"
+        sha: Optional[str] = None
+
+    sig = render_signature_block(_tool("github_list_commits", Args))
+    assert "githubListCommits" in sig  # camelCased
+    assert 'state?: "open" | "closed" | "all"' in sig
+    assert "sha?: string | null" in sig
+    assert "owner: string" in sig  # required, no '?'
+
+
+def test_no_param_tool_renders_no_args():
+    """A tool with no parameters renders ``()``, not a misleading Record<unknown>.
+
+    Regression: empty/absent ``properties`` fell through to the unknown-schema
+    default (``input: Record<string, unknown>``), implying ``githubGetMe`` accepts
+    arbitrary args. It takes none.
+    """
+
+    class Empty(BaseModel):
+        pass
+
+    sig = render_signature_block(_tool("github_get_me", Empty))
+    assert "Record<string, unknown>" not in sig
+    assert "async function githubGetMe(): Promise<unknown>" in sig
+
+
+def test_no_param_dict_schema_renders_no_args():
+    """Same for MCP tools whose dict schema has empty/absent properties."""
+    for schema in ({"type": "object", "properties": {}}, {"type": "object"}):
+        sig = render_signature_block(_tool("github_get_me", schema))
+        assert "async function githubGetMe(): Promise<unknown>" in sig, schema
+        assert "Record<string, unknown>" not in sig
+
+
+def test_recursive_ref_is_guarded():
+    """A self-referential ``$ref`` must terminate, emitting the type name on cycle."""
+    defs = {
+        "Node": {
+            "type": "object",
+            "properties": {
+                "value": {"type": "integer"},
+                "children": {"type": "array", "items": {"$ref": "#/$defs/Node"}},
+            },
+        }
+    }
+    ts = json_schema_to_ts({"$ref": "#/$defs/Node"}, defs)
+    # Renders without hanging; the inner self-reference collapses to the type name.
+    assert "value?: number" in ts
+    assert "children?: Node[]" in ts
+
+
+def test_dict_args_schema_is_rendered():
+    """MCP tools carry a raw JSON-schema dict (not a Pydantic model) on args_schema.
+
+    Regression: these degraded to ``Record<string, unknown>`` because the renderer
+    only handled Pydantic models. The dict must be used directly.
+    """
+    dict_schema = {
+        "type": "object",
+        "properties": {
+            "owner": {"type": "string", "description": "Repo owner"},
+            "repo": {"type": "string"},
+            "state": {"type": "string", "enum": ["open", "closed", "all"]},
+        },
+        "required": ["owner", "repo"],
+    }
+    sig = render_signature_block(_tool("github_list_issues", dict_schema))
+    assert "Record<string, unknown>" not in sig
+    assert "owner: string" in sig
+    assert "repo: string" in sig
+    assert 'state?: "open" | "closed" | "all"' in sig
+
+
+def test_dict_args_schema_resolves_nested_ref():
+    """A dict schema with ``$defs``/``$ref`` (as MCP servers emit) must expand."""
+    dict_schema = {
+        "type": "object",
+        "$defs": {"Label": {"type": "object", "properties": {"name": {"type": "string"}}}},
+        "properties": {
+            "repo": {"type": "string"},
+            "labels": {"type": "array", "items": {"$ref": "#/$defs/Label"}},
+        },
+        "required": ["repo"],
+    }
+    sig = render_signature_block(_tool("github_create_issue", dict_schema))
+    assert "labels?: { name?: string }[]" in sig
+
+
+def test_json_schema_to_ts_scalars_and_arrays():
+    assert json_schema_to_ts({"type": "string"}, {}) == "string"
+    assert json_schema_to_ts({"type": "integer"}, {}) == "number"
+    assert json_schema_to_ts({"type": "boolean"}, {}) == "boolean"
+    assert json_schema_to_ts({"type": "array", "items": {"type": "string"}}, {}) == "string[]"
+    assert json_schema_to_ts({"enum": ["a", "b"]}, {}) == '"a" | "b"'
+    # Unresolvable ref → unknown
+    assert json_schema_to_ts({"$ref": "#/$defs/Missing"}, {}) == "unknown"

--- a/packages/orchestrator-agent/AGENTS.md
+++ b/packages/orchestrator-agent/AGENTS.md
@@ -51,10 +51,14 @@ NEVER use heredoc (`cat << EOF`) to write files - causes fatal errors. Use incre
 The GP agent is a `DynamicLocalAgentRunnable` (from `agent-common`) registered as `"general-purpose"` in the subagent registry. It's special:
 
 - Gets ALL tools from `tool_registry` via `inject_all_tools` (bypasses MCP gateway discovery)
-- Has `ToolsetSelectorMiddleware` for LLM-driven smart tool filtering per task
 - Is the **primary executor of skills** — when the orchestrator is unsure which sub-agent to use, it delegates to GP
 - Loaded from DB as a user-configured sub-agent (name `"general-purpose"`)
 - Uses the same `DynamicLocalAgentRunnable` code path as other local agents
+
+**Tool filtering depends on PTC** (`CODE_INTERPRETER_PTC`):
+
+- **PTC off (native tool calling):** `ToolsetSelectorMiddleware` is added — an LLM filters the full catalog down to a relevant per-turn subset, so hundreds of tools aren't bound to the model.
+- **PTC on:** `ToolsetSelectorMiddleware` is **NOT** added. The catalog is exposed inside `eval` and the model discovers tools at runtime via `tools.search`/`tools.describe` (see `agent-common` → *PTC Tool Exposure*). This supersedes the selector (runtime discovery, no recall ceiling, no per-turn selection LLM call) and is required for prompt caching — keeping the selector under PTC would re-vary the exposed/rendered set per turn. The full catalog is still injected (`inject_all_tools`) so it can be exposed. Gating lives in `build_runtime_context()` via `code_interpreter_ptc_enabled()`.
 
 ### Sub-Agent Registry & Tool Registry
 

--- a/packages/orchestrator-agent/app/utils.py
+++ b/packages/orchestrator-agent/app/utils.py
@@ -125,6 +125,7 @@ def build_runtime_context(
     from langchain_core.tools import BaseTool
     from ringier_a2a_sdk.cost_tracking import CostTrackingCallback
 
+    from agent_common.core.graph_utils import code_interpreter_ptc_enabled
     from agent_common.middleware.ptc_guard import PTC_CODE_INTERPRETER_TOOL_NAME
 
     from .agents.file_analyzer import create_file_analyzer_subagent
@@ -406,31 +407,39 @@ def build_runtime_context(
                     subagent_extra_middlewares: list[Any] = [AuthErrorDetectionMiddleware()]
                     gp_inject_all_tools = None
                     if config.name == "general-purpose":
-                        # Inject ALL MCP tools from tool_registry (already discovered by orchestrator)
+                        # Inject ALL MCP tools from tool_registry (already discovered by orchestrator).
+                        # Under PTC these are exposed (bridge-installed) inside ``eval``; the model
+                        # finds the relevant ones at runtime via ``tools.search`` / ``tools.describe``.
                         gp_inject_all_tools = [t for t in tool_registry.values() if isinstance(t, BaseTool)]
-                        # Add ToolsetSelectorMiddleware for smart tool filtering
-                        subagent_extra_middlewares.append(
-                            ToolsetSelectorMiddleware(
-                                always_include=[
-                                    "get_current_time",
-                                    "generate_presigned_url",
-                                    "docstore_search",
-                                    "semantic_search_file",
-                                    "docstore_export",
-                                    "copy_file",
-                                    # The PTC code interpreter (`eval`) is the gateway to all
-                                    # PTC-exposed tools; it is a "base" tool (no server_name) so
-                                    # it survives Phase 1, but Phase 2 tool-selection can drop it.
-                                    # Pin it so the GP model never loses `tools.*` access.
-                                    PTC_CODE_INTERPRETER_TOOL_NAME,
-                                ],
-                                cost_logger=cost_logger,
-                                compression_server_slug=AgentSettings.GATANA_COMPRESSION_SERVER_SLUG,
+                        # ToolsetSelectorMiddleware (per-turn LLM tool filtering) is only needed on the
+                        # native (PTC-off) path, where the full catalog would otherwise be bound to the
+                        # model. Under PTC, ``tools.search`` supersedes it (runtime discovery, no recall
+                        # ceiling, no per-turn selection LLM call) AND keeping the selector would re-break
+                        # prompt caching by varying the bound/exposed set per turn. So gate it on PTC-off.
+                        if not code_interpreter_ptc_enabled():
+                            subagent_extra_middlewares.append(
+                                ToolsetSelectorMiddleware(
+                                    always_include=[
+                                        "get_current_time",
+                                        "generate_presigned_url",
+                                        "docstore_search",
+                                        "semantic_search_file",
+                                        "docstore_export",
+                                        "copy_file",
+                                        # The PTC code interpreter (`eval`) is the gateway to all
+                                        # PTC-exposed tools; it is a "base" tool (no server_name) so
+                                        # it survives Phase 1, but Phase 2 tool-selection can drop it.
+                                        # Pin it so the GP model never loses `tools.*` access.
+                                        PTC_CODE_INTERPRETER_TOOL_NAME,
+                                    ],
+                                    cost_logger=cost_logger,
+                                    compression_server_slug=AgentSettings.GATANA_COMPRESSION_SERVER_SLUG,
+                                )
                             )
-                        )
+                        _selector_state = "off (PTC runtime discovery)" if code_interpreter_ptc_enabled() else "on"
                         logger.info(
                             f"GP agent: injecting {len(gp_inject_all_tools)} tools from tool_registry "
-                            f"with ToolsetSelectorMiddleware"
+                            f"(ToolsetSelectorMiddleware={_selector_state})"
                         )
 
                     # Auto-expand non-GP sub-agent MCP whitelist with compression


### PR DESCRIPTION
## Problem

When PTC (Programmatic Tool Calling) is enabled, the general-purpose (GP) agent's system prompt listed the full TypeScript signature of every tool. Two issues followed:

1. **Prompt-cache invalidation.** `ToolsetSelectorMiddleware` filtered the MCP catalog down to a different per-turn subset based on the user's query, so the rendered tool block in the system prompt changed every turn → cross-turn cache misses.
2. **Wrong-argument calls on complex tools.** The upstream `langchain_quickjs` renderer degrades nested Pydantic/`TypedDict` args (which appear as JSON-Schema `$ref`/`$defs`) to `unknown`, so tools like the GitHub ones were called with the wrong shape.

## Approach

Separate **exposing** a tool (installing its callable `globalThis.tools` bridge) from **rendering** its signature into the prompt:

- The full catalog stays **callable**; only the **stable core** (filesystem/base tools + `search`/`describe`) is rendered, so the prompt is invariant across turns → caching restored.
- Tools are found at runtime via two read-only, unguarded helpers pinned into the `eval` namespace: **`tools.search({query})`** (keyword/token ranking) and **`tools.describe({name})`** (full typed signature). Triggered when the MCP catalog exceeds `PTC_INLINE_RENDER_THRESHOLD` (default 40), so small fixed sub-agent toolsets keep rendering inline.
- An **own `$ref`/`$defs`-resolving schema→TS renderer** fixes the type-hint problem (used by `describe` and the sub-agent inline path).
- `ToolsetSelectorMiddleware` is **gated on `CODE_INTERPRETER_PTC` off**; under PTC, `tools.search` supersedes it (runtime discovery, no recall ceiling, no per-turn selection LLM call). It remains wired for the native fallback, where it's still needed to avoid binding the full catalog.

Design rationale is documented in `CONTEXT.md` and `docs/adr/0001-ptc-prompt-as-tool-discovery.md`.

## Changes

- **new** `agent-common/core/ptc_signatures.py` — `$ref`-resolving renderer.
- **new** `agent-common/core/ptc_discovery.py` — `search`/`describe` tools.
- `agent-common/core/graph_utils.py` — expose-vs-render split; overridden `_prepare_for_call`; public `code_interpreter_ptc_enabled()`.
- `agent-common/middleware/ptc_guard.py` — preserve `.metadata` through `wrap_tool_for_ptc`.
- `orchestrator-agent/app/utils.py` — gate `ToolsetSelectorMiddleware` on PTC-off.

## Testing

- New unit tests: renderer (`$ref`/enum/recursion), `search`/`describe`, core-vs-render partitioning.
- New **end-to-end test** drives the real QuickJS REPL, proving an *unrendered* MCP tool stays callable, `search`/`describe` work inside `eval`, and the prompt omits the catalog signatures.
- agent-common: **567 passed, 0 failed**. orchestrator toolset_selector: **27 passed**.

## Notes for reviewers

- The `PTC_INLINE_RENDER_THRESHOLD` mechanism (base-vs-`server_name` split) is what distinguishes the large-catalog GP agent from small sub-agent toolsets with no parameter plumbing — flagged in case an explicit GP-only flag is preferred.
- No static GP-prompt edit: the discovery instruction is delivered dynamically (only in core-only mode), which is better for caching than baking it into the user-specific prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)