### PR TITLE
perf(orchestrator): reuse one checkpoint read per turn instead of 4+

### DIFF
--- a/packages/orchestrator-agent/app/core/agent.py
+++ b/packages/orchestrator-agent/app/core/agent.py
@@ -50,6 +50,7 @@ from ..models.config import AgentSettings, GraphRuntimeContext, UserConfig
 from ..utils import build_runtime_context
 from .content_builder import build_text_content
 from .discovery import AgentDiscoveryService, ToolDiscoveryService
+from .turn_state import TurnState
 
 logger = logging.getLogger(__name__)
 
@@ -250,6 +251,7 @@ class OrchestratorDeepAgent:
         user_config: UserConfig,
         config: dict[str, Any],
         resume: Any = None,
+        turn_state: "TurnState | None" = None,
     ) -> AsyncIterable[AgentStreamResponse]:
         """
         Stream agent responses with runtime user context injection.
@@ -629,11 +631,22 @@ class OrchestratorDeepAgent:
             logger.debug("===== STREAM PROCESSING COMPLETE =====")
             logger.debug(f"Total chunks processed: {chunk_count}")
 
-            # Check if the graph was interrupted
+            # Check if the graph was interrupted. Use the native async API: the sync
+            # get_state() on an async (DynamoDB) saver takes a slow sync-bridge path
+            # (fresh, unpooled connection).
             logger.debug("Getting final state...")
-            final_state = graph.get_state(config)  # type: ignore
+            final_state = await graph.aget_state(config)  # type: ignore
             logger.debug(f"Final state type: {type(final_state)}")
             logger.debug(f"Final state: {final_state}")
+
+            # Store this single end-of-stream read on the per-turn carrier so the
+            # executor can reuse it instead of issuing its own get_state() re-reads
+            # (phantom / feedback / terminal checks). Nothing mutates the graph
+            # between here and those checks, so the executor sees identical state.
+            if turn_state is not None:
+                turn_state.final_values = getattr(final_state, "values", None)
+                turn_state.interrupts = tuple(getattr(final_state, "interrupts", ()) or ())
+                turn_state.captured = True
 
             # Check for general interrupt conditions (pending nodes without specific interrupts)
             # Note: Specific interrupt handling is done in agent_executor for proper A2A task state management

--- a/packages/orchestrator-agent/app/core/executor.py
+++ b/packages/orchestrator-agent/app/core/executor.py
@@ -53,6 +53,7 @@ from ..handlers import StreamHandler
 from .agent import OrchestratorDeepAgent
 from .budget_guard import get_budget_guard
 from .registry import RegistryService, User
+from .turn_state import TurnState, count_tool_messages
 from .steering_state import (
     get_all_active_subagent_dispatches,
     get_orchestrator_pending_messages,
@@ -625,8 +626,16 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
                 first_intermediate_chunk_sent = False  # Track if we've sent the initial INTERMEDIATE artifact chunk
                 streamed_chars = 0  # Total chars streamed via the MAIN artifact (code points, not wire bytes; for completion diagnostics)
                 deferred_terminal_item = None
+                # Per-round carrier: the agent populates this from its single
+                # end-of-stream aget_state, so the phantom / feedback / terminal
+                # checks below reuse it instead of re-reading the checkpoint
+                # (~1.5–5s each). Must be a per-round local — agent/executor are
+                # shared singletons.
+                turn_state = TurnState()
 
-                async for item in self.agent.stream(message_parts, user_config, config=config, resume=resume_value):
+                async for item in self.agent.stream(
+                    message_parts, user_config, config=config, resume=resume_value, turn_state=turn_state
+                ):
                     # Buffer the terminal completed item so we can check for unconsumed
                     # steering messages before emitting it to the SSE stream.
                     # Other terminal states are emitted immediately.
@@ -634,21 +643,20 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
                         deferred_terminal_item = item
                         continue
 
-                    # Skip costly graph.get_state() for transient streaming chunks
                     metadata = item.metadata or {}
+                    # is_final for in-loop items is only consumed by plain WORKING status
+                    # items (960/969), which carry metadata=None — so the two branches are
+                    # identical. activity_log / work_plan / streaming_chunk items return
+                    # before then, and interrupt items don't read it. So is_final is
+                    # immaterial here; use a constant and skip the per-item checkpoint read.
+                    # (Validated via the shadow phase: see git history.)
+                    is_final = True
                     if metadata.get("streaming_chunk"):
-                        is_final = True  # Doesn't matter for streaming chunks
                         # Track MAIN-artifact bytes only (intermediate sub-agent thoughts
                         # go to a separate "-thought" artifact and aren't part of the
                         # main response stream the client renders).
                         if not metadata.get("intermediate_output") and item.content:
                             streamed_chars += len(item.content)
-                    else:
-                        current_state = graph.get_state(config)  # type: ignore
-                        if hasattr(current_state, "interrupts") and current_state.interrupts:
-                            is_final = False
-                        else:
-                            is_final = True
 
                     # Pass per-artifact first_chunk_sent flags and update after each chunk
                     first_chunk_sent, first_intermediate_chunk_sent = await self._handle_stream_item(
@@ -697,8 +705,9 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
                     and deferred_terminal_item.state == TaskState.TASK_STATE_COMPLETED
                     and delegation_reinvocations < MAX_DELEGATION_REINVOCATIONS
                 ):
-                    phantom_state = graph.get_state(config)  # type: ignore
-                    phantom_values = phantom_state.values if hasattr(phantom_state, "values") else {}
+                    # Reuse the state the agent already read at end-of-stream (carrier),
+                    # instead of re-reading the checkpoint here (~1.5–5s).
+                    phantom_values = turn_state.final_values or {}
                     if StreamHandler.is_phantom_subagent_completion(phantom_values):
                         delegation_reinvocations += 1
                         message_parts = [Part(text=_DELEGATION_NUDGE)]
@@ -721,9 +730,9 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
                     force_feedback = request_metadata.get("forceFeedbackRequest") in (True, "true", "1")
                     feedback_threshold = int(os.environ.get("FEEDBACK_RECURSION_THRESHOLD", "40"))
                     try:
-                        final_state = graph.get_state(config)  # type: ignore
-                        msgs = final_state.values.get("messages", []) if hasattr(final_state, "values") else []
-                        tool_msg_count = sum(1 for m in msgs if hasattr(m, "tool_call_id"))
+                        # Reuse the agent's end-of-stream state (carrier) instead of re-reading.
+                        msgs = (turn_state.final_values or {}).get("messages", [])
+                        tool_msg_count = count_tool_messages(turn_state.final_values or {})
                         if force_feedback or tool_msg_count > feedback_threshold:
                             # Extract sub-agent IDs from activity-log metadata
                             # Prefer integer sub_agent_id; fall back to agent_name for built-in agents
@@ -756,11 +765,11 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
                     if metadata.get("streaming_chunk"):
                         is_final = True
                     else:
-                        current_state = graph.get_state(config)  # type: ignore
-                        if hasattr(current_state, "interrupts") and current_state.interrupts:
-                            is_final = False
-                        else:
-                            is_final = True
+                        # Reuse the agent's end-of-stream interrupts (carrier) instead of
+                        # re-reading. This preserves the "contradictory completed non-final"
+                        # guard (1099): a COMPLETED item is treated as final unless the
+                        # captured state shows pending interrupts.
+                        is_final = not turn_state.has_interrupts
                     first_chunk_sent, first_intermediate_chunk_sent = await self._handle_stream_item(
                         deferred_terminal_item,
                         updater,

--- a/packages/orchestrator-agent/app/core/turn_state.py
+++ b/packages/orchestrator-agent/app/core/turn_state.py
@@ -1,0 +1,50 @@
+"""Per-turn state carrier shared between the orchestrator agent and its executor.
+
+Created fresh inside ``OrchestratorDeepAgentExecutor.execute()`` for each stream
+round and passed into ``OrchestratorDeepAgent.stream()``. The agent already reads
+the final graph state once at end-of-stream (``graph.aget_state``); it stores that
+result here so the executor can reuse it for the phantom / feedback / terminal
+checks WITHOUT issuing its own ``graph.get_state()`` re-reads — each of which is a
+~5s checkpoint fetch (DynamoDB + S3 offload). Nothing mutates the graph between
+the agent's end-of-stream read and the executor's post-stream checks, so the
+carrier IS what a re-read would return — equivalence by construction.
+
+The executor and agent are module-level singletons shared across concurrent
+requests, so this carrier MUST be a per-``execute()`` local — never stored on
+``self``.
+
+This replaced four redundant ``get_state()`` re-reads per completed turn (the
+executor's phantom / feedback / terminal checks plus a per-status-item read).
+Equivalence was confirmed via a shadow phase that logged carrier-vs-re-read
+agreement across happy-path / auth / HITL / phantom / feedback turns before the
+reads were removed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class TurnState:
+    """Final graph state captured from the stream for one orchestrator turn."""
+
+    # ``StateSnapshot.values`` from the agent's end-of-stream ``aget_state`` —
+    # a dict with "messages". Same object the executor would otherwise re-read.
+    final_values: dict[str, Any] | None = None
+    # ``StateSnapshot.interrupts`` from that same read.
+    interrupts: tuple = ()
+    # True once the agent has populated this carrier from its end-of-stream read.
+    captured: bool = False
+
+    @property
+    def has_interrupts(self) -> bool:
+        return bool(self.interrupts)
+
+
+def count_tool_messages(values: Any) -> int:
+    """Count ToolMessages in state values (feedback-threshold input at executor.py:724)."""
+    if not isinstance(values, dict):
+        return 0
+    return sum(1 for m in (values.get("messages") or []) if hasattr(m, "tool_call_id"))


### PR DESCRIPTION
## Problem

Completed orchestrator turns issued **4+ `graph.get_state()` calls**, each a ~3–5s checkpoint fetch (DynamoDB ref → S3 offload GET → full-state msgpack deserialize). This added a silent **~14s tail after the LLM finished** (three sequential post-stream reads) and inflated total stream time via a per-status-item read in the stream loop.

Traced from a real turn: the model finished at `T`, but the terminal response didn't reach the backend until `T+14s`, with the orchestrator log silent in between — three back-to-back `get_state` reads in the executor.

## Fix

The agent already reads the final state once at end-of-stream. Store that on a per-turn `TurnState` carrier and have the executor reuse it instead of re-reading:

| site | before | after |
|---|---|---|
| in-loop `is_final` | `get_state` per status item | constant (only plain WORKING items consume it, and they carry `metadata=None`) |
| phantom-delegation guard | `get_state` | `turn_state.final_values` |
| feedback-threshold check | `get_state` | `turn_state.final_values` |
| terminal `is_final` | `get_state` | `not turn_state.has_interrupts` (preserves the "contradictory completed non-final" guard) |
| agent end-of-stream | `get_state` (sync) | `aget_state` (async) — **kept**, the sole read, populates the carrier |

Nothing mutates the graph between the agent's read and the executor's post-stream checks, so the carrier is exactly what a re-read would return — equivalence by construction. The carrier is a per-`execute()` local (agent/executor are shared singletons).

## Validation

Landed behind a **shadow phase** that populated the carrier *alongside* the existing reads and logged agreement at every site. Across **happy / auth-interrupt / HITL / phantom / feedback / resume** turns, every comparison was `match=True` and no plain-WORKING-with-interrupts case ever occurred. Reads were removed only after that. Re-verified post-cutover: completed and HITL flows behave identically, terminal event now fires ~1ms after the single read instead of after ~14s of reads.

`91` orchestrator unit tests pass (`test_agent_executor`, `test_stream_handler`, `test_executor_extension_filtering`).

## Scope / follow-ups (intentionally not in this PR)

- The **single remaining `aget_state`** (~3–5s) is left for the planned **PostgreSQL checkpointer migration** to make cheap — see infra issue #135, which now documents the read-latency considerations from this investigation.
- The **interrupt-path final checkpoint write** (~16.5s observed on auth turns) is a separate issue, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
