### PR TITLE
fix(console-backend): stop conversation reload from duplicating/splitting the answer

### DIFF
--- a/packages/console-backend/app.py
+++ b/packages/console-backend/app.py
@@ -706,7 +706,8 @@ async def _process_a2a_response(
                 message_extensions = status_message.get("extensions", []) if isinstance(status_message, dict) else []
                 is_work_plan = "urn:nannos:a2a:work-plan:1.0" in message_extensions
                 is_feedback_request = "urn:nannos:a2a:feedback-request:1.0" in message_extensions
-                is_artifact_append = response_data.get("kind") == "artifact-update" and response_data.get("append")
+                is_artifact_update = response_data.get("kind") == "artifact-update"
+                is_artifact_append = is_artifact_update and response_data.get("append")
                 # Handle both camelCase and snake_case, check explicitly for boolean value
                 # Don't use 'or' because False would fallback to checking second field
                 last_chunk_value = response_data.get("lastChunk")
@@ -721,9 +722,12 @@ async def _process_a2a_response(
                 # Accumulate streaming artifact text for persistence.
                 # Individual chunks are transient (not saved to DB); the assembled
                 # content is persisted when last_chunk arrives.
-                # IMPORTANT: Do NOT accumulate intermediate output (sub-agent thoughts).
-                # Those are display-only events, not part of the final persisted message.
-                if is_artifact_append:
+                # Use is_artifact_update (not is_artifact_append): the FIRST chunk of an
+                # artifact is append=False (it creates the artifact). It must be
+                # accumulated with the rest — otherwise it gets persisted as its own
+                # standalone message (via save_agent_response below) and the content is
+                # split into two messages, which reload renders as two fragments.
+                if is_artifact_update:
                     artifact = response_data.get("artifact", {})
                     artifact_metadata = artifact.get("metadata", {}) if isinstance(artifact, dict) else {}
                     # Detect intermediate output via extensions array on the artifact
@@ -860,7 +864,7 @@ async def _process_a2a_response(
                 if (
                     not is_work_plan
                     and not is_feedback_request
-                    and not is_artifact_append
+                    and not is_artifact_update
                     and not is_bare_completion_signal
                     and not is_streamed_fallback
                     and not safety_net_saved

--- a/packages/console-backend/app.py
+++ b/packages/console-backend/app.py
@@ -845,11 +845,24 @@ async def _process_a2a_response(
                     and not status_obj.get("message")
                 )
 
+                # The terminal status re-sends the streamed answer as a fallback for
+                # non-streaming clients, tagged final_answer_source="fallback". The
+                # streamed answer was already persisted above (accumulated artifact
+                # buffer), so saving this terminal copy too would store the answer
+                # twice and replay it doubled on reload. Skip it — when nothing was
+                # streamed the orchestrator does NOT tag the status, so direct
+                # (non-streamed) answers are still persisted here.
+                is_streamed_fallback = (
+                    response_data.get("kind") == "status-update"
+                    and (response_data.get("metadata") or {}).get("final_answer_source") == "fallback"
+                )
+
                 if (
                     not is_work_plan
                     and not is_feedback_request
                     and not is_artifact_append
                     and not is_bare_completion_signal
+                    and not is_streamed_fallback
                     and not safety_net_saved
                 ):
                     await messages_service.save_agent_response(

--- a/packages/console-backend/tests/test_socket_message_handling.py
+++ b/packages/console-backend/tests/test_socket_message_handling.py
@@ -229,6 +229,40 @@ async def test_terminal_status_without_fallback_is_persisted():
 
 
 @pytest.mark.asyncio
+async def test_first_artifact_chunk_is_accumulated_not_persisted_standalone():
+    """The append=False first chunk of an artifact must be accumulated, not saved standalone.
+
+    The first chunk of any streamed artifact has append=False (it creates the
+    artifact). It used to fall through to save_agent_response as its own message,
+    splitting the content from the accumulated remainder — which reload rendered as
+    two fragments. It must now be accumulated like the appends that follow.
+    """
+    from a2a.types import Artifact, Part, StreamResponse, TaskArtifactUpdateEvent
+
+    from app import _process_a2a_response
+
+    mock_sio = _mock_sio_for_persistence("conv-firstchunk")
+    with patch("app.sio", mock_sio):
+        art = Artifact(
+            artifact_id="a1",
+            parts=[Part(text="The user wants me to delegate")],
+            metadata={"agent_name": "orchestrator"},
+        )
+        art.extensions.append("urn:nannos:a2a:intermediate-output:1.0")
+        event = TaskArtifactUpdateEvent(
+            task_id="t1", context_id="conv-firstchunk", artifact=art, append=False, last_chunk=False
+        )
+        await _process_a2a_response(
+            client_event=StreamResponse(artifact_update=event),
+            sid="sid",
+            request_id="req-fc",
+            context_id="conv-firstchunk",
+        )
+        # The first chunk is accumulated for later assembly, never persisted on its own.
+        mock_sio.app_instance.state.messages_service.save_agent_response.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_conversation_title_with_unicode_characters():
     """Test that conversation title handles Unicode characters correctly."""
 

--- a/packages/console-backend/tests/test_socket_message_handling.py
+++ b/packages/console-backend/tests/test_socket_message_handling.py
@@ -164,6 +164,70 @@ async def test_process_a2a_response_uses_fallback_context_id():
         assert call_kwargs["user_id"] == "user-1"
 
 
+def _mock_sio_for_persistence(context_id: str):
+    """Build a mock sio whose services accept a persisted agent response."""
+    mock_sio = MagicMock()
+    mock_sio.emit = AsyncMock()
+    mock_sio.app_instance = MagicMock()
+    mock_socket_session = MagicMock(user_id="user-1", agent_url="http://agent")
+    mock_sio.app_instance.state.socket_session_service.get_session = AsyncMock(return_value=mock_socket_session)
+    mock_conversation = MagicMock(conversation_id=context_id, user_id="user-1")
+    mock_sio.app_instance.state.conversation_service.get_conversation = AsyncMock(return_value=mock_conversation)
+    mock_sio.app_instance.state.messages_service.save_history_messages = AsyncMock(return_value=0)
+    mock_sio.app_instance.state.messages_service.save_agent_response = AsyncMock()
+    mock_sio.app_instance.state.messages_service.insert_message = AsyncMock()
+    return mock_sio
+
+
+@pytest.mark.asyncio
+async def test_terminal_fallback_status_is_not_persisted():
+    """A terminal status tagged final_answer_source=fallback must NOT be persisted again.
+
+    The orchestrator streams the answer (persisted from the accumulated artifact
+    buffer) and re-sends it in the terminal status as a fallback for non-streaming
+    clients. Saving that terminal copy too stored the answer twice and replayed it
+    doubled on reload.
+    """
+    from a2a.types import Message, Part, Role, StreamResponse, TaskState, TaskStatus, TaskStatusUpdateEvent
+
+    from app import _process_a2a_response
+
+    mock_sio = _mock_sio_for_persistence("conv-fb-1")
+    with patch("app.sio", mock_sio):
+        msg = Message(role=Role.ROLE_AGENT, parts=[Part(text="The poem")], message_id="m1", context_id="conv-fb-1")
+        event = TaskStatusUpdateEvent(
+            task_id="t1",
+            context_id="conv-fb-1",
+            status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED, message=msg),
+            metadata={"final_answer_source": "fallback"},
+        )
+        await _process_a2a_response(
+            client_event=StreamResponse(status_update=event), sid="sid", request_id="req-fb-1", context_id="conv-fb-1"
+        )
+        mock_sio.app_instance.state.messages_service.save_agent_response.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_terminal_status_without_fallback_is_persisted():
+    """A terminal status with NO fallback tag (nothing streamed) is still persisted."""
+    from a2a.types import Message, Part, Role, StreamResponse, TaskState, TaskStatus, TaskStatusUpdateEvent
+
+    from app import _process_a2a_response
+
+    mock_sio = _mock_sio_for_persistence("conv-fb-2")
+    with patch("app.sio", mock_sio):
+        msg = Message(role=Role.ROLE_AGENT, parts=[Part(text="The poem")], message_id="m2", context_id="conv-fb-2")
+        event = TaskStatusUpdateEvent(
+            task_id="t2",
+            context_id="conv-fb-2",
+            status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED, message=msg),
+        )
+        await _process_a2a_response(
+            client_event=StreamResponse(status_update=event), sid="sid", request_id="req-fb-2", context_id="conv-fb-2"
+        )
+        mock_sio.app_instance.state.messages_service.save_agent_response.assert_called_once()
+
+
 @pytest.mark.asyncio
 async def test_conversation_title_with_unicode_characters():
     """Test that conversation title handles Unicode characters correctly."""


### PR DESCRIPTION
Fixes two distinct persistence-layer bugs that made a turn render wrong **on reload** (live was fine). Both are follow-ups to #67.

`_process_a2a_response` persists a turn via two paths: the accumulated streaming-artifact buffer (`insert_message`) and standalone messages (`save_agent_response`). Two defects in that split:

## 1. Terminal fallback persisted as a duplicate
The orchestrator streams the answer (persisted from the buffer) **and** re-sends it in the terminal status as a fallback for non-streaming clients, tagged `final_answer_source: "fallback"`. The skip-conditions never checked the flag, so both were stored → the answer replayed **twice** on reload.

**Fix:** skip `save_agent_response` for terminal status-updates tagged `final_answer_source: "fallback"` (the streamed copy is already persisted). Non-streamed answers aren't tagged, so they're still persisted.

## 2. First artifact chunk persisted standalone (content split)
The first chunk of a streamed artifact is `append=False` (it creates the artifact). Accumulation was gated on `is_artifact_append` (append=True only), so the first chunk was skipped from the buffer **and** fell through to `save_agent_response` as its own message. The content was stored as two messages — standalone first chunk + accumulated remainder — which reload rendered as **two fragments** (e.g. an orchestrator thought split mid-sentence: "The user wants me to delegate" | "a poem generation task…", or a truncated leading bubble).

**Fix:** gate accumulation and the standalone-save skip on `is_artifact_update` (any append) so the first chunk is assembled with the rest into one message. Live streaming is unchanged (first chunk still emits via the normal path).

`#67` exposed #2 by routing the orchestrator's prose to the thinking channel, turning it into a persisted intermediate-output thought.

## Tests
`tests/test_socket_message_handling.py` — 3 new cases: fallback terminal is **not** persisted; non-fallback terminal **is**; the `append=False` first chunk is accumulated, not saved standalone. Full file passes (10 tests).

## Note
Both are symptoms of the same architectural seam (dual emission + per-path persistence, plus separate live vs. reload reconstruction). Tracked separately: single-source emission and single-source (frontend-owned) reconstruction would eliminate the class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
