### PR TITLE
fix: single-source streaming — bare completion, first-chunk accumulation, thought ordering

### DIFF
--- a/packages/console-backend/app.py
+++ b/packages/console-backend/app.py
@@ -4,6 +4,7 @@ import logging
 import os
 import socket
 from collections.abc import AsyncIterator
+from datetime import datetime, timezone
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from http.cookies import SimpleCookie
@@ -477,6 +478,10 @@ _streaming_buffers: dict[str, str] = {}
 # Keyed by "{context_id}:{agent_name}". Persisted when the conversation turn ends
 # (terminal status or main artifact last_chunk) so reasoning blocks survive page reload.
 _intermediate_buffers: dict[str, str] = {}
+# First-chunk arrival time per intermediate buffer key. Buffers are flushed at
+# turn-end, but persisting them with this real start time (not turn-end) keeps
+# reload ordering aligned with how the thoughts streamed live.
+_intermediate_buffer_ts: dict[str, datetime] = {}
 
 
 # ==============================================================================
@@ -587,6 +592,7 @@ async def _flush_intermediate_buffers(
     keys_to_flush = [k for k in _intermediate_buffers if k.startswith(prefix)]
     for buf_key in keys_to_flush:
         content = _intermediate_buffers.pop(buf_key)
+        first_chunk_ts = _intermediate_buffer_ts.pop(buf_key, None)
         if not content.strip():
             continue
         agent_name = buf_key.split(":", 1)[1] if ":" in buf_key else "unknown"
@@ -616,6 +622,7 @@ async def _flush_intermediate_buffers(
             kind="artifact-update",
             raw_payload=synthetic_payload,
             metadata={"agent_name": agent_name},
+            created_at=first_chunk_ts,
         )
 
 
@@ -761,6 +768,10 @@ async def _process_a2a_response(
                         if chunk_text:
                             agent_name = artifact_metadata.get("agent_name", "unknown")
                             buf_key = f"{effective_context_id}:{agent_name}"
+                            # Stamp the first chunk's arrival time so the flushed message
+                            # keeps the real start time (reload ordering matches live).
+                            if buf_key not in _intermediate_buffers:
+                                _intermediate_buffer_ts[buf_key] = datetime.now(tz=timezone.utc)
                             _intermediate_buffers[buf_key] = _intermediate_buffers.get(buf_key, "") + chunk_text
                             logger.info(
                                 f"[STREAMING] Intermediate output chunk ({len(chunk_text)} chars) from {agent_name}, "

--- a/packages/console-backend/app.py
+++ b/packages/console-backend/app.py
@@ -706,7 +706,8 @@ async def _process_a2a_response(
                 message_extensions = status_message.get("extensions", []) if isinstance(status_message, dict) else []
                 is_work_plan = "urn:nannos:a2a:work-plan:1.0" in message_extensions
                 is_feedback_request = "urn:nannos:a2a:feedback-request:1.0" in message_extensions
-                is_artifact_append = response_data.get("kind") == "artifact-update" and response_data.get("append")
+                is_artifact_update = response_data.get("kind") == "artifact-update"
+                is_artifact_append = is_artifact_update and response_data.get("append")
                 # Handle both camelCase and snake_case, check explicitly for boolean value
                 # Don't use 'or' because False would fallback to checking second field
                 last_chunk_value = response_data.get("lastChunk")
@@ -721,9 +722,13 @@ async def _process_a2a_response(
                 # Accumulate streaming artifact text for persistence.
                 # Individual chunks are transient (not saved to DB); the assembled
                 # content is persisted when last_chunk arrives.
-                # IMPORTANT: Do NOT accumulate intermediate output (sub-agent thoughts).
-                # Those are display-only events, not part of the final persisted message.
-                if is_artifact_append:
+                # Use is_artifact_update (not is_artifact_append): the FIRST chunk of an
+                # artifact is append=False (it creates the artifact). It must be
+                # accumulated with the rest — otherwise it falls through to
+                # save_agent_response as its own standalone message and the content is
+                # split into two messages, which reload renders as two fragments
+                # (e.g. an orchestrator thought split mid-sentence).
+                if is_artifact_update:
                     artifact = response_data.get("artifact", {})
                     artifact_metadata = artifact.get("metadata", {}) if isinstance(artifact, dict) else {}
                     # Detect intermediate output via extensions array on the artifact
@@ -848,7 +853,7 @@ async def _process_a2a_response(
                 if (
                     not is_work_plan
                     and not is_feedback_request
-                    and not is_artifact_append
+                    and not is_artifact_update
                     and not is_bare_completion_signal
                     and not safety_net_saved
                 ):

--- a/packages/console-backend/console_backend/services/messages_service.py
+++ b/packages/console-backend/console_backend/services/messages_service.py
@@ -307,6 +307,7 @@ class MessagesService:
         message_id: str | None = None,
         final: bool = False,  # DEPRECATED: A2A 1.0.0 removes this field
         kind: str = "",
+        created_at: datetime | None = None,
     ) -> Message:
         """Insert a new message.
 
@@ -330,7 +331,10 @@ class MessagesService:
         if message_id is None:
             message_id = str(uuid7())
 
-        created_at = datetime.now(tz=timezone.utc)
+        # Allow callers to preserve an event's real time (e.g. streamed thoughts
+        # persisted at turn-end must keep their first-chunk timestamp so reload
+        # orders them where they actually occurred). Defaults to now.
+        created_at = created_at or datetime.now(tz=timezone.utc)
         created_at_iso = created_at.isoformat()
         timestamp_ms = int(created_at.timestamp() * 1000)  # Milliseconds for sort key
 

--- a/packages/console-backend/tests/test_socket_message_handling.py
+++ b/packages/console-backend/tests/test_socket_message_handling.py
@@ -165,6 +165,50 @@ async def test_process_a2a_response_uses_fallback_context_id():
 
 
 @pytest.mark.asyncio
+async def test_first_artifact_chunk_is_accumulated_not_persisted_standalone():
+    """The append=False first chunk of an artifact must be accumulated, not saved standalone.
+
+    The first chunk of a streamed artifact has append=False (it creates the
+    artifact). It used to fall through to save_agent_response as its own message,
+    splitting the content from the accumulated remainder — which reload rendered as
+    two fragments. It must be accumulated like the appends that follow.
+    """
+    from a2a.types import Artifact, Part, StreamResponse, TaskArtifactUpdateEvent
+
+    from app import _process_a2a_response
+
+    mock_sio = MagicMock()
+    mock_sio.emit = AsyncMock()
+    mock_sio.app_instance = MagicMock()
+    mock_socket_session = MagicMock(user_id="user-1", agent_url="http://agent")
+    mock_sio.app_instance.state.socket_session_service.get_session = AsyncMock(return_value=mock_socket_session)
+    mock_conversation = MagicMock(conversation_id="conv-firstchunk", user_id="user-1")
+    mock_sio.app_instance.state.conversation_service.get_conversation = AsyncMock(return_value=mock_conversation)
+    mock_sio.app_instance.state.messages_service.save_history_messages = AsyncMock(return_value=0)
+    mock_sio.app_instance.state.messages_service.save_agent_response = AsyncMock()
+    mock_sio.app_instance.state.messages_service.insert_message = AsyncMock()
+
+    with patch("app.sio", mock_sio):
+        art = Artifact(
+            artifact_id="a1",
+            parts=[Part(text="The user wants me to delegate")],
+            metadata={"agent_name": "orchestrator"},
+        )
+        art.extensions.append("urn:nannos:a2a:intermediate-output:1.0")
+        event = TaskArtifactUpdateEvent(
+            task_id="t1", context_id="conv-firstchunk", artifact=art, append=False, last_chunk=False
+        )
+        await _process_a2a_response(
+            client_event=StreamResponse(artifact_update=event),
+            sid="sid",
+            request_id="req-fc",
+            context_id="conv-firstchunk",
+        )
+        # First chunk is accumulated for later assembly, never persisted on its own.
+        mock_sio.app_instance.state.messages_service.save_agent_response.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_conversation_title_with_unicode_characters():
     """Test that conversation title handles Unicode characters correctly."""
 

--- a/packages/orchestrator-agent/app/core/executor.py
+++ b/packages/orchestrator-agent/app/core/executor.py
@@ -1139,17 +1139,29 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
         """Seal an open streaming artifact (if any) and emit a terminal status update.
 
         Shared by the ``input_required``, ``auth_required`` and ``completed``
-        fallback branches. When the orchestrator streamed token chunks this turn
-        (``first_chunk_sent``), the streaming artifact is closed with a final
-        empty chunk and the status metadata is tagged
-        ``final_answer_source="fallback"`` so well-behaved clients dedupe the
-        terminal message against the artifact text they already rendered.
+        branches. The artifact (if one was streamed) is closed with a final empty
+        chunk, then the terminal status is emitted.
 
-        Centralising this keeps the artifact-close, the completion log line and
-        the metadata key in one place so a format/key change cannot silently
-        miss one branch.
+        SINGLE-SOURCE EMISSION: when the full answer was streamed as artifact
+        chunks, the streamed artifact *is* the answer — re-sending it in the
+        terminal ``status.message`` would duplicate it for every consumer (web
+        render + persistence, slack, google-chat). So in that case emit a BARE
+        completion (state only) and let clients use the streamed artifact.
+
+        The terminal message stays authoritative only when the answer was NOT
+        fully streamed:
+        - interrupts (``input_required`` / ``auth_required`` carry the message);
+        - answers assembled at the terminal (e.g. ``include_subagent_output``,
+          where nothing — or only a partial prefix — was streamed to the main
+          artifact). A streamed partial prefix is tagged ``final_answer_source``
+          so consumers can still dedupe it.
         """
-        status_metadata = dict(base_metadata) if base_metadata else {}
+        answer_fully_streamed = (
+            state == TaskState.TASK_STATE_COMPLETED
+            and first_chunk_sent
+            and final_message_len > 0
+            and streamed_chars >= final_message_len
+        )
         if first_chunk_sent:
             await updater.add_artifact(
                 [Part(text="")],
@@ -1160,18 +1172,24 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
             )
             logger.info(
                 "[STREAMING] Completion: artifact_id=%s streamed_chars=%d "
-                "final_message_len=%d task_state=%s",
+                "final_message_len=%d task_state=%s fully_streamed=%s",
                 streaming_artifact_id,
                 streamed_chars,
                 final_message_len,
                 state,
+                answer_fully_streamed,
             )
-            status_metadata["final_answer_source"] = "fallback"
-        await updater.update_status(
-            state,
-            msg,
-            metadata=status_metadata or None,
-        )
+        if answer_fully_streamed:
+            # Answer already delivered via the streamed artifact — emit a bare
+            # completion (no message) so it isn't re-sent / re-persisted / re-rendered.
+            await updater.update_status(state, None, metadata=(base_metadata or None))
+        else:
+            status_metadata = dict(base_metadata) if base_metadata else {}
+            if first_chunk_sent:
+                # Only a partial prefix was streamed (rare — e.g. a non-empty message
+                # alongside include_subagent_output). Tag so consumers can dedupe it.
+                status_metadata["final_answer_source"] = "fallback"
+            await updater.update_status(state, msg, metadata=status_metadata or None)
 
     def _validate_request(self, context: RequestContext) -> bool:
         return False

--- a/packages/orchestrator-agent/tests/test_agent_executor.py
+++ b/packages/orchestrator-agent/tests/test_agent_executor.py
@@ -150,14 +150,13 @@ class TestAgentExecutorStreamHandling:
         updater.update_status.assert_called_once()
 
     async def test_handle_stream_item_streaming_completion(self, dynamodb_table):
-        """Streaming completion closes the artifact AND embeds the authoritative final answer.
+        """A fully-streamed completion closes the artifact and emits a BARE completion.
 
-        Regression for the production incident on 2026-05-25 where a downstream A2A client
-        failed to parse a streamed artifact frame and the user never received the reply,
-        because the terminal `completed` status carried no message body. The terminal
-        status must now always carry the validated FinalResponseSchema.message text as a
-        fallback / source-of-truth, tagged with `final_answer_source: "fallback"` so
-        well-behaved clients that already rendered the streamed artifact can dedupe.
+        Single-source emission: when the full answer was already streamed as the
+        artifact (streamed_chars >= final_message_len), the terminal `completed`
+        status carries NO message — re-sending it would duplicate the answer for
+        every consumer (web render + persistence, slack, google-chat). Clients use
+        the streamed artifact; the terminal is state-only.
         """
         from app.models.responses import AgentStreamResponse
 
@@ -198,17 +197,15 @@ class TestAgentExecutorStreamHandling:
         parts = artifact_call[0][0]
         assert parts[0].text == ""
 
-        # Completion status MUST carry the authoritative final answer as a fallback
+        # Single-source emission: the full answer was already streamed as the
+        # artifact, so the terminal status is a BARE completion (no message body) —
+        # nothing to re-send / re-persist / re-render.
         updater.update_status.assert_called_once()
         status_call = updater.update_status.call_args
         assert status_call[0][0] == TaskState.TASK_STATE_COMPLETED
-        # Second positional arg is the message carrying the final answer text
-        assert len(status_call[0]) == 2
-        final_msg = status_call[0][1]
-        text_parts = [p.text for p in final_msg.parts if p.WhichOneof("content") == "text"]
-        assert "Full response content" in "".join(text_parts)
-        # Metadata flag signals well-behaved clients to dedupe against the artifact stream
-        assert status_call[1]["metadata"]["final_answer_source"] == "fallback"
+        assert status_call[0][1] is None  # bare completion, no message
+        # No fallback tag — there is no duplicate terminal copy to dedupe.
+        assert status_call[1].get("metadata") is None
 
         # _handle_stream_item now returns (first_chunk_sent, first_intermediate_chunk_sent)
         assert result == (True, False)


### PR DESCRIPTION
Removes the answer-duplication / reload-fragmentation / reload-ordering issues at the source (see [#69](https://github.com/ringier-data/nannos/pull/69) for the design). Three small, paired changes — **verified live in the browser**, live == reload now holds for content *and* ordering.

## 1. Orchestrator — bare completion when the answer was fully streamed
Don't re-send the streamed answer in the terminal `status.message`. When fully streamed (`completed` + `first_chunk_sent` + `streamed_chars >= final_message_len`), emit a **bare completion**; clients use the streamed artifact. The terminal still carries the message when the answer wasn't fully streamed (interrupts; `include_subagent_output`). Removes the live + persisted duplicate; no per-consumer dedup needed (slack/google-chat already prefer artifacts).

## 2. console-backend — accumulate the first artifact chunk
The `append=False` first chunk was skipped from the buffer and persisted standalone, splitting the answer/thought into two messages → reload showed two fragments. Gate accumulation + standalone-save-skip on `is_artifact_update` so the first chunk joins its message.

## 3. console-backend — persist thoughts with their first-chunk time
Intermediate-output buffers were flushed at turn-end, so reload sorted thoughts *after* the activity they preceded. Stamp each buffer's first-chunk time and pass it as `insert_message(created_at=…)` so reload ordering matches live.

## Browser verification
A fresh delegate turn, live vs. reload:
- thinking blocks: one coherent block each (no mid-sentence split) ✓
- answer: rendered once (no duplication) ✓
- ordering: orchestrator thought before "Delegating…", same as live ✓

(Confirmed against a turn persisted *before* fix #3, which still shows the old ordering — proving the fix.)

## Outcome on Phase 3
The full frontend reducer rewrite (#69's option) is **not needed** — these targeted fixes achieve live == reload, verified in the browser. #69 stays as the north-star doc if a new divergence ever appears. Old pre-a2a-v1 conversations are intentionally not reconstructed (line drawn).

## Tests
Orchestrator 91 pass; console-backend `test_socket_message_handling.py` + `test_messages_service_unit.py` pass (20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
