### PR TITLE
refactor!: remove A2A pre-1.0 deprecations before v1 release

### DIFF
--- a/packages/agent-common/agent_common/core/copy_file_tool.py
+++ b/packages/agent-common/agent_common/core/copy_file_tool.py
@@ -6,7 +6,6 @@ particularly useful for large files that shouldn't be processed by the model.
 """
 
 import logging
-from typing import Any
 
 from deepagents.backends.protocol import BackendProtocol
 from langchain.tools import ToolRuntime
@@ -56,7 +55,7 @@ def _validate_path(path: str) -> str:
     return path
 
 
-def create_copy_file_tool(backend: Any) -> BaseTool:
+def create_copy_file_tool(backend: BackendProtocol) -> BaseTool:
     """Create tool for copying files to long-term memory without LLM context loading.
 
     The tool uses the CompositeBackend's routing to automatically:
@@ -69,7 +68,7 @@ def create_copy_file_tool(backend: Any) -> BaseTool:
     - Automatic semantic indexing on write to /memories/
 
     Args:
-        backend: A BackendProtocol instance (or legacy callable factory)
+        backend: A BackendProtocol instance
 
     Returns:
         BaseTool for copying files to memories
@@ -113,8 +112,7 @@ def create_copy_file_tool(backend: Any) -> BaseTool:
 
             destination_path = _validate_path(destination_path)
 
-            # Get backend (supports both instances and legacy callable factories)
-            resolved_backend: BackendProtocol = backend(runtime) if callable(backend) else backend
+            resolved_backend: BackendProtocol = backend
 
             logger.info(f"Copying file from '{source_path}' to '{destination_path}'")
 

--- a/packages/agent-common/agent_common/core/playbook_reader.py
+++ b/packages/agent-common/agent_common/core/playbook_reader.py
@@ -29,11 +29,6 @@ logger = logging.getLogger(__name__)
 # Cache TTL in seconds
 _CACHE_TTL = 60
 
-# Legacy namespace — try as fallback when "agent-data" yields nothing.
-# Remove after one release cycle.
-_LEGACY_NAMESPACE = "playbooks"
-_CURRENT_NAMESPACE = "agent-data"
-
 
 @dataclass
 class SkillIndexEntry:
@@ -86,10 +81,6 @@ class PlaybookReaderService:
     async def _read_file_from_store(self, namespace: tuple[str, ...], file_path: str) -> str | None:
         """Read a file from the store by namespace and path.
 
-        Tries the provided namespace first; if the namespace ends with
-        ``_CURRENT_NAMESPACE`` and no content is found, retries with the
-        legacy ``_LEGACY_NAMESPACE`` for backward compatibility.
-
         Args:
             namespace: Store namespace tuple (e.g., (user_id, "agent-data"))
             file_path: The file path key in the store
@@ -97,13 +88,6 @@ class PlaybookReaderService:
         Returns:
             File content as string, or None if not found
         """
-        content = await self._try_read(namespace, file_path)
-        if content is None and len(namespace) >= 2 and namespace[-1] == _CURRENT_NAMESPACE:
-            content = await self._try_read((*namespace[:-1], _LEGACY_NAMESPACE), file_path)
-        return content
-
-    async def _try_read(self, namespace: tuple[str, ...], file_path: str) -> str | None:
-        """Attempt to read a single file from the store."""
         try:
             items = await self._store.aget(namespace=namespace, key=file_path)
             if items and hasattr(items, "value") and items.value:
@@ -130,8 +114,7 @@ class PlaybookReaderService:
         """List file keys in a store namespace matching a prefix.
 
         Uses asearch without a semantic query (query=None) to list items,
-        then filters by key prefix client-side. Falls back to the legacy
-        namespace if the current one returns no results.
+        then filters by key prefix client-side.
 
         Args:
             namespace: Store namespace tuple
@@ -140,13 +123,6 @@ class PlaybookReaderService:
         Returns:
             List of matching file path keys
         """
-        results = await self._try_list(namespace, prefix)
-        if not results and len(namespace) >= 2 and namespace[-1] == _CURRENT_NAMESPACE:
-            results = await self._try_list((*namespace[:-1], _LEGACY_NAMESPACE), prefix)
-        return results
-
-    async def _try_list(self, namespace: tuple[str, ...], prefix: str) -> list[str]:
-        """Attempt to list files in a single namespace."""
         try:
             results = await self._store.asearch(namespace, limit=100)
             return [item.key for item in results if item.key.startswith(prefix)]
@@ -424,9 +400,8 @@ class PlaybookReaderService:
     async def _extract_skill_description(self, namespace: tuple[str, ...], file_path: str) -> str:
         """Extract description from a skill file.
 
-        Supports both SKILL.md frontmatter format (preferred) and legacy
-        markdown heading format (fallback). Uses parse_skill_frontmatter
-        which handles both formats.
+        Reads the ``description`` field from SKILL.md YAML frontmatter via
+        parse_skill_frontmatter.
 
         Args:
             namespace: Store namespace

--- a/packages/agent-common/agent_common/core/skill_frontmatter.py
+++ b/packages/agent-common/agent_common/core/skill_frontmatter.py
@@ -76,80 +76,40 @@ def validate_skill_name(name: str) -> str | None:
 def parse_skill_frontmatter(content: str) -> ParsedSkill | None:
     """Parse a SKILL.md file into frontmatter and body.
 
-    Supports both:
-    - New format: YAML frontmatter between --- delimiters
-    - Legacy format: H1 heading + first paragraph (returns synthetic frontmatter)
-
-    Returns None if content is empty or unparseable.
+    Expects YAML frontmatter between ``---`` delimiters. Returns None if the
+    content is empty, has no frontmatter block, or the frontmatter is unparseable.
     """
     if not content or not content.strip():
         return None
 
     stripped = content.strip()
+    if not stripped.startswith("---"):
+        return None
 
-    # Try YAML frontmatter format
-    if stripped.startswith("---"):
-        parts = stripped.split("---", 2)
-        if len(parts) >= 3:
-            yaml_str = parts[1].strip()
-            body = parts[2].strip()
-            try:
-                fm_data = yaml.safe_load(yaml_str)
-                if isinstance(fm_data, dict):
-                    name = str(fm_data.get("name", ""))
-                    description = str(fm_data.get("description", ""))
-                    raw_meta = fm_data.get("metadata", {})
-                    metadata = {str(k): str(v) for k, v in raw_meta.items()} if isinstance(raw_meta, dict) else {}
-                    return ParsedSkill(
-                        frontmatter=SkillFrontmatter(
-                            name=name,
-                            description=description,
-                            metadata=metadata,
-                        ),
-                        body=body,
-                    )
-            except yaml.YAMLError:
-                pass  # Fall through to legacy parsing
+    parts = stripped.split("---", 2)
+    if len(parts) < 3:
+        return None
 
-    # Legacy format: extract from markdown headings
-    return _parse_legacy_skill(content)
+    yaml_str = parts[1].strip()
+    body = parts[2].strip()
+    try:
+        fm_data = yaml.safe_load(yaml_str)
+    except yaml.YAMLError:
+        return None
+    if not isinstance(fm_data, dict):
+        return None
 
-
-def _parse_legacy_skill(content: str) -> ParsedSkill:
-    """Parse a legacy skill file (no frontmatter) into a ParsedSkill.
-
-    Extracts:
-    - name from first H1 heading (normalized to skill-name format)
-    - description from first non-empty, non-heading line
-    - body is the entire content
-    """
-    first_heading = ""
-    description = ""
-
-    for line in content.split("\n"):
-        stripped = line.strip()
-        if not stripped:
-            continue
-        if stripped.startswith("#"):
-            heading_text = stripped.lstrip("#").strip()
-            if not first_heading:
-                first_heading = heading_text
-            continue
-        if first_heading and not description:
-            description = stripped[:_MAX_DESCRIPTION_LEN]
-            break
-
-    # Normalize heading to a skill-name-like identifier
-    name = re.sub(r"[^a-z0-9-]", "-", first_heading.lower())
-    name = re.sub(r"-+", "-", name).strip("-")
-
+    name = str(fm_data.get("name", ""))
+    description = str(fm_data.get("description", ""))
+    raw_meta = fm_data.get("metadata", {})
+    metadata = {str(k): str(v) for k, v in raw_meta.items()} if isinstance(raw_meta, dict) else {}
     return ParsedSkill(
         frontmatter=SkillFrontmatter(
-            name=name or "untitled",
+            name=name,
             description=description,
-            metadata={},
+            metadata=metadata,
         ),
-        body=content,
+        body=body,
     )
 
 

--- a/packages/agent-common/agent_common/models/__init__.py
+++ b/packages/agent-common/agent_common/models/__init__.py
@@ -1,12 +1,12 @@
 """Shared model types and configuration."""
 
-from .base import DEFAULT_MODEL, DEFAULT_THINKING_LEVEL, ModelType, ThinkingLevel
+from .base import DEFAULT_THINKING_LEVEL, ModelType, ThinkingLevel, get_resolved_default_model
 from .exceptions import A2AClientError, AgentFrameworkAuthError
 
 __all__ = [
     "ModelType",
     "ThinkingLevel",
-    "DEFAULT_MODEL",
+    "get_resolved_default_model",
     "DEFAULT_THINKING_LEVEL",
     "A2AClientError",
     "AgentFrameworkAuthError",

--- a/packages/agent-common/agent_common/models/base.py
+++ b/packages/agent-common/agent_common/models/base.py
@@ -64,9 +64,6 @@ def get_resolved_default_model() -> ModelType:
     return _default_model
 
 
-# DEFAULT_MODEL kept for backward compat — reads env var directly.
-# Use get_resolved_default_model() for runtime resolution that respects available credentials.
-DEFAULT_MODEL: ModelType = os.getenv("DEFAULT_MODEL", "claude-sonnet-4.5")  # type: ignore
 DEFAULT_THINKING_LEVEL: ThinkingLevel | None = (
     ThinkingLevel(os.getenv("ORCHESTRATOR_THINKING_LEVEL", ThinkingLevel.low))
     if os.getenv("ORCHESTRATOR_ENABLE_THINKING", "false").lower() == "true"

--- a/packages/agent-common/tests/test_copy_to_memories_tool.py
+++ b/packages/agent-common/tests/test_copy_to_memories_tool.py
@@ -16,12 +16,7 @@ async def test_copy_file_success():
     mock_backend.aread.return_value = "Test content for large file"
     mock_backend.awrite.return_value = WriteResult(path="/memories/test.txt", error=None, files_update=None)
 
-    # Mock backend factory
-    def backend_factory(runtime):
-        return mock_backend
-
-    # Create tool
-    tool = create_copy_file_tool(backend_factory)
+    tool = create_copy_file_tool(mock_backend)
 
     # Invoke tool directly with function parameters (bypassing LangChain's parameter injection)
     result = await tool.coroutine(
@@ -50,10 +45,7 @@ async def test_copy_file_with_auto_destination():
         path="/memories/large_result.json", error=None, files_update=None
     )
 
-    def backend_factory(runtime):
-        return mock_backend
-
-    tool = create_copy_file_tool(backend_factory)
+    tool = create_copy_file_tool(mock_backend)
 
     # Invoke without destination_name
     result = await tool.coroutine(
@@ -75,10 +67,7 @@ async def test_copy_file_source_not_found():
     mock_backend = AsyncMock()
     mock_backend.aread.side_effect = FileNotFoundError("File not found")
 
-    def backend_factory(runtime):
-        return mock_backend
-
-    tool = create_copy_file_tool(backend_factory)
+    tool = create_copy_file_tool(mock_backend)
 
     result = await tool.coroutine(
         source_path="/temp/nonexistent.txt",
@@ -97,10 +86,7 @@ async def test_copy_file_write_error():
     mock_backend.aread.return_value = "Content"
     mock_backend.awrite.return_value = WriteResult(path=None, error="Write failed: disk full", files_update=None)
 
-    def backend_factory(runtime):
-        return mock_backend
-
-    tool = create_copy_file_tool(backend_factory)
+    tool = create_copy_file_tool(mock_backend)
 
     result = await tool.coroutine(
         source_path="/temp/test.txt",
@@ -118,10 +104,7 @@ async def test_copy_file_invalid_path():
     """Test validation of invalid paths."""
     mock_backend = AsyncMock()
 
-    def backend_factory(runtime):
-        return mock_backend
-
-    tool = create_copy_file_tool(backend_factory)
+    tool = create_copy_file_tool(mock_backend)
 
     # Test relative path (should fail validation)
     result = await tool.coroutine(
@@ -150,10 +133,7 @@ async def test_copy_file_empty_file():
     mock_backend = AsyncMock()
     mock_backend.aread.return_value = ""  # Empty content
 
-    def backend_factory(runtime):
-        return mock_backend
-
-    tool = create_copy_file_tool(backend_factory)
+    tool = create_copy_file_tool(mock_backend)
 
     result = await tool.coroutine(
         source_path="/temp/empty.txt",
@@ -180,10 +160,7 @@ async def test_copy_file_file_size_display():
         mock_backend.aread.return_value = content
         mock_backend.awrite.return_value = WriteResult(path="/memories/test.txt", error=None, files_update=None)
 
-        def backend_factory(runtime):
-            return mock_backend
-
-        tool = create_copy_file_tool(backend_factory)
+        tool = create_copy_file_tool(mock_backend)
 
         result = await tool.coroutine(
             source_path="/temp/test.txt",

--- a/packages/agent-common/tests/test_skill_frontmatter.py
+++ b/packages/agent-common/tests/test_skill_frontmatter.py
@@ -48,7 +48,7 @@ class TestValidateSkillName:
 
 
 class TestParseSkillFrontmatter:
-    """Test frontmatter parsing for both new and legacy formats."""
+    """Test frontmatter parsing."""
 
     def test_parse_frontmatter_format(self):
         content = "---\nname: my-skill\ndescription: Does something useful.\n---\n\n## Steps\n\n1. Do it"
@@ -65,12 +65,10 @@ class TestParseSkillFrontmatter:
         assert result.frontmatter.name == "deploy"
         assert result.frontmatter.metadata["author"] == "test-user"
 
-    def test_parse_legacy_format(self):
+    def test_no_frontmatter_returns_none(self):
+        # Plain markdown without a frontmatter block is no longer supported.
         content = "# Incident Triage\n\nHandle production incidents step by step.\n\n## Steps\n\n1. Check alerts"
-        result = parse_skill_frontmatter(content)
-        assert result is not None
-        assert result.frontmatter.name == "incident-triage"
-        assert "Handle production incidents" in result.frontmatter.description
+        assert parse_skill_frontmatter(content) is None
 
     def test_empty_content(self):
         assert parse_skill_frontmatter("") is None

--- a/packages/agent-runner/agent/core.py
+++ b/packages/agent-runner/agent/core.py
@@ -44,7 +44,7 @@ from agent_common.core.document_store_tools import create_document_store_tools
 from agent_common.core.graph_utils import build_sub_agent_graph
 from agent_common.core.model_factory import _has_aws_credentials, create_model, is_valid_model
 from object_storage import get_object_storage_service
-from agent_common.models.base import DEFAULT_MODEL
+from agent_common.models.base import get_resolved_default_model
 
 if TYPE_CHECKING:
     from agent_common.core.sandbox_pool import SandboxPool
@@ -790,7 +790,7 @@ Create a brief, actionable message (1-2 sentences) that a user would want to rec
             "description": cfg_version.get("description", ""),
             "system_prompt": cfg_version.get("system_prompt", ""),
             "mcp_tools": cfg_version.get("mcp_tools") or [],
-            "model": cfg_version.get("model") or DEFAULT_MODEL,
+            "model": cfg_version.get("model") or get_resolved_default_model(),
             "agent_url": cfg_version.get("agent_url"),
             "enable_thinking": cfg_version.get("enable_thinking", False),
             "thinking_level": cfg_version.get("thinking_level"),
@@ -906,7 +906,7 @@ Create a brief, actionable message (1-2 sentences) that a user would want to rec
         # Validate and create LLM via agent-common model factory
         if not is_valid_model(model_name):
             logger.warning(
-                f"Invalid model '{model_name}' in sub-agent config for job {scheduled_job_id} — defaulting to {DEFAULT_MODEL}",
+                f"Invalid model '{model_name}' in sub-agent config for job {scheduled_job_id} — defaulting to {get_resolved_default_model()}",
             )
 
         # Determine thinking level

--- a/packages/console-backend/app.py
+++ b/packages/console-backend/app.py
@@ -489,11 +489,11 @@ _intermediate_buffer_ts: dict[str, datetime] = {}
 # ==============================================================================
 
 
-# Map v1.0 protobuf TaskState names -> the legacy short wire strings that the
-# backend's turn-ending / persistence control-flow is keyed against. The frontend
-# handles raw v1.0 states natively (so we no longer rewrite the outbound payload);
-# this is used only to normalize states for internal branching below.
-_LEGACY_STATE: dict[str, str] = {
+# Map v1.0 protobuf TaskState names -> the short state strings that the backend's
+# turn-ending / persistence control-flow is keyed against. The frontend handles raw
+# v1.0 states natively (so we no longer rewrite the outbound payload); this is used
+# only to normalize states for internal branching below.
+_SHORT_STATE_NAMES: dict[str, str] = {
     "TASK_STATE_SUBMITTED": "submitted",
     "TASK_STATE_WORKING": "working",
     "TASK_STATE_COMPLETED": "completed",
@@ -506,9 +506,9 @@ _LEGACY_STATE: dict[str, str] = {
 }
 
 
-def _legacy_state_name(state: Any) -> Any:
-    """Normalize a v1.0 ProtoJSON TaskState name to its legacy short form."""
-    return _LEGACY_STATE.get(state, state) if isinstance(state, str) else state
+def _short_state_name(state: Any) -> Any:
+    """Normalize a v1.0 ProtoJSON TaskState name to its short form."""
+    return _SHORT_STATE_NAMES.get(state, state) if isinstance(state, str) else state
 
 
 def _extract_a2a_task_id(stream_result: Any) -> str | None:
@@ -724,7 +724,7 @@ async def _process_a2a_response(
 
                 # Extract status object early for use in multiple checks below
                 status_obj = response_data.get("status", {})
-                status_state = _legacy_state_name(status_obj.get("state")) if isinstance(status_obj, dict) else None
+                status_state = _short_state_name(status_obj.get("state")) if isinstance(status_obj, dict) else None
 
                 # Accumulate streaming artifact text for persistence.
                 # Individual chunks are transient (not saved to DB); the assembled

--- a/packages/console-backend/console_backend/dependencies.py
+++ b/packages/console-backend/console_backend/dependencies.py
@@ -481,7 +481,7 @@ class GroupAdminChecker:
         # Get DB session from app state
         async_session_factory = request.app.state.async_session_factory
         async with async_session_factory() as db:
-            is_admin = await user_group_service.is_group_admin(db, group_id, user.id)
+            is_admin = await user_group_service.is_group_manager(db, group_id, user.id)
 
         if not is_admin:
             raise HTTPException(
@@ -519,7 +519,7 @@ async def require_group_admin_or_admin(
         return user
 
     # Check if user is group admin
-    is_admin = await user_group_service.is_group_admin(db, group_id, user.id)
+    is_admin = await user_group_service.is_group_manager(db, group_id, user.id)
     if not is_admin:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/packages/console-backend/console_backend/models/message.py
+++ b/packages/console-backend/console_backend/models/message.py
@@ -30,5 +30,4 @@ class Message(BaseModel):
     state: int = TaskState.TASK_STATE_UNSPECIFIED  # Message state as A2A TaskState
     raw_payload: str = ""  # Original JSON payload
     metadata: dict[str, Any] = Field(default_factory=dict)  # Optional metadata
-    final: bool = False  # DEPRECATED: A2A 1.0.0 removes this field (kept for backward compatibility)
     kind: str = ""  # Message kind: 'message', 'status-update', etc.

--- a/packages/console-backend/console_backend/routers/group_router.py
+++ b/packages/console-backend/console_backend/routers/group_router.py
@@ -79,7 +79,7 @@ async def get_group(
         )
 
     # If not admin or group admin, hide member list
-    is_group_admin = await user_group_service.is_group_admin(db, group_id, user.id)
+    is_group_admin = await user_group_service.is_group_manager(db, group_id, user.id)
     if not user.is_administrator and not is_group_admin:
         # Return group without detailed member info
         group.members = []

--- a/packages/console-backend/console_backend/services/in_memory_messages_service.py
+++ b/packages/console-backend/console_backend/services/in_memory_messages_service.py
@@ -47,7 +47,6 @@ class InMemoryMessagesService:
         raw_payload: str = "",
         metadata: dict[str, Any] | None = None,
         message_id: str | None = None,
-        final: bool = False,
         kind: str = "",
     ) -> Message:
         now = datetime.now(timezone.utc)
@@ -67,7 +66,6 @@ class InMemoryMessagesService:
             state=state,
             raw_payload=raw_payload,
             metadata=metadata or {},
-            final=final,
             kind=kind,
         )
         self._messages.setdefault(conversation_id, []).append(msg)

--- a/packages/console-backend/console_backend/services/messages_service.py
+++ b/packages/console-backend/console_backend/services/messages_service.py
@@ -276,7 +276,6 @@ class MessagesService:
                             state=stored_state_enum,
                             raw_payload=row["raw_payload"] or "",
                             metadata=row["metadata"] or {},
-                            final=row["final"] or False,
                             kind=row["kind"] or "",
                         )
                     )
@@ -305,7 +304,6 @@ class MessagesService:
         raw_payload: str = "",
         metadata: dict[str, Any] | None = None,
         message_id: str | None = None,
-        final: bool = False,  # DEPRECATED: A2A 1.0.0 removes this field
         kind: str = "",
         created_at: datetime | None = None,
     ) -> Message:
@@ -322,7 +320,6 @@ class MessagesService:
             raw_payload: Original JSON payload (optional)
             metadata: Optional metadata dictionary
             message_id: Optional message ID (will be generated if not provided)
-            final: DEPRECATED - A2A 1.0.0 removes this field (terminal states indicate finality)
             kind: Message kind ('message', 'status-update', etc.) (optional)
 
         Returns:
@@ -359,7 +356,6 @@ class MessagesService:
             state=state,
             raw_payload=raw_payload,
             metadata=metadata or {},
-            final=final,
             kind=kind,
         )
 
@@ -369,9 +365,9 @@ class MessagesService:
                     text(
                         "INSERT INTO messages "
                         "(conversation_id, message_id, sort_key, user_id, role, parts, "
-                        "task_id, created_at, state, raw_payload, metadata, kind, final) "
+                        "task_id, created_at, state, raw_payload, metadata, kind) "
                         "VALUES (:conversation_id, :message_id, :sort_key, :user_id, :role, CAST(:parts AS jsonb), "
-                        ":task_id, :created_at, :state, :raw_payload, CAST(:metadata AS jsonb), :kind, :final) "
+                        ":task_id, :created_at, :state, :raw_payload, CAST(:metadata AS jsonb), :kind) "
                         "ON CONFLICT (message_id) DO UPDATE SET "
                         "conversation_id = EXCLUDED.conversation_id, "
                         "sort_key = EXCLUDED.sort_key, "
@@ -382,8 +378,7 @@ class MessagesService:
                         "state = EXCLUDED.state, "
                         "raw_payload = EXCLUDED.raw_payload, "
                         "metadata = EXCLUDED.metadata, "
-                        "kind = EXCLUDED.kind, "
-                        "final = EXCLUDED.final"
+                        "kind = EXCLUDED.kind"
                     ),
                     {
                         "conversation_id": conversation_id,
@@ -398,7 +393,6 @@ class MessagesService:
                         "raw_payload": raw_payload,
                         "metadata": json.dumps(metadata or {}, default=str),
                         "kind": kind,
-                        "final": final,
                     },
                 )
                 await db.commit()

--- a/packages/console-backend/console_backend/services/playbook_service.py
+++ b/packages/console-backend/console_backend/services/playbook_service.py
@@ -530,10 +530,10 @@ class PlaybookService:
         return None
 
     def _extract_title_and_description(self, content: str) -> tuple[str, str]:
-        """Extract title (name) and description from a skill file.
+        """Extract title (name) and description from a SKILL.md file.
 
-        Supports both SKILL.md frontmatter format (preferred) and legacy
-        markdown heading format (fallback for old skills).
+        Reads the required ``name`` and ``description`` fields from YAML
+        frontmatter. Returns empty strings when no frontmatter is present.
 
         Args:
             content: Full skill file content
@@ -541,7 +541,6 @@ class PlaybookService:
         Returns:
             Tuple of (title/name, description)
         """
-        # Try YAML frontmatter first
         stripped = content.strip()
         if stripped.startswith("---"):
             parts = stripped.split("---", 2)
@@ -555,20 +554,7 @@ class PlaybookService:
                 except yaml.YAMLError:
                     pass
 
-        # Legacy: extract from markdown headings
-        title = ""
-        description = ""
-        lines = content.split("\n")
-
-        for line in lines:
-            stripped_line = line.strip()
-            if not title and stripped_line.startswith("# "):
-                title = stripped_line[2:].strip()
-            elif title and not description and stripped_line and not stripped_line.startswith("#"):
-                description = stripped_line
-                break
-
-        return title, description
+        return "", ""
 
 
 def _to_jsonb(content: str, encoding: str | None = None) -> str:

--- a/packages/console-backend/console_backend/services/skill_activation_service.py
+++ b/packages/console-backend/console_backend/services/skill_activation_service.py
@@ -322,7 +322,6 @@ class SkillActivationService:
         sub_agent_id: int,
         agent_name: str,
         actor: "User | None" = None,
-        user_id: str | None = None,
     ) -> bool:
         """Auto-update the calling agent's own activation after a registry edit.
 
@@ -338,7 +337,6 @@ class SkillActivationService:
             sub_agent_id: Target sub-agent ID
             agent_name: Sub-agent name (for docstore keys)
             actor: User performing the update (required for sub-agent activations)
-            user_id: Deprecated — use actor instead. Falls back for docstore writes.
 
         Returns:
             True if an activation was updated, False if no activation exists
@@ -363,7 +361,7 @@ class SkillActivationService:
             return False
 
         new_hash = registry.content_hash
-        effective_user_id = actor.id if actor else user_id
+        effective_user_id = actor.id if actor else None
 
         for act in activations:
             # Update activation hash

--- a/packages/console-backend/console_backend/services/user_group_service.py
+++ b/packages/console-backend/console_backend/services/user_group_service.py
@@ -1196,10 +1196,6 @@ class UserGroupService:
             logger.error(f"Failed to check group membership: {e}")
             return False
 
-    async def is_group_admin(self, db: AsyncSession, group_id: int, user_id: str) -> bool:
-        """Backward compatibility alias for is_group_manager."""
-        return await self.is_group_manager(db, group_id, user_id)
-
     async def check_user_permission(self, db: AsyncSession, user_id: str, resource: str, action: str) -> bool:
         """Check if a user has a specific permission based on their system role.
 

--- a/packages/console-backend/sqlmigrations/ddl/060_drop_final_from_messages.sql
+++ b/packages/console-backend/sqlmigrations/ddl/060_drop_final_from_messages.sql
@@ -1,0 +1,8 @@
+-- rambler up
+-- A2A 1.0.0 removed the message-level `final` flag; terminal TaskStates now
+-- indicate finality. Drop the now-unused column.
+ALTER TABLE messages DROP COLUMN final;
+-- rambler down
+-- Restore the `final` column (defaults to FALSE for existing rows).
+ALTER TABLE messages
+ADD COLUMN final BOOLEAN NOT NULL DEFAULT FALSE;

--- a/packages/console-backend/tests/test_messages_service_unit.py
+++ b/packages/console-backend/tests/test_messages_service_unit.py
@@ -44,7 +44,6 @@ async def test_save_agent_response_nested_and_flat_formats():
             raw_payload=kwargs.get("raw_payload", ""),
             metadata=kwargs.get("metadata", {}),
             ttl=0,
-            final=kwargs.get("final", False),
             kind=kwargs.get("kind", ""),
         )
 
@@ -233,7 +232,6 @@ async def test_save_agent_response_with_history():
             raw_payload=kwargs["raw_payload"],
             metadata=kwargs["metadata"],
             ttl=0,
-            final=False,  # A2A 1.0.0: final field removed from protocol
             kind=kwargs["kind"],
         )
 

--- a/packages/console-backend/tests/test_skill_activation_service.py
+++ b/packages/console-backend/tests/test_skill_activation_service.py
@@ -346,7 +346,7 @@ class TestSelfUpdate:
             registry_id=registry_id,
             sub_agent_id=agent_id,
             agent_name="test-agent",
-            user_id=user_id,
+            actor=MagicMock(id=user_id),
         )
         await pg_session.commit()
 
@@ -372,7 +372,7 @@ class TestSelfUpdate:
             registry_id=registry_id,
             sub_agent_id=agent_id,
             agent_name="test-agent",
-            user_id=user_id,
+            actor=MagicMock(id=user_id),
         )
         assert result is False
 

--- a/packages/console-backend/tests/test_socket_message_handling.py
+++ b/packages/console-backend/tests/test_socket_message_handling.py
@@ -233,21 +233,21 @@ async def test_conversation_title_with_unicode_characters():
     assert "🌍" in title or "🚀" in title  # Emojis might be truncated depending on char count
 
 
-def test_legacy_state_name_normalizes_v1_states():
+def test_short_state_name_normalizes_v1_states():
     """v1.0 ProtoJSON TaskState names normalize to the short forms the backend branches on.
 
     The outbound payload is now emitted as raw v1.0 (the frontend handles it natively),
     but the backend's turn-ending / is_bare_completion_signal control-flow still keys off
-    the short state strings. _legacy_state_name bridges that — if it stops mapping
+    the short state strings. _short_state_name bridges that — if it stops mapping
     TASK_STATE_COMPLETED -> "completed", is_bare_completion_signal misfires and the reply
     is persisted/rendered twice.
     """
-    from app import _legacy_state_name
+    from app import _short_state_name
 
-    assert _legacy_state_name("TASK_STATE_COMPLETED") == "completed"
-    assert _legacy_state_name("TASK_STATE_INPUT_REQUIRED") == "input-required"
-    assert _legacy_state_name("TASK_STATE_FAILED") == "failed"
-    assert _legacy_state_name("TASK_STATE_CANCELED") == "canceled"
-    # Already-short (legacy) values and non-strings pass through untouched.
-    assert _legacy_state_name("completed") == "completed"
-    assert _legacy_state_name(None) is None
+    assert _short_state_name("TASK_STATE_COMPLETED") == "completed"
+    assert _short_state_name("TASK_STATE_INPUT_REQUIRED") == "input-required"
+    assert _short_state_name("TASK_STATE_FAILED") == "failed"
+    assert _short_state_name("TASK_STATE_CANCELED") == "canceled"
+    # Already-short values and non-strings pass through untouched.
+    assert _short_state_name("completed") == "completed"
+    assert _short_state_name(None) is None

--- a/packages/console-backend/tests/test_user_management.py
+++ b/packages/console-backend/tests/test_user_management.py
@@ -648,9 +648,9 @@ class TestUserGroupService:
             db=pg_session, group_id=group.id, user_ids=[member_user.id], role="read", actor=test_user
         )
 
-        assert await user_group_service.is_group_admin(pg_session, group.id, admin_user.id) is True
-        assert await user_group_service.is_group_admin(pg_session, group.id, member_user.id) is False
-        assert await user_group_service.is_group_admin(pg_session, group.id, "non-member") is False
+        assert await user_group_service.is_group_manager(pg_session, group.id, admin_user.id) is True
+        assert await user_group_service.is_group_manager(pg_session, group.id, member_user.id) is False
+        assert await user_group_service.is_group_manager(pg_session, group.id, "non-member") is False
 
     async def test_is_group_member(
         self, user_service: UserService, user_group_service: UserGroupService, pg_session: AsyncSession

--- a/packages/orchestrator-agent/app/core/agent.py
+++ b/packages/orchestrator-agent/app/core/agent.py
@@ -29,7 +29,7 @@ from agent_common.backends.attachments_store import (
     set_current_attachments_backend,
 )
 from agent_common.middleware.ptc_guard import PTC_CODE_INTERPRETER_TOOL_NAME
-from agent_common.models.base import DEFAULT_MODEL, DEFAULT_THINKING_LEVEL, ModelType, ThinkingLevel
+from agent_common.models.base import DEFAULT_THINKING_LEVEL, ModelType, ThinkingLevel, get_resolved_default_model
 from langchain.messages import HumanMessage
 from langchain_core.messages import AIMessageChunk
 from langgraph.errors import GraphRecursionError
@@ -136,7 +136,7 @@ class OrchestratorDeepAgent:
     ):
         self.config = AgentSettings()
         self._default_thinking_level: ThinkingLevel | None = thinking_level or DEFAULT_THINKING_LEVEL
-        self._default_model_type: ModelType = model or DEFAULT_MODEL
+        self._default_model_type: ModelType = model or get_resolved_default_model()
 
         # Initialize GraphFactory - centralizes all graph-related concerns
         # (model creation, checkpointer, middleware, graph caching)

--- a/packages/orchestrator-agent/app/core/graph_factory.py
+++ b/packages/orchestrator-agent/app/core/graph_factory.py
@@ -38,7 +38,7 @@ from agent_common.middleware.conversation_context_tools_middleware import Conver
 from agent_common.middleware.steering_middleware import SteeringMiddleware
 from agent_common.middleware.storage_paths_middleware import StoragePathsInstructionMiddleware
 from agent_common.middleware.tool_status import ToolStatusMiddleware
-from agent_common.models.base import DEFAULT_MODEL, ModelType, ThinkingLevel
+from agent_common.models.base import ModelType, ThinkingLevel, get_resolved_default_model
 from deepagents import create_deep_agent
 from langchain.agents import create_agent
 from langchain.agents.middleware import ToolRetryMiddleware
@@ -723,12 +723,12 @@ class GraphFactory:
         """Get or create a graph for the given model type.
 
         Args:
-            model_type: The type of model (defaults to DEFAULT_MODEL)
+            model_type: The type of model (defaults to the resolved default model)
 
         Returns:
             CompiledStateGraph: The graph instance (cached or newly created)
         """
-        effective_model: ModelType = model_type or DEFAULT_MODEL
+        effective_model: ModelType = model_type or get_resolved_default_model()
 
         cache_key = (effective_model, thinking_level)
 

--- a/packages/ringier-a2a-sdk/ringier_a2a_sdk/agent/langgraph.py
+++ b/packages/ringier-a2a-sdk/ringier_a2a_sdk/agent/langgraph.py
@@ -365,9 +365,7 @@ class LangGraphAgent(BaseAgent):
         interface_json = json.dumps(interface_data, sort_keys=True)
         return hashlib.sha256(interface_json.encode()).hexdigest()
 
-    async def _check_mcp_interface_changed(
-        self, server_name: str, tools: list[BaseTool], server_info: dict | None = None
-    ) -> bool:
+    async def _check_mcp_interface_changed(self, server_name: str, tools: list[BaseTool]) -> bool:
         """Check if MCP server interface has changed since last discovery.
 
         Uses tool interface hash (names and schemas) for reliable change detection.
@@ -379,7 +377,6 @@ class LangGraphAgent(BaseAgent):
         Args:
             server_name: Name of the MCP server
             tools: List of tools discovered from the server
-            server_info: Unused (kept for compatibility), hash comparison is reliable
 
         Returns:
             True if interface changed (refresh needed), False if unchanged

--- a/packages/ringier-a2a-sdk/ringier_a2a_sdk/agent/langgraph_anthropic.py
+++ b/packages/ringier-a2a-sdk/ringier_a2a_sdk/agent/langgraph_anthropic.py
@@ -12,7 +12,7 @@ from langchain_core.language_models import BaseChatModel
 from pydantic import SecretStr
 
 from .dynamodb_checkpointer_mixin import DynamoDBCheckpointerMixin
-from .langgraph import FinalResponseSchema, LangGraphAgent  # noqa: F401
+from .langgraph import LangGraphAgent
 
 logger = logging.getLogger(__name__)
 

--- a/packages/ringier-a2a-sdk/ringier_a2a_sdk/agent/langgraph_bedrock.py
+++ b/packages/ringier-a2a-sdk/ringier_a2a_sdk/agent/langgraph_bedrock.py
@@ -48,10 +48,6 @@ def _get_thinking_budget(thinking_level: str) -> int:
     return budget_map.get(thinking_level, 4096)
 
 
-# Re-export FinalResponseSchema from langgraph module for backward compatibility
-from .langgraph import FinalResponseSchema  # noqa: F401, E402
-
-
 class LangGraphBedrockAgent(DynamoDBCheckpointerMixin, LangGraphAgent):
     """LangGraph agent using AWS Bedrock and DynamoDB checkpointing.
 

--- a/packages/ringier-a2a-sdk/ringier_a2a_sdk/agent/langgraph_google.py
+++ b/packages/ringier-a2a-sdk/ringier_a2a_sdk/agent/langgraph_google.py
@@ -21,9 +21,6 @@ from .langgraph import LangGraphAgent
 
 logger = logging.getLogger(__name__)
 
-# Re-export FinalResponseSchema for backward compatibility
-from .langgraph import FinalResponseSchema  # noqa: F401, E402
-
 
 class LangGraphGoogleGenAIAgent(DynamoDBCheckpointerMixin, LangGraphAgent):
     """LangGraph agent using Google Generative AI (Gemini) and DynamoDB checkpointing.

--- a/packages/ringier-a2a-sdk/ringier_a2a_sdk/cost_tracking/callback.py
+++ b/packages/ringier-a2a-sdk/ringier_a2a_sdk/cost_tracking/callback.py
@@ -48,7 +48,8 @@ class CostTrackingCallback(BaseCallbackHandler):
             logger.info("[COST TRACKING] on_llm_end callback invoked")
             for generation_list in response.generations:
                 for generation in generation_list:
-                    message = generation.message
+                    # Only chat generations carry a `.message`; base Generation does not.
+                    message = getattr(generation, "message", None)
 
                     # Extract usage metadata if available
                     if not hasattr(message, "usage_metadata") or not message.usage_metadata:

--- a/packages/ringier-a2a-sdk/ringier_a2a_sdk/oauth/base.py
+++ b/packages/ringier-a2a-sdk/ringier_a2a_sdk/oauth/base.py
@@ -79,7 +79,9 @@ class BaseOAuth2Client:
                     logger.info(f"Discovered OIDC metadata for {self.issuer}")
             except httpx.HTTPError as e:
                 logger.error(
-                    f"HTTP error fetching OIDC metadata: status={getattr(e.response, 'status_code', 'N/A')}, url={well_known_url}, error={e}"
+                    f"HTTP error fetching OIDC metadata: "
+                    f"status={getattr(getattr(e, 'response', None), 'status_code', 'N/A')}, "
+                    f"url={well_known_url}, error={e}"
                 )
                 raise OAuthError(f"Failed to fetch OIDC metadata from {well_known_url}: {e}") from e
             except Exception as e:

--- a/packages/ringier-a2a-sdk/ringier_a2a_sdk/utils/schema_cleaning.py
+++ b/packages/ringier-a2a-sdk/ringier_a2a_sdk/utils/schema_cleaning.py
@@ -136,8 +136,6 @@ def clean_schema_properties(
     level: CleanupLevel = CleanupLevel.MINIMAL,
     tool_name: str | None = None,
     _path: str = "",
-    # Legacy positional arg — older callers pass depth: int as 4th arg
-    depth: int = 0,
 ) -> dict[str, Any]:
     """Recursively remove invalid property schemas with progressive cleanup levels.
 

--- a/packages/ringier-a2a-sdk/tests/test_mcp_refresh.py
+++ b/packages/ringier-a2a-sdk/tests/test_mcp_refresh.py
@@ -354,21 +354,18 @@ async def test_check_mcp_interface_changed_detects_version_change(mock_langgraph
 
     # First check should store the version and return False (no change)
     changed = await mock_langgraph_agent._check_mcp_interface_changed(
-        server_name="test_server", tools=tools, server_info={"version": "1.0"}
-    )
+        server_name="test_server", tools=tools    )
     assert not changed, "First check should store version without detecting change"
 
     # Second check with same tools should return False
     changed = await mock_langgraph_agent._check_mcp_interface_changed(
-        server_name="test_server", tools=tools, server_info={"version": "1.0"}
-    )
+        server_name="test_server", tools=tools    )
     assert not changed, "Same tools should not be detected as changed"
 
     # Third check with changed tool (simulating a version bump) should return True
     tool.description = "Test tool v1.1"
     changed = await mock_langgraph_agent._check_mcp_interface_changed(
-        server_name="test_server", tools=tools, server_info={"version": "1.1"}
-    )
+        server_name="test_server", tools=tools    )
     assert changed, "Version change should be detected"
 
 
@@ -386,16 +383,14 @@ async def test_check_mcp_interface_changed_detects_schema_change(mock_langgraph_
 
     # First check should store the hash and return False
     changed = await mock_langgraph_agent._check_mcp_interface_changed(
-        server_name="test_server", tools=tools_v1, server_info={"version": "1.0"}
-    )
+        server_name="test_server", tools=tools_v1    )
     assert not changed, "First check should store hash without detecting change"
 
     # Second check with modified tool should detect change
     tool1.description = "Modified description"
 
     changed = await mock_langgraph_agent._check_mcp_interface_changed(
-        server_name="test_server", tools=tools_v1, server_info={"version": "1.0"}
-    )
+        server_name="test_server", tools=tools_v1    )
     assert changed, "Tool description change should be detected"
 
 
@@ -435,8 +430,7 @@ async def test_refresh_worker_skips_rebuild_when_no_changes(mock_langgraph_agent
 
     # Store initial hash
     await mock_langgraph_agent._check_mcp_interface_changed(
-        server_name="test_server", tools=[tool], server_info={"version": "1.0"}
-    )
+        server_name="test_server", tools=[tool]    )
 
     # Mock interval for fast testing
     mock_langgraph_agent._mcp_refresh_interval_seconds = 0.05


### PR DESCRIPTION
Clean up backward-compat shims and deprecated fields ahead of the v1 release, now that the A2A 1.0.0 migration has landed.

- Drop the message-level `final` flag: removed from the `messages` table (migration 060), the console-backend `Message` model, and the message services. Finality is now derived from terminal A2A TaskStates.
- Remove the `DEFAULT_MODEL` back-compat constant from agent-common; use `get_resolved_default_model()` for runtime resolution that respects available credentials.
- Prune deprecated/legacy code paths across agent-common (playbook reader, skill frontmatter, copy_file tool), orchestrator-agent, and the ringier-a2a-sdk (langgraph providers, oauth, schema cleaning, cost tracking), updating the affected tests.

The two A2A clients keep their legacy base64 (FileWithBytes) fallback for attachments without S3 URLs.

BREAKING CHANGE: the `messages.final` column and `Message.final` field are removed; consumers must read finality from the A2A TaskState. The `DEFAULT_MODEL` constant is removed in favor of get_resolved_default_model().

closes #

## Checklist
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨
