### PR TITLE
refactor: drop legacy store-schema cleanup before v1

### DIFF
--- a/packages/orchestrator-agent/app/core/graph_factory.py
+++ b/packages/orchestrator-agent/app/core/graph_factory.py
@@ -317,46 +317,7 @@ class GraphFactory:
                 await self._connection_pool.open()
                 logger.info("Opened AsyncConnectionPool for document store")
 
-            # Check if store table exists with incompatible schema and clean it up
-            try:
-                from langgraph.checkpoint.postgres import _ainternal
-
-                async with _ainternal.get_connection(store.conn) as conn:
-                    async with conn.cursor() as cur:
-                        # Check if store table exists
-                        await cur.execute("""
-                            SELECT EXISTS (
-                                SELECT FROM information_schema.tables 
-                                WHERE table_name = 'store'
-                            )
-                        """)
-                        table_exists = (await cur.fetchone())[0]
-
-                        if table_exists:
-                            # Check if prefix column exists
-                            await cur.execute("""
-                                SELECT EXISTS (
-                                    SELECT FROM information_schema.columns 
-                                    WHERE table_name = 'store' AND column_name = 'prefix'
-                                )
-                            """)
-                            has_prefix = (await cur.fetchone())[0]
-
-                            if not has_prefix:
-                                # Drop incompatible table and related objects
-                                logger.warning("Found incompatible 'store' table schema, dropping and recreating...")
-                                await cur.execute("DROP TABLE IF EXISTS store CASCADE")
-                                await cur.execute("DROP TABLE IF EXISTS store_migrations CASCADE")
-                                await cur.execute("DROP TABLE IF EXISTS vector_migrations CASCADE")
-                                await cur.execute("DROP TABLE IF EXISTS store_vectors CASCADE")
-                                await conn.commit()
-                                logger.info("Dropped incompatible schema objects")
-
-            except Exception as e:
-                logger.error(f"Error checking/cleaning store schema: {e}")
-                # Continue anyway - setup() will handle it
-
-            # Now run the standard setup
+            # Set up the schema (idempotent; safe to call repeatedly)
             await store.setup()
             self._store_setup_complete = True
             logger.info("AsyncPostgresStore schema setup completed successfully")


### PR DESCRIPTION
## What

Removes the incompatible-schema detection/cleanup block from `GraphFactory.ensure_store_setup()`. `store.setup()` now owns schema provisioning directly.

## Why

Two independent reasons this guard should go for v1:

1. **It never ran.** The block indexed `dict_row` cursor rows positionally — `(await cur.fetchone())[0]` — which raises `KeyError(0)` (the connection pool uses `row_factory: dict_row`). The bare `except` swallowed it, logging the cryptic `Error checking/cleaning store schema: 0` on **every** startup since the initial commit. A guard that has thrown on every boot and never executed its cleanup branch cannot be load-bearing.

2. **This codebase can't have created the schema it guards against.** The block drops a legacy `store` table missing the `prefix` column — the *old* langgraph PostgresStore layout. But we're pinned to `langgraph-checkpoint-postgres>=2.0.11` and were born on 2.x, whose schema already has `prefix`. So we never wrote a pre-`prefix` table ourselves.

This is the same class of pre-1.0 migration shim removed in #72 (A2A deprecations). `store.setup()` is idempotent and safe to call repeatedly.

## Risk

Low. If a long-lived deployed DB somehow still carried a pre-`prefix` `store` table, it would already be broken today (the guard never fired). If in doubt, verify with `\d store` for a `prefix` column rather than re-running this on every boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)