### PR TITLE
fix: drop uvicorn color_message field from orchestrator JSON logs

### DIFF
--- a/packages/orchestrator-agent/log_conf.yml
+++ b/packages/orchestrator-agent/log_conf.yml
@@ -7,12 +7,39 @@ formatters:
     rename_fields:
       levelname: level
       asctime: time
+    # Drop uvicorn's ANSI-colored duplicate of the message from the JSON output.
+    reserved_attrs: &reserved_attrs
+      - args
+      - asctime
+      - created
+      - exc_info
+      - exc_text
+      - filename
+      - funcName
+      - levelname
+      - levelno
+      - lineno
+      - message
+      - module
+      - msecs
+      - msg
+      - name
+      - pathname
+      - process
+      - processName
+      - relativeCreated
+      - stack_info
+      - taskName
+      - thread
+      - threadName
+      - color_message
   access:
     "()": "rcplus_alloy_common.logging.CustomJsonFormatter"
     fmt: "%(asctime)s %(levelname)s %(name)s %(message)s"
     rename_fields:
       levelname: level
       asctime: time
+    reserved_attrs: *reserved_attrs
 handlers:
   default:
     formatter: default


### PR DESCRIPTION
## What

Uvicorn attaches an ANSI-colored duplicate of each log message via `extra={"color_message": ...}` (unconditionally — `use_colors` does not gate it). Our `CustomJsonFormatter` serializes every non-reserved record attribute, so this leaked a raw escape-code string into the JSON logs, e.g.:

```json
{"time": "...", "level": "INFO", "name": "uvicorn.error", "message": "Started server process [33581]", "color_message": "Started server process [[36m%d[0m]"}
```

## Change

Add `color_message` to the formatters' `reserved_attrs` so it is excluded from the output. Since passing `reserved_attrs` *replaces* python-json-logger's default reserved set rather than extending it, the full default list is reproduced and `color_message` appended; the `access` formatter reuses it via a YAML anchor.

## Verification

Loading the config and emitting a record with the `color_message` extra now yields:

```json
{"time": "2026-06-17T12:15:35.469Z", "level": "INFO", "name": "uvicorn.error", "message": "Started server process [33581]"}
```

> Note: `reserved_attrs` is now a copy of a library-internal default. If `python-json-logger` changes that default in a future upgrade, this list will need to be kept in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)