### PR TITLE
fix: normalize orchestrator thinking_level to plain string for checkpoint serde

### DIFF
--- a/packages/orchestrator-agent/app/core/executor.py
+++ b/packages/orchestrator-agent/app/core/executor.py
@@ -22,7 +22,7 @@ from a2a.types import (
     TaskStatusUpdateEvent,
 )
 from agent_common.a2a.client_runnable import A2AClientRunnable
-from agent_common.models.base import ModelType
+from agent_common.models.base import ModelType, ThinkingLevel
 from pydantic import SecretStr
 from ringier_a2a_sdk.cost_tracking.logger import set_request_access_token
 from ringier_a2a_sdk.server.executor import (
@@ -532,6 +532,16 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
                 thinking_level = user_config.thinking_level
             elif user_config.enable_thinking is None:
                 thinking_level = self.agent._default_thinking_level
+
+            # Normalize to a plain string. thinking_level may be a ThinkingLevel enum
+            # (str-Enum) here, and it gets stored in config["metadata"] below, which
+            # LangGraph persists into the checkpoint. Serializing the enum triggers a
+            # "Deserializing unregistered type ... ThinkingLevel" warning from the
+            # msgpack serde on read-back. The plain value works identically downstream
+            # (get_thinking_budget's map and the model factory accept the string) and
+            # keeps the graph cache key consistent across resolution paths.
+            if isinstance(thinking_level, ThinkingLevel):
+                thinking_level = thinking_level.value
 
             model_type = user_config.model if user_config.model else self.agent._default_model_type
             graph = await self.agent.get_or_create_graph(


### PR DESCRIPTION
## Problem

The orchestrator emitted a recurring warning on checkpoint read-back:

```
Deserializing unregistered type agent_common.models.base.ThinkingLevel from checkpoint.
This will be blocked in a future version.
```

`ThinkingLevel` is a `str`-Enum. The resolved `thinking_level` is stored in `config["metadata"]` (`executor.py`), which LangGraph persists into the checkpoint. Two of the resolution branches assigned a `ThinkingLevel` **enum** instance (`user_config.thinking_level`, pydantic-coerced; and `self.agent._default_thinking_level`) rather than a plain string, so the msgpack serde flagged it as an unregistered custom type.

## Fix

Normalize the resolved `thinking_level` to its plain string value before it is used:

```python
if isinstance(thinking_level, ThinkingLevel):
    thinking_level = thinking_level.value
```

- **Safe downstream** — `get_thinking_budget`'s `budget_map` is keyed by plain strings, and the model factory accepts the string equally.
- **Consistency bonus** — the `(model_type, thinking_level)` graph cache key is now uniform; previously it mixed `"low"` strings (the no-level default path) with enum instances.

## Caveat

This stops the warning for **new** checkpoints. Threads whose checkpoints were written before this change still carry the persisted enum, so resuming an old conversation may emit the warning once until that checkpoint ages out. It's non-fatal in either case. A complementary option is registering the module via LangGraph's `allowed_msgpack_modules` where the `DynamoDBSaver` is constructed (`graph_factory.py`) — not included here.

## Testing

- `tests/test_thinking_level.py` — 13 passed
- `tests/test_orchestrator_thinking_integration.py` — 8 passed
- `tests/test_agent_executor.py` — 31 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)