### PR TITLE
feat(console): enable/disable sub-agents from the card + scope/activation filters

### DIFF
--- a/packages/console-frontend/src/components/subagents/SubAgentCard.tsx
+++ b/packages/console-frontend/src/components/subagents/SubAgentCard.tsx
@@ -1,7 +1,16 @@
 import { useState } from 'react';
-import { Bot, Globe, Terminal, Users, Database, User, Shield, UsersRound } from 'lucide-react';
+import { Bot, Globe, Terminal, Users, Database, Shield, UsersRound } from 'lucide-react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import {
+  consoleListSubAgentsOptions,
+  activateSubAgentApiV1SubAgentsSubAgentIdActivatePostMutation,
+  deactivateSubAgentApiV1SubAgentsSubAgentIdDeactivatePostMutation,
+} from '@/api/generated/@tanstack/react-query.gen';
 import { SubAgentPermissionsDialog } from './SubAgentPermissionsDialog';
 import { useAuth } from '@/contexts/AuthContext';
 import type { SubAgentListItem, SubAgentStatus } from './types';
@@ -22,7 +31,41 @@ interface SubAgentCardProps {
 
 export function SubAgentCard({ subAgent, onClick, showOwner = true, showManageAccess = false }: SubAgentCardProps) {
   const { user, adminMode } = useAuth();
+  const queryClient = useQueryClient();
   const [showPermissionsDialog, setShowPermissionsDialog] = useState(false);
+
+  const invalidateList = () => {
+    queryClient.invalidateQueries({ queryKey: consoleListSubAgentsOptions({}).queryKey });
+    queryClient.invalidateQueries({ queryKey: consoleListSubAgentsOptions({ query: { owned_only: true } }).queryKey });
+  };
+
+  const activateMutation = useMutation({
+    ...activateSubAgentApiV1SubAgentsSubAgentIdActivatePostMutation(),
+    onSuccess: () => {
+      toast.success('Sub-agent enabled');
+      invalidateList();
+    },
+    onError: () => toast.error('Failed to enable sub-agent'),
+  });
+
+  const deactivateMutation = useMutation({
+    ...deactivateSubAgentApiV1SubAgentsSubAgentIdDeactivatePostMutation(),
+    onSuccess: () => {
+      toast.success('Sub-agent disabled');
+      invalidateList();
+    },
+    onError: () => toast.error('Failed to disable sub-agent'),
+  });
+
+  const isToggling = activateMutation.isPending || deactivateMutation.isPending;
+
+  const handleToggleActivation = () => {
+    if (subAgent.is_activated) {
+      deactivateMutation.mutate({ path: { sub_agent_id: subAgent.id } });
+    } else {
+      activateMutation.mutate({ path: { sub_agent_id: subAgent.id } });
+    }
+  };
   
   // Get status from embedded config_version
   const status = subAgent.config_version?.status ?? 'draft';
@@ -65,6 +108,20 @@ export function SubAgentCard({ subAgent, onClick, showOwner = true, showManageAc
     e.stopPropagation();
     setShowPermissionsDialog(true);
   };
+
+  const activationControl = (
+    <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+      <span className="text-xs text-muted-foreground">
+        {subAgent.is_activated ? 'Enabled' : 'Disabled'}
+      </span>
+      <Switch
+        checked={subAgent.is_activated ?? false}
+        onCheckedChange={handleToggleActivation}
+        disabled={!isApproved || isToggling}
+        aria-label={`Enable ${subAgent.name}`}
+      />
+    </div>
+  );
 
   return (
     <>
@@ -118,8 +175,8 @@ export function SubAgentCard({ subAgent, onClick, showOwner = true, showManageAc
           <p className="text-sm text-muted-foreground line-clamp-2">{subAgent.config_version.description}</p>
         )}
 
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3 text-xs text-muted-foreground">
+        <div className="mt-auto flex items-center justify-between text-xs text-muted-foreground">
+          <div className="flex items-center gap-3">
             <span className="flex items-center gap-1">
               <TypeIcon className="h-3 w-3" />
               <span className="capitalize">{subAgent.type}</span>
@@ -129,48 +186,51 @@ export function SubAgentCard({ subAgent, onClick, showOwner = true, showManageAc
                 🤖 Automated
               </Badge>
             )}
-            {subAgent.activated_by && (
-              <>
-                {subAgent.activated_by === 'user' && (
-                  <Badge variant="outline" className="flex items-center gap-1 text-xs">
-                    <User className="h-3 w-3" />
-                    Self-enabled
-                  </Badge>
+            {subAgent.activated_by === 'group' && (
+              <Badge variant="secondary" className="flex items-center gap-1 text-xs">
+                <UsersRound className="h-3 w-3" />
+                Group default
+                {subAgent.activated_by_groups && subAgent.activated_by_groups.length > 0 && (
+                  <span className="ml-1">({subAgent.activated_by_groups.length})</span>
                 )}
-                {subAgent.activated_by === 'group' && (
-                  <Badge variant="secondary" className="flex items-center gap-1 text-xs">
-                    <UsersRound className="h-3 w-3" />
-                    Group default
-                    {subAgent.activated_by_groups && subAgent.activated_by_groups.length > 0 && (
-                      <span className="ml-1">({subAgent.activated_by_groups.length})</span>
-                    )}
-                  </Badge>
-                )}
-                {subAgent.activated_by === 'admin' && (
-                  <Badge variant="default" className="flex items-center gap-1 text-xs">
-                    <Shield className="h-3 w-3" />
-                    Admin-enabled
-                  </Badge>
-                )}
-              </>
+              </Badge>
+            )}
+            {subAgent.activated_by === 'admin' && (
+              <Badge variant="default" className="flex items-center gap-1 text-xs">
+                <Shield className="h-3 w-3" />
+                Admin-enabled
+              </Badge>
             )}
           </div>
-          <div className="flex items-center gap-1">
-            {canManageAccess && (
-              <Button
-                variant="ghost"
-                size="sm"
-                className="opacity-0 group-hover:opacity-100 transition-opacity"
-                onClick={handleManageAccessClick}
-                title="Manage group access"
-              >
-                <Users className="h-4 w-4" />
-              </Button>
-            )}
-            <Button variant="ghost" size="sm" className="opacity-0 group-hover:opacity-100 transition-opacity">
-              Open
-            </Button>
-          </div>
+          {canManageAccess && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="-mr-2 h-7 gap-1.5 px-2 opacity-0 group-hover:opacity-100 transition-opacity"
+                  onClick={handleManageAccessClick}
+                >
+                  <Users className="h-3.5 w-3.5" />
+                  Access
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Manage group access</TooltipContent>
+            </Tooltip>
+          )}
+        </div>
+
+        {/* Activation row — anchored to the bottom block so it aligns across all cards */}
+        <div className="-mb-1 flex items-center justify-between border-t pt-3">
+          <span className="text-xs font-medium text-foreground">Use in orchestrator</span>
+          {isApproved ? (
+            activationControl
+          ) : (
+            <Tooltip>
+              <TooltipTrigger asChild>{activationControl}</TooltipTrigger>
+              <TooltipContent>Approve a version before enabling</TooltipContent>
+            </Tooltip>
+          )}
         </div>
 
         {status === 'rejected' && subAgent.config_version?.rejection_reason && (

--- a/packages/console-frontend/src/components/subagents/SubAgentList.tsx
+++ b/packages/console-frontend/src/components/subagents/SubAgentList.tsx
@@ -12,41 +12,84 @@ import {
 import { SubAgentCard } from './SubAgentCard';
 import type { SubAgentListItem, SubAgentStatus, SubAgentType } from './types';
 
+export type ScopeFilter = 'all' | 'mine' | 'shared' | 'pending';
+
 interface SubAgentListProps {
   subAgents: SubAgentListItem[];
   onSelect: (subAgent: SubAgentListItem) => void;
   emptyMessage?: string;
   showManageAccess?: boolean;
+  currentUserId?: string;
+  scope?: ScopeFilter;
+  onScopeChange?: (scope: ScopeFilter) => void;
+  showPendingScope?: boolean;
 }
 
-export function SubAgentList({ subAgents, onSelect, emptyMessage = 'No sub-agents found', showManageAccess = false }: SubAgentListProps) {
+export function SubAgentList({
+  subAgents,
+  onSelect,
+  emptyMessage = 'No sub-agents found',
+  showManageAccess = false,
+  currentUserId,
+  scope = 'all',
+  onScopeChange,
+  showPendingScope = false,
+}: SubAgentListProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<SubAgentStatus | 'all'>('all');
   const [typeFilter, setTypeFilter] = useState<SubAgentType | 'all'>('all');
+  const [activationFilter, setActivationFilter] = useState<'all' | 'enabled' | 'disabled'>('all');
 
   const filteredSubAgents = subAgents.filter((sa) => {
     const matchesSearch =
       searchQuery === '' ||
       sa.name.toLowerCase().includes(searchQuery.toLowerCase());
 
-    const matchesStatus = statusFilter === 'all';
-    const matchesType = typeFilter === 'all' || sa.type === typeFilter;
+    // Owner facet (skipped for 'all' and the admin 'pending' approval queue)
+    const matchesScope =
+      scope === 'mine'
+        ? sa.owner_user_id === currentUserId
+        : scope === 'shared'
+          ? sa.owner_user_id !== currentUserId
+          : true;
 
-    return matchesSearch && matchesStatus && matchesType;
+    const matchesStatus =
+      statusFilter === 'all' || (sa.config_version?.status ?? 'draft') === statusFilter;
+    const matchesType = typeFilter === 'all' || sa.type === typeFilter;
+    const matchesActivation =
+      activationFilter === 'all' ||
+      (activationFilter === 'enabled' ? !!sa.is_activated : !sa.is_activated);
+
+    return matchesSearch && matchesScope && matchesStatus && matchesType && matchesActivation;
   });
 
-  const hasFilters = searchQuery !== '' || statusFilter !== 'all' || typeFilter !== 'all';
+  const hasFilters =
+    searchQuery !== '' || statusFilter !== 'all' || typeFilter !== 'all' || activationFilter !== 'all';
 
   const clearFilters = () => {
     setSearchQuery('');
     setStatusFilter('all');
     setTypeFilter('all');
+    setActivationFilter('all');
   };
 
   return (
     <div className="flex flex-col gap-4">
       {/* Filters */}
       <div className="flex flex-wrap items-center gap-3">
+        {onScopeChange && (
+          <Select value={scope} onValueChange={(v) => onScopeChange(v as ScopeFilter)}>
+            <SelectTrigger className="w-[170px]">
+              <SelectValue placeholder="Owner" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All owners</SelectItem>
+              <SelectItem value="mine">Mine</SelectItem>
+              <SelectItem value="shared">Shared with me</SelectItem>
+              {showPendingScope && <SelectItem value="pending">Pending approval</SelectItem>}
+            </SelectContent>
+          </Select>
+        )}
         <div className="relative flex-1 min-w-[200px]">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
@@ -77,6 +120,16 @@ export function SubAgentList({ subAgents, onSelect, emptyMessage = 'No sub-agent
             <SelectItem value="all">All Types</SelectItem>
             <SelectItem value="remote">Remote</SelectItem>
             <SelectItem value="local">Local</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select value={activationFilter} onValueChange={(v) => setActivationFilter(v as 'all' | 'enabled' | 'disabled')}>
+          <SelectTrigger className="w-[150px]">
+            <SelectValue placeholder="Activation" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Activation</SelectItem>
+            <SelectItem value="enabled">Enabled</SelectItem>
+            <SelectItem value="disabled">Disabled</SelectItem>
           </SelectContent>
         </Select>
         {hasFilters && (

--- a/packages/console-frontend/src/pages/SubAgentsPage.tsx
+++ b/packages/console-frontend/src/pages/SubAgentsPage.tsx
@@ -1,9 +1,9 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router';
-import { Plus, Bot, Users, Clock } from 'lucide-react';
+import { Plus } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
-import { SubAgentList } from '@/components/subagents/SubAgentList';
+import { SubAgentList, type ScopeFilter } from '@/components/subagents/SubAgentList';
 import {
   consoleListSubAgentsOptions,
   listPendingApprovalsApiV1SubAgentsPendingGetOptions,
@@ -11,77 +11,37 @@ import {
 import type { SubAgentListItem, SubAgentListResponse } from '@/api/generated/types.gen';
 import { useAuth } from '@/contexts/AuthContext';
 
-type TabId = 'my' | 'accessible' | 'pending';
-
-interface Tab {
-  id: TabId;
-  label: string;
-  icon: typeof Bot;
-  requiresAdmin?: boolean;
-}
-
-const tabs: Tab[] = [
-  { id: 'my', label: 'My Sub-Agents', icon: Bot },
-  { id: 'accessible', label: 'Accessible', icon: Users },
-  { id: 'pending', label: 'Pending Approval', icon: Clock, requiresAdmin: true },
-];
-
 export function SubAgentsPage() {
   const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState<TabId>('my');
+  const [scope, setScope] = useState<ScopeFilter>('all');
   const { user, adminMode } = useAuth();
 
-  // Reset to 'my' tab when admin mode is disabled and currently on pending tab
-  useEffect(() => {
-    if (!adminMode && activeTab === 'pending') {
-      setActiveTab('my');
-    }
-  }, [adminMode, activeTab]);
+  // Derive the effective scope so the approval queue isn't shown once admin mode is off,
+  // without resetting state in an effect.
+  const effectiveScope: ScopeFilter = !adminMode && scope === 'pending' ? 'all' : scope;
 
-  // Fetch owned sub-agents
-  const { data: ownedData } = useQuery({
-    ...consoleListSubAgentsOptions({
-      query: { owned_only: true },
-    }),
-    enabled: activeTab === 'my',
-  });
-
-  // Fetch all accessible sub-agents (for 'accessible' tab)
-  const { data: accessibleData } = useQuery({
+  // Full list (owned + shared) — owner faceting happens client-side in SubAgentList
+  const { data: listData } = useQuery({
     ...consoleListSubAgentsOptions({}),
-    enabled: activeTab === 'accessible',
+    enabled: effectiveScope !== 'pending',
   });
 
-  // Fetch pending approvals (admin mode only)
+  // Approval queue (admin only) — a distinct dataset surfaced via the 'pending' scope
   const { data: pendingData } = useQuery({
     ...listPendingApprovalsApiV1SubAgentsPendingGetOptions(),
-    enabled: activeTab === 'pending' && adminMode,
+    enabled: effectiveScope === 'pending' && adminMode,
   });
 
-  // Show pending tab only when admin mode is active
-  const visibleTabs = tabs.filter(
-    (tab) => !tab.requiresAdmin || adminMode
-  );
-
-  const getSubAgentsForTab = (): SubAgentListItem[] => {
-    switch (activeTab) {
-      case 'my':
-        return (ownedData as SubAgentListResponse)?.items ?? [];
-      case 'accessible':
-        // Filter out owned sub-agents from accessible list
-        return ((accessibleData as SubAgentListResponse)?.items ?? []).filter((sa: any) => sa.owner_user_id !== user?.id);
-      case 'pending':
-        return (pendingData as SubAgentListResponse)?.items ?? [];
-      default:
-        return [];
-    }
-  };
+  const subAgents: SubAgentListItem[] =
+    effectiveScope === 'pending'
+      ? (pendingData as SubAgentListResponse)?.items ?? []
+      : (listData as SubAgentListResponse)?.items ?? [];
 
   const getEmptyMessage = (): string => {
-    switch (activeTab) {
-      case 'my':
+    switch (effectiveScope) {
+      case 'mine':
         return "You haven't created any sub-agents yet";
-      case 'accessible':
+      case 'shared':
         return 'No sub-agents have been shared with you';
       case 'pending':
         return 'No sub-agents are pending approval';
@@ -114,30 +74,16 @@ export function SubAgentsPage() {
         </Button>
       </div>
 
-      {/* Tabs */}
-      <div className="flex gap-1 border-b">
-        {visibleTabs.map((tab) => (
-          <button
-            key={tab.id}
-            onClick={() => setActiveTab(tab.id)}
-            className={`flex items-center gap-2 px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
-              activeTab === tab.id
-                ? 'border-primary text-primary'
-                : 'border-transparent text-muted-foreground hover:text-foreground hover:border-muted-foreground/50'
-            }`}
-          >
-            <tab.icon className="h-4 w-4" />
-            {tab.label}
-          </button>
-        ))}
-      </div>
-
       {/* Content */}
       <SubAgentList
-        subAgents={getSubAgentsForTab()}
+        subAgents={subAgents}
         onSelect={handleSelectSubAgent}
         emptyMessage={getEmptyMessage()}
-        showManageAccess={activeTab === 'my' || adminMode}
+        showManageAccess
+        currentUserId={user?.id}
+        scope={effectiveScope}
+        onScopeChange={setScope}
+        showPendingScope={adminMode}
       />
     </div>
   );

--- a/packages/console-frontend/src/pages/UsagePage.tsx
+++ b/packages/console-frontend/src/pages/UsagePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo, useEffect, Fragment } from 'react';
 import { useSearchParams } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { Download, ChevronDown, ChevronRight, MessageSquare, Copy, Check, Calendar, X, Filter, ExternalLink, Database } from 'lucide-react';
@@ -152,11 +152,6 @@ export function UsagePage() {
       return newSet;
     });
   };
-
-  // Debug: Log the first record to see what data we're receiving
-  if (logs.length > 0) {
-    console.log('First log record:', logs[0]);
-  }
 
   const handleExportCSV = () => {
     if (!logs.length) return;
@@ -552,10 +547,9 @@ export function UsagePage() {
                   };
                   
                   return (
-                    <>
+                    <Fragment key={conversationId}>
                       {/* Conversation Summary Row */}
                       <TableRow
-                        key={conversationId}
                         id={`conversation-${conversationId}`}
                         className="bg-muted/50 hover:bg-muted cursor-pointer font-medium"
                         onClick={() => toggleConversation(conversationId)}
@@ -765,7 +759,7 @@ export function UsagePage() {
                           </TableRow>
                         );
                       })}
-                    </>
+                    </Fragment>
                   );
                 })
               )}


### PR DESCRIPTION
Frontend-only changes to the Sub-Agents console.

## What changed
- **SubAgentCard** — adds a *"Use in orchestrator"* activation toggle (`Switch`) wired to the existing activate/deactivate mutations, with success/error toasts and sub-agent list invalidation. The toggle is gated behind an approved version (tooltip explains why when disabled). Badge/access-button layout tidied; the activation row is anchored to the bottom so cards align in the grid.
- **SubAgentList** — adds an owner **scope** facet (all / mine / shared / pending) and an **activation** facet (all / enabled / disabled), and applies real status filtering.
- **SubAgentsPage** — delegates filtering to `SubAgentList`, removing the duplicated filter logic (net simplification).
- **UsagePage** — drops a stray debug `console.log`; fixes a React `key` warning by using `<Fragment key>` instead of a keyed `<TableRow>` inside a fragment.

## Verification
- `tsc -b` passes.
- `eslint` on the changed files reports no **new** problems (the one pre-existing `set-state-in-effect` error + deps warnings in UsagePage live in code this PR doesn't touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)