### PR TITLE
feat: per-user discovery/registry cache with cross-service invalidation

### DIFF
--- a/packages/console-backend/app.py
+++ b/packages/console-backend/app.py
@@ -4,9 +4,9 @@ import logging
 import os
 import socket
 from collections.abc import AsyncIterator
-from datetime import datetime, timezone
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from http.cookies import SimpleCookie
 from typing import Any
 from urllib.parse import urlparse, urlunparse
@@ -26,12 +26,12 @@ from a2a.types import (
     SendMessageRequest,
     TaskState,
 )
-from google.protobuf.json_format import MessageToDict, ParseDict
-from google.protobuf.struct_pb2 import Value
 from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi_mcp import FastApiMCP
+from google.protobuf.json_format import MessageToDict, ParseDict
+from google.protobuf.struct_pb2 import Value
 from rcplus_alloy_common.logging import (
     configure_existing_logger,
     configure_logger,
@@ -39,7 +39,6 @@ from rcplus_alloy_common.logging import (
 from sqlalchemy import text as sa_text
 from starlette.middleware.sessions import SessionMiddleware
 
-from console_backend.services.messages_service import _parse_task_state
 from console_backend.config import config
 from console_backend.db import close_db, get_async_session_factory, init_db
 from console_backend.db.docstore import close_docstore, init_docstore
@@ -51,8 +50,11 @@ from console_backend.models.socket_session import SocketSession
 from console_backend.models.user import User
 from console_backend.routers.admin_audit_router import router as admin_audit_router
 from console_backend.routers.admin_group_router import router as admin_group_router
-from console_backend.routers.admin_mcp_gateway_server_access_router import router as admin_mcp_gateway_server_access_router
+from console_backend.routers.admin_mcp_gateway_server_access_router import (
+    router as admin_mcp_gateway_server_access_router,
+)
 from console_backend.routers.admin_user_router import router as admin_user_router
+from console_backend.routers.analytics_router import router as analytics_router
 from console_backend.routers.auth_router import router as auth_router
 from console_backend.routers.bug_report_mcp_tools import router as bug_report_mcp_router
 from console_backend.routers.bug_report_router import router as bug_report_router
@@ -77,11 +79,10 @@ from console_backend.routers.skill_activations_router import router as skill_act
 from console_backend.routers.skills_registry_router import router as skills_registry_router
 from console_backend.routers.sub_agent_router import router as sub_agent_router
 from console_backend.routers.tool_risk_router import router as tool_risk_router
-from console_backend.routers.analytics_router import router as analytics_router
 from console_backend.routers.usage_router import router as usage_router
 from console_backend.service_instances import cleanup_services, initialize_services
 from console_backend.services.conversation_service import ConversationService
-from console_backend.services.messages_service import MessagesService
+from console_backend.services.messages_service import MessagesService, _parse_task_state
 from console_backend.services.socket_notification_manager import SocketNotificationManager
 from console_backend.utils.connection_pool import connection_pool
 from console_backend.utils.cookie_signer import verify_cookie

--- a/packages/console-backend/console_backend/routers/admin_mcp_gateway_server_access_router.py
+++ b/packages/console-backend/console_backend/routers/admin_mcp_gateway_server_access_router.py
@@ -1,7 +1,8 @@
 """Admin router for MCP gateway server access management."""
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 
+from ..db.session import DbSession
 from ..dependencies import require_admin
 from ..models.mcp_gateway_server_access import (
     McpGatewayGrantServerAccessRequest,
@@ -10,7 +11,7 @@ from ..models.mcp_gateway_server_access import (
 )
 from ..models.user import User
 from ..services.mcp_gateway_server_access_service import McpGatewayServerAccessService
-from ..services.orchestrator_cache import invalidate_orchestrator_discovery_cache
+from ..services.orchestrator_cache import schedule_orchestrator_discovery_cache_invalidation
 from ..utils.gatana_auth import get_gatana_token
 
 router = APIRouter(prefix="/api/v1/admin/groups", tags=["admin-mcp-gateway"])
@@ -19,6 +20,14 @@ router = APIRouter(prefix="/api/v1/admin/groups", tags=["admin-mcp-gateway"])
 def get_mcp_gateway_service(request: Request) -> McpGatewayServerAccessService:
     """Get MCP gateway server access service from app state."""
     return request.app.state.mcp_gateway_server_access_service
+
+
+async def _invalidate_group_members_cache(
+    background_tasks: BackgroundTasks, request: Request, db: DbSession, group_id: int, reason: str
+) -> None:
+    """Schedule a scoped discovery-cache invalidation for the members of ``group_id``."""
+    member_subs = await request.app.state.user_group_service.get_group_member_subs(db, group_id)
+    schedule_orchestrator_discovery_cache_invalidation(background_tasks, request, reason, member_subs)
 
 
 @router.get(
@@ -68,6 +77,8 @@ async def grant_mcp_gateway_server_access(
     server_slug: str,
     body: McpGatewayGrantServerAccessRequest,
     request: Request,
+    db: DbSession,
+    background_tasks: BackgroundTasks,
     user: User = Depends(require_admin),
     service: McpGatewayServerAccessService = Depends(get_mcp_gateway_service),
 ) -> None:
@@ -76,7 +87,9 @@ async def grant_mcp_gateway_server_access(
         await service.grant_server_access(gatana_token, group_id, server_slug, body.role)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
-    await invalidate_orchestrator_discovery_cache(f"grant server '{server_slug}' to group {group_id}")
+    await _invalidate_group_members_cache(
+        background_tasks, request, db, group_id, f"grant server '{server_slug}' to group {group_id}"
+    )
 
 
 @router.delete(
@@ -89,6 +102,8 @@ async def revoke_mcp_gateway_server_access(
     group_id: int,
     server_slug: str,
     request: Request,
+    db: DbSession,
+    background_tasks: BackgroundTasks,
     user: User = Depends(require_admin),
     service: McpGatewayServerAccessService = Depends(get_mcp_gateway_service),
 ) -> None:
@@ -97,4 +112,6 @@ async def revoke_mcp_gateway_server_access(
         await service.revoke_server_access(gatana_token, group_id, server_slug)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
-    await invalidate_orchestrator_discovery_cache(f"revoke server '{server_slug}' from group {group_id}")
+    await _invalidate_group_members_cache(
+        background_tasks, request, db, group_id, f"revoke server '{server_slug}' from group {group_id}"
+    )

--- a/packages/console-backend/console_backend/routers/admin_mcp_gateway_server_access_router.py
+++ b/packages/console-backend/console_backend/routers/admin_mcp_gateway_server_access_router.py
@@ -10,6 +10,7 @@ from ..models.mcp_gateway_server_access import (
 )
 from ..models.user import User
 from ..services.mcp_gateway_server_access_service import McpGatewayServerAccessService
+from ..services.orchestrator_cache import invalidate_orchestrator_discovery_cache
 from ..utils.gatana_auth import get_gatana_token
 
 router = APIRouter(prefix="/api/v1/admin/groups", tags=["admin-mcp-gateway"])
@@ -75,6 +76,7 @@ async def grant_mcp_gateway_server_access(
         await service.grant_server_access(gatana_token, group_id, server_slug, body.role)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    await invalidate_orchestrator_discovery_cache(f"grant server '{server_slug}' to group {group_id}")
 
 
 @router.delete(
@@ -95,3 +97,4 @@ async def revoke_mcp_gateway_server_access(
         await service.revoke_server_access(gatana_token, group_id, server_slug)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    await invalidate_orchestrator_discovery_cache(f"revoke server '{server_slug}' from group {group_id}")

--- a/packages/console-backend/console_backend/routers/admin_user_router.py
+++ b/packages/console-backend/console_backend/routers/admin_user_router.py
@@ -350,7 +350,7 @@ async def update_user_role(
     # new role takes effect on their next turn instead of waiting out the orchestrator TTL.
     if current_user.sub:
         schedule_orchestrator_discovery_cache_invalidation(
-            background_tasks, request, f"role change for user {user_id}", [current_user.sub]
+            background_tasks, request, f"role change for user sub={current_user.sub}", [current_user.sub]
         )
 
     # Trigger outbound SCIM push (fire-and-forget)

--- a/packages/console-backend/console_backend/routers/admin_user_router.py
+++ b/packages/console-backend/console_backend/routers/admin_user_router.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..db.session import get_db_session
@@ -24,6 +24,7 @@ from ..models.user import (
     UserStatusUpdate,
 )
 from ..services.audit_service import AuditService
+from ..services.orchestrator_cache import schedule_orchestrator_discovery_cache_invalidation
 from ..services.user_group_service import UserGroupService
 from ..services.user_service import UserService
 
@@ -313,6 +314,7 @@ async def update_user_role(
     request: Request,
     update_request: UserRoleUpdate,
     db: DbSession,
+    background_tasks: BackgroundTasks,
     admin: User = Depends(require_admin),
 ) -> UserDetailResponse:
     """Update a user's role.
@@ -343,6 +345,13 @@ async def update_user_role(
         )
 
     await db.commit()
+
+    # The user's system role changed → flush their (now stale) cached registry record so the
+    # new role takes effect on their next turn instead of waiting out the orchestrator TTL.
+    if current_user.sub:
+        schedule_orchestrator_discovery_cache_invalidation(
+            background_tasks, request, f"role change for user {user_id}", [current_user.sub]
+        )
 
     # Trigger outbound SCIM push (fire-and-forget)
     if hasattr(request.app.state, "outbound_scim_push_service"):

--- a/packages/console-backend/console_backend/routers/auth_router.py
+++ b/packages/console-backend/console_backend/routers/auth_router.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -21,6 +21,7 @@ from ..models.user import (
 )
 from ..services.audit_service import AuditService
 from ..services.keycloak_admin_service import KeycloakAdminService, KeycloakSyncError
+from ..services.orchestrator_cache import schedule_orchestrator_discovery_cache_invalidation
 from ..services.phone_verification_service import PhoneVerificationService
 from ..services.session_service import SessionService
 from ..services.user_group_service import UserGroupService
@@ -210,6 +211,7 @@ async def update_current_user_settings(
     update_request: UserSettingsUpdate,
     request: Request,
     db: DbSession,
+    background_tasks: BackgroundTasks,
     user: User = Depends(require_auth),
     keycloak_admin_service: KeycloakAdminService | None = Depends(get_keycloak_admin_service),
 ) -> UserSettingsResponse:
@@ -267,6 +269,14 @@ async def update_current_user_settings(
     )
     await db.commit()
 
+    # If the user changed an entitlement field carried on the orchestrator's cached User
+    # (tool whitelist or HITL bypass rules), flush their cache so it takes effect next turn
+    # rather than after the TTL — these aren't part of the orchestrator cache key.
+    if {"mcp_tools", "tool_bypass_rules"} & update_request.model_fields_set and user.sub:
+        schedule_orchestrator_discovery_cache_invalidation(
+            background_tasks, request, f"settings change for user {user.id}", [user.sub]
+        )
+
     # Sync phone override to Keycloak if it was updated
     if "phone_number_override" in update_request.model_fields_set and keycloak_admin_service is not None:
         try:
@@ -299,6 +309,7 @@ async def upsert_tool_bypass_rule(
     body: ToolBypassRuleRequest,
     request: Request,
     db: DbSession,
+    background_tasks: BackgroundTasks,
     user: User = Depends(require_auth_or_bearer_token),
 ) -> ToolBypassRuleResponse:
     """Set or remove a tool bypass rule for the current user.
@@ -331,6 +342,13 @@ async def upsert_tool_bypass_rule(
 
     await user_settings_service.upsert_settings(db, user.id, tool_bypass_rules=rules)
     await db.commit()
+
+    # Bypass rules ride on the orchestrator's cached User (not part of its cache key), so
+    # flush this user's cache to apply the change on their next turn instead of after the TTL.
+    if user.sub:
+        schedule_orchestrator_discovery_cache_invalidation(
+            background_tasks, request, f"tool bypass rule change for user {user.id}", [user.sub]
+        )
 
     return ToolBypassRuleResponse(tool_bypass_rules=rules)
 

--- a/packages/console-backend/console_backend/routers/auth_router.py
+++ b/packages/console-backend/console_backend/routers/auth_router.py
@@ -274,7 +274,7 @@ async def update_current_user_settings(
     # rather than after the TTL — these aren't part of the orchestrator cache key.
     if {"mcp_tools", "tool_bypass_rules"} & update_request.model_fields_set and user.sub:
         schedule_orchestrator_discovery_cache_invalidation(
-            background_tasks, request, f"settings change for user {user.id}", [user.sub]
+            background_tasks, request, f"settings change for user sub={user.sub}", [user.sub]
         )
 
     # Sync phone override to Keycloak if it was updated
@@ -347,7 +347,7 @@ async def upsert_tool_bypass_rule(
     # flush this user's cache to apply the change on their next turn instead of after the TTL.
     if user.sub:
         schedule_orchestrator_discovery_cache_invalidation(
-            background_tasks, request, f"tool bypass rule change for user {user.id}", [user.sub]
+            background_tasks, request, f"tool bypass rule change for user sub={user.sub}", [user.sub]
         )
 
     return ToolBypassRuleResponse(tool_bypass_rules=rules)

--- a/packages/console-backend/console_backend/routers/group_router.py
+++ b/packages/console-backend/console_backend/routers/group_router.py
@@ -21,6 +21,7 @@ from ..models.user_group import (
     UserGroupDetailResponse,
     UserGroupWithMembers,
 )
+from ..services.orchestrator_cache import invalidate_orchestrator_discovery_cache
 from ..services.user_group_service import UserGroupService
 
 router = APIRouter(prefix="/api/v1/groups", tags=["groups"])
@@ -312,6 +313,7 @@ async def set_group_default_agents(
             actor=user,
         )
         await db.commit()
+        await invalidate_orchestrator_discovery_cache(f"set default agents for group {group_id}")
 
     except ValueError as e:
         raise HTTPException(
@@ -353,6 +355,7 @@ async def add_group_default_agent(
             actor=user,
         )
         await db.commit()
+        await invalidate_orchestrator_discovery_cache(f"add default agent {sub_agent_id} to group {group_id}")
 
     except ValueError as e:
         raise HTTPException(
@@ -393,6 +396,7 @@ async def remove_group_default_agent(
             actor=user,
         )
         await db.commit()
+        await invalidate_orchestrator_discovery_cache(f"remove default agent {sub_agent_id} from group {group_id}")
 
     except ValueError as e:
         raise HTTPException(

--- a/packages/console-backend/console_backend/routers/group_router.py
+++ b/packages/console-backend/console_backend/routers/group_router.py
@@ -1,6 +1,6 @@
 """Group management router for non-admin users."""
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, status
 
 from ..db.session import DbSession
 from ..dependencies import (
@@ -21,7 +21,7 @@ from ..models.user_group import (
     UserGroupDetailResponse,
     UserGroupWithMembers,
 )
-from ..services.orchestrator_cache import invalidate_orchestrator_discovery_cache
+from ..services.orchestrator_cache import schedule_orchestrator_discovery_cache_invalidation
 from ..services.user_group_service import UserGroupService
 
 router = APIRouter(prefix="/api/v1/groups", tags=["groups"])
@@ -293,6 +293,7 @@ async def set_group_default_agents(
     request: Request,
     db: DbSession,
     request_body: SubAgentAdd,
+    background_tasks: BackgroundTasks,
     user: User = Depends(require_auth),
 ):
     """Set (replace) default agents for a group (bulk operation).
@@ -313,7 +314,10 @@ async def set_group_default_agents(
             actor=user,
         )
         await db.commit()
-        await invalidate_orchestrator_discovery_cache(f"set default agents for group {group_id}")
+        member_subs = await user_group_service.get_group_member_subs(db, group_id)
+        schedule_orchestrator_discovery_cache_invalidation(
+            background_tasks, request, f"set default agents for group {group_id}", member_subs
+        )
 
     except ValueError as e:
         raise HTTPException(
@@ -328,6 +332,7 @@ async def add_group_default_agent(
     sub_agent_id: int,
     request: Request,
     db: DbSession,
+    background_tasks: BackgroundTasks,
     user: User = Depends(require_auth),
 ):
     """Add a single default agent to a group.
@@ -355,7 +360,10 @@ async def add_group_default_agent(
             actor=user,
         )
         await db.commit()
-        await invalidate_orchestrator_discovery_cache(f"add default agent {sub_agent_id} to group {group_id}")
+        member_subs = await user_group_service.get_group_member_subs(db, group_id)
+        schedule_orchestrator_discovery_cache_invalidation(
+            background_tasks, request, f"add default agent {sub_agent_id} to group {group_id}", member_subs
+        )
 
     except ValueError as e:
         raise HTTPException(
@@ -370,6 +378,7 @@ async def remove_group_default_agent(
     sub_agent_id: int,
     request: Request,
     db: DbSession,
+    background_tasks: BackgroundTasks,
     user: User = Depends(require_auth),
 ):
     """Remove a single default agent from a group.
@@ -396,7 +405,10 @@ async def remove_group_default_agent(
             actor=user,
         )
         await db.commit()
-        await invalidate_orchestrator_discovery_cache(f"remove default agent {sub_agent_id} from group {group_id}")
+        member_subs = await user_group_service.get_group_member_subs(db, group_id)
+        schedule_orchestrator_discovery_cache_invalidation(
+            background_tasks, request, f"remove default agent {sub_agent_id} from group {group_id}", member_subs
+        )
 
     except ValueError as e:
         raise HTTPException(

--- a/packages/console-backend/console_backend/services/orchestrator_cache.py
+++ b/packages/console-backend/console_backend/services/orchestrator_cache.py
@@ -1,30 +1,41 @@
-"""Best-effort invalidation of the orchestrator's per-user discovery/registry caches.
+"""Best-effort, scoped invalidation of the orchestrator's per-user discovery/registry caches.
 
 The orchestrator memoizes capability discovery (MCP tools + sub-agents) and the registry
 user lookup per user, keyed by the inputs that determine entitlements and bounded by a TTL.
-When an admin or group manager changes a group→MCP-server or group→default-agent mapping,
-the affected users' entitlements change *without* their groups/config changing, so the cache
-would otherwise serve stale tools/sub-agents until the TTL lapses.
+When an admin or group manager changes a group→MCP-server / group→default-agent mapping, or
+a per-user entitlement (role, tool whitelist, bypass rules), the affected users' entitlements
+change *without* their groups/config necessarily changing, so the cache would otherwise serve
+stale tools/sub-agents until the TTL lapses.
 
 This nudges the orchestrator to flush immediately. It is best-effort by design: any failure
 is logged and swallowed so it can never block the triggering action, and the orchestrator's
 TTL remains the correctness floor.
 
+Scoping: the caller passes the ``user_subs`` whose entitlements changed (a single user, or
+the members of an affected group). The orchestrator drops only those users' entries, so one
+group edit never evicts every active user's cache. Pass ``user_subs=None`` only for a
+deliberate fleet-wide flush.
+
 Auth: a trusted service-to-service call. console-backend authenticates with the OIDC
-client-credentials grant (its own client id/secret) to mint a token for the orchestrator's
-audience; the orchestrator validates that JWT via its standard middleware. This is
-independent of which user triggered the change (admin or group manager) — no user token,
-session state, or per-user permission is involved, and there is no bespoke shared secret.
+client-credentials grant (its own client id/secret, via the shared ``app.state.oauth_service``)
+to mint a token for the orchestrator's audience; the orchestrator validates that JWT and
+additionally checks the token's ``azp`` is console-backend's client. No user token, session
+state, or per-user permission is involved, and there is no bespoke shared secret.
+
+Dispatch: callers schedule this via ``schedule_orchestrator_discovery_cache_invalidation`` so
+it runs as a FastAPI background task — the token mint + cross-service POST never block the
+triggering request's response.
 
 Multi-replica note: the orchestrator cache is in-process, so a single POST flushes the one
 replica that receives it. Behind a load balancer the other replicas fall back to the TTL
-(or an ``ENTITLEMENT_POLICY_VERSION`` bump for a fleet-wide flush). A fan-out/pub-sub
-broadcast is the follow-up for instant fleet-wide invalidation.
+(kept short for this reason) or an ``ENTITLEMENT_POLICY_VERSION`` bump for a fleet-wide flush.
+A fan-out/pub-sub broadcast is the follow-up for instant fleet-wide invalidation.
 """
 
 import logging
 
 import httpx
+from fastapi import BackgroundTasks, Request
 from ringier_a2a_sdk.oauth import OidcOAuth2Client
 
 from ..config import config
@@ -43,13 +54,24 @@ def _orchestrator_base_url() -> str | None:
     return f"{schema}://{domain}"
 
 
-async def invalidate_orchestrator_discovery_cache(reason: str) -> None:
-    """Tell the orchestrator to drop its cached discovery + registry records (best-effort).
+async def invalidate_orchestrator_discovery_cache(
+    oauth_client: OidcOAuth2Client,
+    reason: str,
+    user_subs: list[str] | None = None,
+) -> None:
+    """Tell the orchestrator to drop cached discovery + registry records (best-effort, scoped).
 
-    Authenticated service-to-service via the OIDC client-credentials grant (see module
-    docstring): no user token is involved, so this works regardless of whether an admin or
-    a group manager triggered the underlying entitlement change.
+    Args:
+        oauth_client: the shared, long-lived OIDC client (``app.state.oauth_service``); reused
+            so we don't leak an httpx pool or re-mint a service token on every call.
+        reason: human-readable reason, logged for traceability.
+        user_subs: the users whose entitlements changed. An empty list means "no affected
+            users" → no-op. ``None`` means a deliberate fleet-wide flush.
     """
+    if user_subs is not None and len(user_subs) == 0:
+        logger.debug("No affected users for cache invalidation (%s); skipping", reason)
+        return
+
     base = _orchestrator_base_url()
     if not base:
         logger.debug("Orchestrator base URL not configured; skipping cache invalidation (%s)", reason)
@@ -61,18 +83,36 @@ async def invalidate_orchestrator_discovery_cache(reason: str) -> None:
         return
 
     try:
-        oauth2_client = OidcOAuth2Client(
-            client_id=config.oidc.client_id,
-            client_secret=config.oidc.client_secret.get_secret_value(),
-            issuer=config.oidc.issuer,
-        )
-        service_token = await oauth2_client.get_token(audience=target_client_id)
+        service_token = await oauth_client.get_token(audience=target_client_id)
+        payload: dict = {} if user_subs is None else {"user_subs": user_subs}
         async with httpx.AsyncClient(timeout=3.0) as client:
             resp = await client.post(
                 f"{base}{_INVALIDATE_PATH}",
                 headers={"Authorization": f"Bearer {service_token}"},
+                json=payload,
             )
             resp.raise_for_status()
-        logger.info("Invalidated orchestrator discovery cache (%s)", reason)
+        scope = "all" if user_subs is None else f"{len(user_subs)} user(s)"
+        logger.info("Invalidated orchestrator discovery cache (%s; scope=%s)", reason, scope)
     except Exception as e:  # noqa: BLE001 — best-effort; must never block the triggering action
         logger.warning("Failed to invalidate orchestrator discovery cache (%s): %s", reason, e)
+
+
+def schedule_orchestrator_discovery_cache_invalidation(
+    background_tasks: BackgroundTasks,
+    request: Request,
+    reason: str,
+    user_subs: list[str] | None = None,
+) -> None:
+    """Schedule a best-effort, scoped cache invalidation to run after the response is sent.
+
+    Pulls the shared OIDC client off ``app.state`` and enqueues the POST as a background task,
+    so the triggering request never waits on the token mint or the cross-service call.
+    """
+    if user_subs is not None and len(user_subs) == 0:
+        return  # nothing to invalidate
+    oauth_client = getattr(request.app.state, "oauth_service", None)
+    if oauth_client is None:
+        logger.debug("No oauth_service on app.state; skipping cache invalidation (%s)", reason)
+        return
+    background_tasks.add_task(invalidate_orchestrator_discovery_cache, oauth_client, reason, user_subs)

--- a/packages/console-backend/console_backend/services/orchestrator_cache.py
+++ b/packages/console-backend/console_backend/services/orchestrator_cache.py
@@ -1,0 +1,78 @@
+"""Best-effort invalidation of the orchestrator's per-user discovery/registry caches.
+
+The orchestrator memoizes capability discovery (MCP tools + sub-agents) and the registry
+user lookup per user, keyed by the inputs that determine entitlements and bounded by a TTL.
+When an admin or group manager changes a group→MCP-server or group→default-agent mapping,
+the affected users' entitlements change *without* their groups/config changing, so the cache
+would otherwise serve stale tools/sub-agents until the TTL lapses.
+
+This nudges the orchestrator to flush immediately. It is best-effort by design: any failure
+is logged and swallowed so it can never block the triggering action, and the orchestrator's
+TTL remains the correctness floor.
+
+Auth: a trusted service-to-service call. console-backend authenticates with the OIDC
+client-credentials grant (its own client id/secret) to mint a token for the orchestrator's
+audience; the orchestrator validates that JWT via its standard middleware. This is
+independent of which user triggered the change (admin or group manager) — no user token,
+session state, or per-user permission is involved, and there is no bespoke shared secret.
+
+Multi-replica note: the orchestrator cache is in-process, so a single POST flushes the one
+replica that receives it. Behind a load balancer the other replicas fall back to the TTL
+(or an ``ENTITLEMENT_POLICY_VERSION`` bump for a fleet-wide flush). A fan-out/pub-sub
+broadcast is the follow-up for instant fleet-wide invalidation.
+"""
+
+import logging
+
+import httpx
+from ringier_a2a_sdk.oauth import OidcOAuth2Client
+
+from ..config import config
+
+logger = logging.getLogger(__name__)
+
+_INVALIDATE_PATH = "/internal/discovery-cache/invalidate"
+
+
+def _orchestrator_base_url() -> str | None:
+    """Build the orchestrator base URL from config, or None if not configured."""
+    domain = config.orchestrator.base_domain
+    if not domain:
+        return None
+    schema = "http" if config.orchestrator.is_local() or "localhost" in domain else "https"
+    return f"{schema}://{domain}"
+
+
+async def invalidate_orchestrator_discovery_cache(reason: str) -> None:
+    """Tell the orchestrator to drop its cached discovery + registry records (best-effort).
+
+    Authenticated service-to-service via the OIDC client-credentials grant (see module
+    docstring): no user token is involved, so this works regardless of whether an admin or
+    a group manager triggered the underlying entitlement change.
+    """
+    base = _orchestrator_base_url()
+    if not base:
+        logger.debug("Orchestrator base URL not configured; skipping cache invalidation (%s)", reason)
+        return
+
+    target_client_id = config.orchestrator.client_id
+    if not target_client_id:
+        logger.debug("ORCHESTRATOR_CLIENT_ID not configured; skipping cache invalidation (%s)", reason)
+        return
+
+    try:
+        oauth2_client = OidcOAuth2Client(
+            client_id=config.oidc.client_id,
+            client_secret=config.oidc.client_secret.get_secret_value(),
+            issuer=config.oidc.issuer,
+        )
+        service_token = await oauth2_client.get_token(audience=target_client_id)
+        async with httpx.AsyncClient(timeout=3.0) as client:
+            resp = await client.post(
+                f"{base}{_INVALIDATE_PATH}",
+                headers={"Authorization": f"Bearer {service_token}"},
+            )
+            resp.raise_for_status()
+        logger.info("Invalidated orchestrator discovery cache (%s)", reason)
+    except Exception as e:  # noqa: BLE001 — best-effort; must never block the triggering action
+        logger.warning("Failed to invalidate orchestrator discovery cache (%s): %s", reason, e)

--- a/packages/console-backend/console_backend/services/user_group_service.py
+++ b/packages/console-backend/console_backend/services/user_group_service.py
@@ -783,6 +783,28 @@ class UserGroupService:
             logger.error(f"Failed to list members: {e}")
             raise
 
+    async def get_group_member_subs(self, db: AsyncSession, group_id: int) -> list[str]:
+        """Return the OIDC subs of a group's active members.
+
+        Used to scope orchestrator discovery-cache invalidation to exactly the users whose
+        entitlements a group-level change affects (instead of flushing every user's cache).
+        """
+        query = text("""
+            SELECT u.sub
+            FROM user_group_members ugm
+            JOIN users u ON u.id = ugm.user_id
+            WHERE ugm.user_group_id = :group_id
+            AND u.deleted_at IS NULL
+            AND u.status = 'active'
+            AND u.sub IS NOT NULL
+        """)
+        try:
+            result = await db.execute(query, {"group_id": group_id})
+            return [row[0] for row in result.fetchall()]
+        except Exception as e:
+            logger.error(f"Failed to fetch member subs for group {group_id}: {e}")
+            return []
+
     async def add_members(
         self,
         db: AsyncSession,

--- a/packages/console-backend/tests/test_orchestrator_cache.py
+++ b/packages/console-backend/tests/test_orchestrator_cache.py
@@ -1,4 +1,4 @@
-"""Tests for best-effort orchestrator discovery-cache invalidation."""
+"""Tests for best-effort, scoped orchestrator discovery-cache invalidation."""
 
 import httpx
 import pytest
@@ -17,6 +17,7 @@ class _FakeClient:
 
     last_url: str | None = None
     last_headers: dict | None = None
+    last_json: dict | None = None
     raise_on_post: Exception | None = None
 
     def __init__(self, *args, **kwargs):
@@ -28,21 +29,19 @@ class _FakeClient:
     async def __aexit__(self, *args):
         return False
 
-    async def post(self, url, headers=None):
+    async def post(self, url, headers=None, json=None):
         _FakeClient.last_url = url
         _FakeClient.last_headers = headers
+        _FakeClient.last_json = json
         if _FakeClient.raise_on_post is not None:
             raise _FakeClient.raise_on_post
         return _FakeResponse()
 
 
 class _FakeOAuthClient:
-    """Stand-in for OidcOAuth2Client: records the client-credentials audience requested."""
+    """Stand-in for the shared OidcOAuth2Client: records the audience requested."""
 
     requested_audience: str | None = None
-
-    def __init__(self, *args, **kwargs):
-        pass
 
     async def get_token(self, audience):
         _FakeOAuthClient.requested_audience = audience
@@ -53,6 +52,7 @@ class _FakeOAuthClient:
 def _reset_fakes():
     _FakeClient.last_url = None
     _FakeClient.last_headers = None
+    _FakeClient.last_json = None
     _FakeClient.raise_on_post = None
     _FakeOAuthClient.requested_audience = None
     yield
@@ -61,7 +61,6 @@ def _reset_fakes():
 @pytest.fixture
 def _patch(monkeypatch):
     monkeypatch.setattr(oc.httpx, "AsyncClient", _FakeClient)
-    monkeypatch.setattr(oc, "OidcOAuth2Client", _FakeOAuthClient)
     # Happy-path config: orchestrator reachable and its OIDC client id known.
     monkeypatch.setattr(config.orchestrator, "base_domain", "localhost:10001", raising=False)
     monkeypatch.setattr(config.orchestrator, "client_id", "orchestrator", raising=False)
@@ -70,29 +69,94 @@ def _patch(monkeypatch):
 @pytest.mark.asyncio
 async def test_skips_when_orchestrator_not_configured(monkeypatch, _patch):
     monkeypatch.setattr(config.orchestrator, "base_domain", "", raising=False)
-    await oc.invalidate_orchestrator_discovery_cache("test")
+    await oc.invalidate_orchestrator_discovery_cache(_FakeOAuthClient(), "test", ["sub-1"])
     assert _FakeClient.last_url is None  # no call attempted
 
 
 @pytest.mark.asyncio
 async def test_skips_when_client_id_not_configured(monkeypatch, _patch):
     monkeypatch.setattr(config.orchestrator, "client_id", "", raising=False)
-    await oc.invalidate_orchestrator_discovery_cache("test")
+    await oc.invalidate_orchestrator_discovery_cache(_FakeOAuthClient(), "test", ["sub-1"])
     assert _FakeClient.last_url is None  # no audience to mint a token for
 
 
 @pytest.mark.asyncio
-async def test_posts_with_client_credentials_bearer(_patch):
-    await oc.invalidate_orchestrator_discovery_cache("test")
+async def test_skips_when_no_affected_users(_patch):
+    # Empty list = "no affected users" → must not POST (distinct from None = flush-all).
+    await oc.invalidate_orchestrator_discovery_cache(_FakeOAuthClient(), "test", [])
+    assert _FakeClient.last_url is None
+
+
+@pytest.mark.asyncio
+async def test_posts_scoped_with_client_credentials_bearer(_patch):
+    await oc.invalidate_orchestrator_discovery_cache(_FakeOAuthClient(), "test", ["sub-1", "sub-2"])
     assert _FakeClient.last_url == "http://localhost:10001/internal/discovery-cache/invalidate"
     # A service token was minted for the orchestrator audience and sent as a Bearer.
     assert _FakeOAuthClient.requested_audience == "orchestrator"
     assert _FakeClient.last_headers["Authorization"] == "Bearer svc-token-for::orchestrator"
     assert "X-Internal-Auth" not in _FakeClient.last_headers
+    # The affected user subs are carried in the body so the orchestrator can scope the flush.
+    assert _FakeClient.last_json == {"user_subs": ["sub-1", "sub-2"]}
+
+
+@pytest.mark.asyncio
+async def test_posts_empty_body_for_fleet_wide_flush(_patch):
+    # user_subs=None is the explicit "flush everything" path.
+    await oc.invalidate_orchestrator_discovery_cache(_FakeOAuthClient(), "test", None)
+    assert _FakeClient.last_url is not None
+    assert _FakeClient.last_json == {}
 
 
 @pytest.mark.asyncio
 async def test_swallows_errors(_patch):
     _FakeClient.raise_on_post = httpx.ConnectError("orchestrator down")
     # Must not raise — invalidation is best-effort and must never block the triggering action.
-    await oc.invalidate_orchestrator_discovery_cache("test")
+    await oc.invalidate_orchestrator_discovery_cache(_FakeOAuthClient(), "test", ["sub-1"])
+
+
+class _FakeBackgroundTasks:
+    def __init__(self):
+        self.tasks = []
+
+    def add_task(self, func, *args):
+        self.tasks.append((func, args))
+
+
+class _FakeAppState:
+    def __init__(self, oauth_service):
+        self.oauth_service = oauth_service
+
+
+class _FakeApp:
+    def __init__(self, oauth_service):
+        self.state = _FakeAppState(oauth_service)
+
+
+class _FakeRequest:
+    def __init__(self, oauth_service):
+        self.app = _FakeApp(oauth_service)
+
+
+def test_schedule_enqueues_task_with_shared_client():
+    oauth = _FakeOAuthClient()
+    bg = _FakeBackgroundTasks()
+    req = _FakeRequest(oauth)
+    oc.schedule_orchestrator_discovery_cache_invalidation(bg, req, "reason", ["sub-1"])
+    assert len(bg.tasks) == 1
+    func, args = bg.tasks[0]
+    assert func is oc.invalidate_orchestrator_discovery_cache
+    assert args == (oauth, "reason", ["sub-1"])
+
+
+def test_schedule_skips_empty_user_subs():
+    bg = _FakeBackgroundTasks()
+    req = _FakeRequest(_FakeOAuthClient())
+    oc.schedule_orchestrator_discovery_cache_invalidation(bg, req, "reason", [])
+    assert bg.tasks == []
+
+
+def test_schedule_skips_when_no_oauth_service():
+    bg = _FakeBackgroundTasks()
+    req = _FakeRequest(None)
+    oc.schedule_orchestrator_discovery_cache_invalidation(bg, req, "reason", ["sub-1"])
+    assert bg.tasks == []

--- a/packages/console-backend/tests/test_orchestrator_cache.py
+++ b/packages/console-backend/tests/test_orchestrator_cache.py
@@ -1,0 +1,98 @@
+"""Tests for best-effort orchestrator discovery-cache invalidation."""
+
+import httpx
+import pytest
+
+from console_backend.config import config
+from console_backend.services import orchestrator_cache as oc
+
+
+class _FakeResponse:
+    def raise_for_status(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+class _FakeClient:
+    """Records the single POST the helper makes; returns a 200-ish response."""
+
+    last_url: str | None = None
+    last_headers: dict | None = None
+    raise_on_post: Exception | None = None
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def post(self, url, headers=None):
+        _FakeClient.last_url = url
+        _FakeClient.last_headers = headers
+        if _FakeClient.raise_on_post is not None:
+            raise _FakeClient.raise_on_post
+        return _FakeResponse()
+
+
+class _FakeOAuthClient:
+    """Stand-in for OidcOAuth2Client: records the client-credentials audience requested."""
+
+    requested_audience: str | None = None
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def get_token(self, audience):
+        _FakeOAuthClient.requested_audience = audience
+        return f"svc-token-for::{audience}"
+
+
+@pytest.fixture(autouse=True)
+def _reset_fakes():
+    _FakeClient.last_url = None
+    _FakeClient.last_headers = None
+    _FakeClient.raise_on_post = None
+    _FakeOAuthClient.requested_audience = None
+    yield
+
+
+@pytest.fixture
+def _patch(monkeypatch):
+    monkeypatch.setattr(oc.httpx, "AsyncClient", _FakeClient)
+    monkeypatch.setattr(oc, "OidcOAuth2Client", _FakeOAuthClient)
+    # Happy-path config: orchestrator reachable and its OIDC client id known.
+    monkeypatch.setattr(config.orchestrator, "base_domain", "localhost:10001", raising=False)
+    monkeypatch.setattr(config.orchestrator, "client_id", "orchestrator", raising=False)
+
+
+@pytest.mark.asyncio
+async def test_skips_when_orchestrator_not_configured(monkeypatch, _patch):
+    monkeypatch.setattr(config.orchestrator, "base_domain", "", raising=False)
+    await oc.invalidate_orchestrator_discovery_cache("test")
+    assert _FakeClient.last_url is None  # no call attempted
+
+
+@pytest.mark.asyncio
+async def test_skips_when_client_id_not_configured(monkeypatch, _patch):
+    monkeypatch.setattr(config.orchestrator, "client_id", "", raising=False)
+    await oc.invalidate_orchestrator_discovery_cache("test")
+    assert _FakeClient.last_url is None  # no audience to mint a token for
+
+
+@pytest.mark.asyncio
+async def test_posts_with_client_credentials_bearer(_patch):
+    await oc.invalidate_orchestrator_discovery_cache("test")
+    assert _FakeClient.last_url == "http://localhost:10001/internal/discovery-cache/invalidate"
+    # A service token was minted for the orchestrator audience and sent as a Bearer.
+    assert _FakeOAuthClient.requested_audience == "orchestrator"
+    assert _FakeClient.last_headers["Authorization"] == "Bearer svc-token-for::orchestrator"
+    assert "X-Internal-Auth" not in _FakeClient.last_headers
+
+
+@pytest.mark.asyncio
+async def test_swallows_errors(_patch):
+    _FakeClient.raise_on_post = httpx.ConnectError("orchestrator down")
+    # Must not raise — invalidation is best-effort and must never block the triggering action.
+    await oc.invalidate_orchestrator_discovery_cache("test")

--- a/packages/orchestrator-agent/app/core/discovery_cache.py
+++ b/packages/orchestrator-agent/app/core/discovery_cache.py
@@ -11,25 +11,39 @@ Both are memoized here.
 
 Keying
 ------
-``entitlement_key`` folds in the inputs that determine *which* tools/sub-agents a user
-is entitled to::
+``cache_key`` folds in the inputs that determine *which* tools/sub-agents a user is
+entitled to *and* that the cached value actually depends on::
 
-    user_sub, sorted(groups), sub_agent_config_hash, sorted(tool_names), policy_version
+    user_sub, sorted(groups), sub_agent_config_hash, policy_version
+
+Note that the per-user *tool whitelist* (``tool_names``) is deliberately NOT part of the
+key: discovery runs unfiltered (``white_list=None``) and the whitelist is applied later in
+``build_runtime_context``, so the cached ``(tools, sub_agents)`` value does not depend on
+it. Keying on it would only fragment the cache. A whitelist change (or any other per-user
+entitlement field carried on the cached ``User`` — role, bypass rules, catalog access) is
+propagated by console-backend calling ``invalidate_users`` for the affected user(s); see
+``main.invalidate_discovery_cache``.
 
 Group-membership changes invalidate **automatically** (the next request carries a
 different group set → different key → miss). ``policy_version`` is a cross-cutting
-invalidation lever (see ``AgentSettings.ENTITLEMENT_POLICY_VERSION`` and
-``invalidate_all``) for the case a group→server/tool access *policy* changes without the
-user's own groups/config changing — bump it (or call ``invalidate_all``) and every entry
-is recomputed.
+invalidation lever (see ``AgentSettings.ENTITLEMENT_POLICY_VERSION`` and ``invalidate_all``)
+for a fleet-wide flush without per-user targeting — bump it (or call ``invalidate_all``)
+and every entry is recomputed.
 
 Token-expiry safety
 -------------------
-Discovered tools embed the user's exchanged bearer token in their MCP connection (and the
-registry data was fetched with the user token), so a cache entry must not outlive that
-token. Each entry is bounded by ``min(ttl, access_token.exp - margin)``. The exchanged
-gatana/console tokens are minted at discovery time with the realm lifetime, so they expire
-no earlier than the user token — bounding by the user token's ``exp`` is therefore safe.
+Discovered tools embed an *exchanged* bearer token (gatana/console) in their MCP connection,
+and the registry data was fetched with the user token, so a cache entry must not outlive
+those tokens. Each entry is bounded by ``min(ttl, user_token.exp - margin)``.
+
+The user token's ``exp`` is used as the bound because the exchanged tokens are not available
+at ``put`` time. This is safe **only while** the exchanged gatana/console tokens are minted
+with a lifetime at least as long as the user token's remaining validity — which holds when
+those OIDC clients use (at least) the realm's default access-token lifespan. To keep that
+assumption robust the default TTL is kept well below a typical realm access-token lifespan,
+so an entry can never outlive a freshly-minted exchanged token even if a client is
+configured with a shorter lifespan. If you shorten the gatana/console token lifespan below
+``AGENT_DISCOVERY_CACHE_TTL``, lower the TTL to match.
 """
 
 from __future__ import annotations
@@ -48,35 +62,25 @@ logger = logging.getLogger(__name__)
 # in-flight tool call can still complete with a valid token.
 _TOKEN_EXP_MARGIN_S = 30.0
 
-
-def entitlement_key(
-    user_sub: str,
-    groups: list[str] | None,
-    sub_agent_config_hash: str | None,
-    tool_names: list[str] | None,
-    policy_version: str = "0",
-) -> str:
-    """Build a cache key from the inputs that determine a user's entitlements."""
-    payload = json.dumps(
-        {
-            "u": user_sub,
-            "g": sorted(groups or []),
-            "c": sub_agent_config_hash or "",
-            "t": sorted(tool_names or []),
-            "v": policy_version,
-        },
-        sort_keys=True,
-    )
-    return hashlib.sha256(payload.encode()).hexdigest()
+# Hard cap on entries per cache so a long-lived process with high user/entitlement churn
+# cannot grow unbounded (entries for users who never return are otherwise only reclaimed
+# lazily when their own key is read again). When exceeded we drop expired entries first,
+# then evict the entry closest to expiry.
+_DEFAULT_MAX_ENTRIES = 5000
 
 
-def user_key(
+def cache_key(
     user_sub: str,
     groups: list[str] | None,
     sub_agent_config_hash: str | None,
     policy_version: str = "0",
 ) -> str:
-    """Cache key for the registry user record (no tool_names — those come from the fetch)."""
+    """Build a cache key from the inputs the cached value actually depends on.
+
+    Shared by both the discovery cache and the user cache (they live in separate stores,
+    so an identical key string never collides across them). ``tool_names`` is intentionally
+    excluded — see the module docstring.
+    """
     payload = json.dumps(
         {"u": user_sub, "g": sorted(groups or []), "c": sub_agent_config_hash or "", "v": policy_version},
         sort_keys=True,
@@ -102,14 +106,16 @@ def token_exp(access_token: str | None) -> float | None:
 class _Entry:
     value: Any
     expires_at: float
+    owner: str | None = None  # user_sub this entry belongs to, for scoped invalidation
 
 
 class TtlTokenCache:
     """A TTL cache whose entries are additionally bounded by a bearer token's expiry."""
 
-    def __init__(self, ttl_seconds: float, name: str = "cache") -> None:
+    def __init__(self, ttl_seconds: float, name: str = "cache", max_entries: int = _DEFAULT_MAX_ENTRIES) -> None:
         self._ttl = ttl_seconds
         self._name = name
+        self._max_entries = max_entries
         self._store: dict[str, _Entry] = {}
 
     def get(self, key: str) -> Any | None:
@@ -121,14 +127,35 @@ class TtlTokenCache:
             return None
         return entry.value
 
-    def put(self, key: str, value: Any, access_token: str | None) -> None:
+    def put(self, key: str, value: Any, access_token: str | None, owner: str | None = None) -> None:
         expires_at = time.time() + self._ttl
         exp = token_exp(access_token)
         if exp is not None:
             expires_at = min(expires_at, exp - _TOKEN_EXP_MARGIN_S)
         if expires_at <= time.time():
             return  # token already (nearly) expired — don't cache a stale entry
-        self._store[key] = _Entry(value=value, expires_at=expires_at)
+        self._store[key] = _Entry(value=value, expires_at=expires_at, owner=owner)
+        if len(self._store) > self._max_entries:
+            self._evict()
+
+    def _evict(self) -> None:
+        """Bound the store size: drop expired entries first, then the entry closest to expiry."""
+        now = time.time()
+        expired = [k for k, e in self._store.items() if e.expires_at <= now]
+        for k in expired:
+            self._store.pop(k, None)
+        while len(self._store) > self._max_entries:
+            oldest = min(self._store, key=lambda k: self._store[k].expires_at)
+            self._store.pop(oldest, None)
+
+    def invalidate_owner(self, owner: str) -> int:
+        """Drop every entry belonging to ``owner`` (a user_sub). Returns the count removed."""
+        keys = [k for k, e in self._store.items() if e.owner == owner]
+        for k in keys:
+            self._store.pop(k, None)
+        if keys:
+            logger.info("[%s] invalidated %d entries for owner=%s", self._name, len(keys), owner)
+        return len(keys)
 
     def clear(self) -> None:
         n = len(self._store)
@@ -157,12 +184,28 @@ def get_user_cache(ttl_seconds: float | None = None) -> TtlTokenCache:
     return _user_cache
 
 
-def invalidate_all() -> None:
-    """Drop all cached discovery + user records.
+def invalidate_users(user_subs: list[str]) -> int:
+    """Drop cached discovery + user records for the given users only. Returns total removed.
 
-    Call when a cross-cutting entitlement policy changes (e.g. a group→server/tool access
-    mapping). Exposed so console-backend (or an admin action) can trigger invalidation
-    without waiting for the TTL or bumping ENTITLEMENT_POLICY_VERSION via redeploy.
+    This is the targeted path: console-backend computes the set of users whose entitlements
+    changed (the members of an affected group, or a single user whose role/whitelist/bypass
+    rules changed) and asks the orchestrator to flush just those, so an entitlement change
+    for one group cannot trigger an expensive re-discovery storm for every active user.
+    """
+    removed = 0
+    for sub in user_subs:
+        if _discovery_cache is not None:
+            removed += _discovery_cache.invalidate_owner(sub)
+        if _user_cache is not None:
+            removed += _user_cache.invalidate_owner(sub)
+    return removed
+
+
+def invalidate_all() -> None:
+    """Drop all cached discovery + user records (fleet-wide flush, no per-user targeting).
+
+    Used for the unscoped admin/maintenance flush. Prefer ``invalidate_users`` for routine
+    entitlement changes so a single group edit does not evict every user's cache.
     """
     if _discovery_cache is not None:
         _discovery_cache.clear()

--- a/packages/orchestrator-agent/app/core/discovery_cache.py
+++ b/packages/orchestrator-agent/app/core/discovery_cache.py
@@ -1,0 +1,170 @@
+"""Per-user caches for the request hot path.
+
+Two things were recomputed on *every* turn even though they're identical turn-to-turn
+for the same user/entitlements (the compiled graph is already cached):
+
+  * capability discovery — MCP tools + sub-agents (~2s: gatana token exchange +
+    ``fetch_available_servers`` + hundreds of per-server ``list_tools`` handshakes);
+  * the registry user fetch (~1s: 4 concurrent console-backend calls).
+
+Both are memoized here.
+
+Keying
+------
+``entitlement_key`` folds in the inputs that determine *which* tools/sub-agents a user
+is entitled to::
+
+    user_sub, sorted(groups), sub_agent_config_hash, sorted(tool_names), policy_version
+
+Group-membership changes invalidate **automatically** (the next request carries a
+different group set → different key → miss). ``policy_version`` is a cross-cutting
+invalidation lever (see ``AgentSettings.ENTITLEMENT_POLICY_VERSION`` and
+``invalidate_all``) for the case a group→server/tool access *policy* changes without the
+user's own groups/config changing — bump it (or call ``invalidate_all``) and every entry
+is recomputed.
+
+Token-expiry safety
+-------------------
+Discovered tools embed the user's exchanged bearer token in their MCP connection (and the
+registry data was fetched with the user token), so a cache entry must not outlive that
+token. Each entry is bounded by ``min(ttl, access_token.exp - margin)``. The exchanged
+gatana/console tokens are minted at discovery time with the realm lifetime, so they expire
+no earlier than the user token — bounding by the user token's ``exp`` is therefore safe.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Never serve an entry within this many seconds of its bounding token's expiry, so an
+# in-flight tool call can still complete with a valid token.
+_TOKEN_EXP_MARGIN_S = 30.0
+
+
+def entitlement_key(
+    user_sub: str,
+    groups: list[str] | None,
+    sub_agent_config_hash: str | None,
+    tool_names: list[str] | None,
+    policy_version: str = "0",
+) -> str:
+    """Build a cache key from the inputs that determine a user's entitlements."""
+    payload = json.dumps(
+        {
+            "u": user_sub,
+            "g": sorted(groups or []),
+            "c": sub_agent_config_hash or "",
+            "t": sorted(tool_names or []),
+            "v": policy_version,
+        },
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def user_key(
+    user_sub: str,
+    groups: list[str] | None,
+    sub_agent_config_hash: str | None,
+    policy_version: str = "0",
+) -> str:
+    """Cache key for the registry user record (no tool_names — those come from the fetch)."""
+    payload = json.dumps(
+        {"u": user_sub, "g": sorted(groups or []), "c": sub_agent_config_hash or "", "v": policy_version},
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def token_exp(access_token: str | None) -> float | None:
+    """Read ``exp`` (unix seconds) from a JWT without verifying it. None if unparseable."""
+    if not access_token:
+        return None
+    try:
+        segment = access_token.split(".")[1]
+        segment += "=" * (-len(segment) % 4)  # restore base64 padding
+        claims = json.loads(base64.urlsafe_b64decode(segment))
+        exp = claims.get("exp")
+        return float(exp) if exp is not None else None
+    except Exception:
+        return None
+
+
+@dataclass
+class _Entry:
+    value: Any
+    expires_at: float
+
+
+class TtlTokenCache:
+    """A TTL cache whose entries are additionally bounded by a bearer token's expiry."""
+
+    def __init__(self, ttl_seconds: float, name: str = "cache") -> None:
+        self._ttl = ttl_seconds
+        self._name = name
+        self._store: dict[str, _Entry] = {}
+
+    def get(self, key: str) -> Any | None:
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+        if entry.expires_at <= time.time():
+            self._store.pop(key, None)
+            return None
+        return entry.value
+
+    def put(self, key: str, value: Any, access_token: str | None) -> None:
+        expires_at = time.time() + self._ttl
+        exp = token_exp(access_token)
+        if exp is not None:
+            expires_at = min(expires_at, exp - _TOKEN_EXP_MARGIN_S)
+        if expires_at <= time.time():
+            return  # token already (nearly) expired — don't cache a stale entry
+        self._store[key] = _Entry(value=value, expires_at=expires_at)
+
+    def clear(self) -> None:
+        n = len(self._store)
+        self._store.clear()
+        if n:
+            logger.info("[%s] cleared %d entries", self._name, n)
+
+
+_discovery_cache: TtlTokenCache | None = None
+_user_cache: TtlTokenCache | None = None
+
+
+def get_discovery_cache(ttl_seconds: float | None = None) -> TtlTokenCache:
+    """Process-wide cache of discovered (tools, sub_agents) tuples."""
+    global _discovery_cache
+    if _discovery_cache is None:
+        _discovery_cache = TtlTokenCache(ttl_seconds if ttl_seconds is not None else 300.0, name="DISCOVERY-CACHE")
+    return _discovery_cache
+
+
+def get_user_cache(ttl_seconds: float | None = None) -> TtlTokenCache:
+    """Process-wide cache of registry User records."""
+    global _user_cache
+    if _user_cache is None:
+        _user_cache = TtlTokenCache(ttl_seconds if ttl_seconds is not None else 300.0, name="USER-CACHE")
+    return _user_cache
+
+
+def invalidate_all() -> None:
+    """Drop all cached discovery + user records.
+
+    Call when a cross-cutting entitlement policy changes (e.g. a group→server/tool access
+    mapping). Exposed so console-backend (or an admin action) can trigger invalidation
+    without waiting for the TTL or bumping ENTITLEMENT_POLICY_VERSION via redeploy.
+    """
+    if _discovery_cache is not None:
+        _discovery_cache.clear()
+    if _user_cache is not None:
+        _user_cache.clear()

--- a/packages/orchestrator-agent/app/core/executor.py
+++ b/packages/orchestrator-agent/app/core/executor.py
@@ -52,7 +52,7 @@ from .a2a_extensions import (
 from ..handlers import StreamHandler
 from .agent import OrchestratorDeepAgent
 from .budget_guard import get_budget_guard
-from .discovery_cache import entitlement_key, get_discovery_cache, get_user_cache, user_key
+from .discovery_cache import cache_key, get_discovery_cache, get_user_cache
 from .registry import RegistryService, User
 from .turn_state import TurnState, count_tool_messages
 from .steering_state import (
@@ -264,14 +264,13 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
         # list_tools) on every turn. Keyed by the entitlement-determining inputs so group
         # changes invalidate automatically; entries are bounded by the token expiry.
         cache = get_discovery_cache(AgentSettings.AGENT_DISCOVERY_CACHE_TTL)
-        cache_key = entitlement_key(
+        dkey = cache_key(
             user_sub=user_config.user_sub,
             groups=user_config.groups,
             sub_agent_config_hash=user_config.sub_agent_config_hash,
-            tool_names=user.tool_names,
             policy_version=AgentSettings.ENTITLEMENT_POLICY_VERSION,
         )
-        cached = cache.get(cache_key)
+        cached = cache.get(dkey)
         if cached is not None:
             tools, sub_agents = cached
             logger.info(
@@ -293,7 +292,12 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
                 user_config.access_token.get_secret_value(),
                 white_list=None,  # Don't filter here - GP agent needs access to all tools
             )
-            cache.put(cache_key, (tools, sub_agents), user_config.access_token.get_secret_value())
+            cache.put(
+                dkey,
+                (tools, sub_agents),
+                user_config.access_token.get_secret_value(),
+                owner=user_config.user_sub,
+            )
             logger.info(
                 "[DISCOVERY-CACHE] miss → discovered %d tools, %d sub-agents for user_sub=%s",
                 len(tools),
@@ -456,7 +460,7 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
         # (keyed incl. groups + policy_version) to avoid the ~1s of console-backend calls
         # on every turn; entry bounded by the user token's expiry.
         ucache = get_user_cache(AgentSettings.AGENT_DISCOVERY_CACHE_TTL)
-        ukey = user_key(
+        ukey = cache_key(
             user_sub=user_sub,
             groups=user_groups,
             sub_agent_config_hash=sub_agent_config_hash,
@@ -471,7 +475,7 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
                 access_token=user_token,
                 sub_agent_config_hash=sub_agent_config_hash,
             )
-            ucache.put(ukey, user, user_token)
+            ucache.put(ukey, user, user_token, owner=user_sub)
             logger.info(f"[REGISTRY] Retrieved user from registry: database_id={user.id}, sub={user.sub}")
 
         # Extract metadata from both message-level and params-level (message takes priority)

--- a/packages/orchestrator-agent/app/core/executor.py
+++ b/packages/orchestrator-agent/app/core/executor.py
@@ -35,7 +35,7 @@ from ringier_a2a_sdk.server.executor import (
 
 from app.models.responses import AgentStreamResponse
 
-from ..models.config import UserConfig
+from ..models.config import AgentSettings, UserConfig
 from .a2a_extensions import (
     ACTIVITY_LOG_EXTENSION,
     FEEDBACK_REQUEST_EXTENSION,
@@ -52,6 +52,7 @@ from .a2a_extensions import (
 from ..handlers import StreamHandler
 from .agent import OrchestratorDeepAgent
 from .budget_guard import get_budget_guard
+from .discovery_cache import entitlement_key, get_discovery_cache, get_user_cache, user_key
 from .registry import RegistryService, User
 from .turn_state import TurnState, count_tool_messages
 from .steering_state import (
@@ -258,22 +259,49 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
             tool_bypass_rules=user.tool_bypass_rules,
         )
 
-        # Discover capabilities (tools and sub-agents)
-        logger.debug(f"Discovering capabilities for user_sub: {user_config.user_sub}")
-        sub_agents = await self.agent.agent_discovery_service.register_agents(
-            agent_metadata=user_config.agent_metadata or {},
-            token=user_config.access_token.get_secret_value(),
+        # Discover capabilities (tools and sub-agents), memoized per-user to avoid
+        # re-running the ~3s discovery (gatana token exchange + fetch servers + per-server
+        # list_tools) on every turn. Keyed by the entitlement-determining inputs so group
+        # changes invalidate automatically; entries are bounded by the token expiry.
+        cache = get_discovery_cache(AgentSettings.AGENT_DISCOVERY_CACHE_TTL)
+        cache_key = entitlement_key(
+            user_sub=user_config.user_sub,
+            groups=user_config.groups,
+            sub_agent_config_hash=user_config.sub_agent_config_hash,
+            tool_names=user.tool_names,
+            policy_version=AgentSettings.ENTITLEMENT_POLICY_VERSION,
         )
-
-        # Discover ALL tools (without whitelist)
-        # The whitelist will be applied later in build_runtime_context for orchestrator binding
-        # Server info is stored in tool.metadata["server_name"] by MultiServerMCPClient
-        tools = await self.agent.tool_discovery_service.discover_tools(
-            user_config.access_token.get_secret_value(),
-            white_list=None,  # Don't filter here - GP agent needs access to all tools
-        )
+        cached = cache.get(cache_key)
+        if cached is not None:
+            tools, sub_agents = cached
+            logger.info(
+                "[DISCOVERY-CACHE] hit for user_sub=%s (%d tools, %d sub-agents) — skipping discovery",
+                user_config.user_sub,
+                len(tools),
+                len(sub_agents),
+            )
+        else:
+            logger.debug(f"[DISCOVERY-CACHE] miss; discovering capabilities for user_sub: {user_config.user_sub}")
+            sub_agents = await self.agent.agent_discovery_service.register_agents(
+                agent_metadata=user_config.agent_metadata or {},
+                token=user_config.access_token.get_secret_value(),
+            )
+            # Discover ALL tools (without whitelist)
+            # The whitelist will be applied later in build_runtime_context for orchestrator binding
+            # Server info is stored in tool.metadata["server_name"] by MultiServerMCPClient
+            tools = await self.agent.tool_discovery_service.discover_tools(
+                user_config.access_token.get_secret_value(),
+                white_list=None,  # Don't filter here - GP agent needs access to all tools
+            )
+            cache.put(cache_key, (tools, sub_agents), user_config.access_token.get_secret_value())
+            logger.info(
+                "[DISCOVERY-CACHE] miss → discovered %d tools, %d sub-agents for user_sub=%s",
+                len(tools),
+                len(sub_agents),
+                user_config.user_sub,
+            )
         logger.debug(f"Discovered {len(sub_agents)} sub-agents: {[agent['name'] for agent in sub_agents]}")
-        logger.debug(f"Discovered {len(tools)} total tools (unfiltered)")
+        logger.debug(f"Discovered {len(tools)} total tools (cached or fresh)")
 
         # Update user_config with discovered data
         user_config.tools = tools
@@ -424,14 +452,27 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
         if sub_agent_config_hash:
             logger.info(f"[CONSOLE] Console mode enabled for sub-agent config hash: {sub_agent_config_hash}")
 
-        # Fetch user from registry to get stable database ID (user.id)
-        # This allows us to use the database ID in config metadata instead of OIDC sub e.g. for docstore read/write
-        user = await self._get_user_from_registry(
-            user_sub,
-            access_token=user_token,
+        # Fetch user from registry to get stable database ID (user.id). Memoized per-user
+        # (keyed incl. groups + policy_version) to avoid the ~1s of console-backend calls
+        # on every turn; entry bounded by the user token's expiry.
+        ucache = get_user_cache(AgentSettings.AGENT_DISCOVERY_CACHE_TTL)
+        ukey = user_key(
+            user_sub=user_sub,
+            groups=user_groups,
             sub_agent_config_hash=sub_agent_config_hash,
+            policy_version=AgentSettings.ENTITLEMENT_POLICY_VERSION,
         )
-        logger.info(f"[REGISTRY] Retrieved user from registry: database_id={user.id}, sub={user.sub}")
+        user = ucache.get(ukey)
+        if user is not None:
+            logger.info(f"[USER-CACHE] hit for user_sub={user_sub}, database_id={user.id}")
+        else:
+            user = await self._get_user_from_registry(
+                user_sub,
+                access_token=user_token,
+                sub_agent_config_hash=sub_agent_config_hash,
+            )
+            ucache.put(ukey, user, user_token)
+            logger.info(f"[REGISTRY] Retrieved user from registry: database_id={user.id}, sub={user.sub}")
 
         # Extract metadata from both message-level and params-level (message takes priority)
         logger.info(f"[EXECUTOR] Params-level metadata: {context.metadata}")

--- a/packages/orchestrator-agent/app/models/config.py
+++ b/packages/orchestrator-agent/app/models/config.py
@@ -300,7 +300,13 @@ class AgentSettings:
     """Model to use for server and tool selection (fast, cheap model preferred)."""
 
     # Cache configuration
-    AGENT_DISCOVERY_CACHE_TTL = 30  # seconds
+    AGENT_DISCOVERY_CACHE_TTL = int(
+        os.getenv("AGENT_DISCOVERY_CACHE_TTL", "300")
+    )  # seconds; per-user discovery + registry cache
+    # Cross-cutting invalidation lever for the discovery/registry caches: bump this (env)
+    # or call discovery_cache.invalidate_all() when a group→server/tool access policy
+    # changes without the user's own groups/config changing.
+    ENTITLEMENT_POLICY_VERSION = os.getenv("ENTITLEMENT_POLICY_VERSION", "0")
 
     # PostgreSQL checkpoint configuration.
     # The checkpointer reuses the main POSTGRES_* connection (same DB/user/schema as the

--- a/packages/orchestrator-agent/app/models/config.py
+++ b/packages/orchestrator-agent/app/models/config.py
@@ -19,6 +19,23 @@ from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, SecretStr
 
 logger = logging.getLogger(__name__)
 
+
+def _int_env(name: str, default: int) -> int:
+    """Parse an int env var, falling back to ``default`` (with a warning) on a bad value.
+
+    A misconfigured value (e.g. ``"300s"`` or an empty string) must not crash the process
+    at import time — fall back to the default instead.
+    """
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return int(raw.strip())
+    except ValueError:
+        logger.warning("Invalid int for %s=%r; using default %d", name, raw, default)
+        return default
+
+
 # Message formatting literal for type safety
 
 if TYPE_CHECKING:
@@ -299,10 +316,13 @@ class AgentSettings:
     TOOLSET_SELECTION_MODEL: ModelType = os.getenv("TOOLSET_SELECTION_MODEL", "gpt-4o-mini")  # type: ignore
     """Model to use for server and tool selection (fast, cheap model preferred)."""
 
-    # Cache configuration
-    AGENT_DISCOVERY_CACHE_TTL = int(
-        os.getenv("AGENT_DISCOVERY_CACHE_TTL", "300")
-    )  # seconds; per-user discovery + registry cache
+    # Cache configuration.
+    # Per-user discovery + registry cache TTL (seconds). Kept well below a typical realm
+    # access-token lifespan so a cache entry can never outlive the exchanged gatana/console
+    # tokens embedded in the discovered tools (see discovery_cache "Token-expiry safety"),
+    # and so an entitlement *revocation* that only reaches one replica (the invalidation POST
+    # is in-process / single-replica) self-heals fleet-wide within the TTL.
+    AGENT_DISCOVERY_CACHE_TTL = _int_env("AGENT_DISCOVERY_CACHE_TTL", 60)
     # Cross-cutting invalidation lever for the discovery/registry caches: bump this (env)
     # or call discovery_cache.invalidate_all() when a group→server/tool access policy
     # changes without the user's own groups/config changing.

--- a/packages/orchestrator-agent/main.py
+++ b/packages/orchestrator-agent/main.py
@@ -3,6 +3,8 @@ import os
 import sys
 from contextlib import asynccontextmanager
 
+import jwt
+
 # Load .env BEFORE any agent_common imports (MODEL_CONFIG is built at import time)
 from dotenv import load_dotenv
 
@@ -36,7 +38,7 @@ from a2a.types import (
     SecurityScheme,
     StringList,
 )
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from google.protobuf.json_format import MessageToDict
 from agent_common.core.model_factory import MODEL_CONFIG, get_available_models_metadata, get_default_model
@@ -61,7 +63,12 @@ from app.core.a2a_extensions import (
 )
 from app.core.agent import OrchestratorDeepAgent
 from app.core.budget_guard import init_budget_guard
-from app.core.discovery_cache import invalidate_all as invalidate_discovery_caches
+from app.core.discovery_cache import (
+    invalidate_all as invalidate_discovery_caches,
+)
+from app.core.discovery_cache import (
+    invalidate_users as invalidate_discovery_for_users,
+)
 from app.core.executor import OrchestratorDeepAgentExecutor
 from app.core.risk_score_api_client import HttpRiskScoreAPIClient
 from app.core.task_store import create_task_store
@@ -417,27 +424,70 @@ async def list_available_models():
     return metadata
 
 
+def _caller_azp(request: Request) -> str | None:
+    """Read the validated bearer's ``azp`` (authorized party) claim, or None.
+
+    The JWT was already verified by ``JWTValidatorMiddleware`` (signature/issuer/expiry),
+    which stores the raw token on ``request.state.user``; here we only read a claim, so
+    decoding without re-verifying is fine.
+    """
+    user = getattr(request.state, "user", None)
+    token = user.get("token") if isinstance(user, dict) else None
+    if not token:
+        return None
+    try:
+        return jwt.decode(token, options={"verify_signature": False}).get("azp")
+    except Exception:
+        return None
+
+
 @app.post("/internal/discovery-cache/invalidate")
-async def invalidate_discovery_cache() -> JSONResponse:
-    """Flush this replica's per-user discovery + registry caches.
+async def invalidate_discovery_cache(request: Request) -> JSONResponse:
+    """Flush per-user discovery + registry caches on this replica.
 
-    console-backend calls this when an admin changes a group→MCP-server or
-    group→default-agent mapping, so the affected users' entitlements take effect on their
-    next turn instead of waiting out the cache TTL. Idempotent and cheap.
+    console-backend calls this when a group→MCP-server / group→default-agent mapping or a
+    per-user entitlement (role, tool whitelist, bypass rules) changes, so the affected
+    users' entitlements take effect on their next turn instead of waiting out the TTL.
 
-    Auth: protected by the orchestrator's standard OIDC JWT middleware (this is not a
-    public path). The admin gate lives in console-backend — the calling routes require an
-    admin, and console-backend exchanges that admin's token for this service's audience
-    before calling. The action only clears an in-memory cache, so the blast radius of an
-    unexpected authenticated call is a brief cache rebuild.
+    Scope: the body may carry ``{"user_subs": [...]}`` to flush only those users' entries
+    (the normal path — console-backend computes the affected set, e.g. the members of the
+    changed group). An empty/absent body flushes everything (unscoped admin/maintenance
+    flush). Scoping keeps a single group edit from evicting every active user's cache and
+    triggering a re-discovery storm.
+
+    Auth: behind the orchestrator's OIDC JWT middleware (not a public path) AND restricted
+    here to the console-backend service client — the validated token's ``azp`` must equal
+    ``CONSOLE_BACKEND_CLIENT_ID``. This stops any other authenticated principal (e.g. an
+    end-user token) from flushing caches. When the auth middleware is disabled (no OIDC
+    issuer configured, dev only) there is no token to check and the call is allowed.
 
     Multi-replica note: the cache is in-process, so one call flushes one replica. Behind a
-    load balancer the other replicas fall back to the TTL (or bump
-    ``ENTITLEMENT_POLICY_VERSION`` for a fleet-wide flush). A fan-out/pub-sub broadcast is
-    the follow-up for instant fleet-wide invalidation.
+    load balancer the other replicas fall back to the TTL (kept short for this reason) or a
+    ``ENTITLEMENT_POLICY_VERSION`` bump for a fleet-wide flush. A fan-out/pub-sub broadcast
+    is the follow-up for instant fleet-wide invalidation.
     """
+    azp = _caller_azp(request)
+    if azp is not None and azp != AgentSettings.CONSOLE_BACKEND_CLIENT_ID:
+        logger.warning("Rejected discovery-cache invalidation from unexpected azp=%s", azp)
+        return JSONResponse(status_code=403, content={"error": "forbidden", "message": "caller not permitted"})
+
+    user_subs: list[str] | None = None
+    try:
+        body = await request.json()
+        if isinstance(body, dict):
+            subs = body.get("user_subs")
+            if isinstance(subs, list):
+                user_subs = [s for s in subs if isinstance(s, str)]
+    except Exception:
+        body = None  # empty/invalid body → unscoped flush
+
+    if user_subs:
+        removed = invalidate_discovery_for_users(user_subs)
+        logger.info("Scoped discovery-cache invalidation: %d users, %d entries dropped", len(user_subs), removed)
+        return JSONResponse({"status": "ok", "scope": "users", "users": len(user_subs), "removed": removed})
+
     invalidate_discovery_caches()
-    return JSONResponse({"status": "ok"})
+    return JSONResponse({"status": "ok", "scope": "all"})
 
 
 @click.command()

--- a/packages/orchestrator-agent/main.py
+++ b/packages/orchestrator-agent/main.py
@@ -61,6 +61,7 @@ from app.core.a2a_extensions import (
 )
 from app.core.agent import OrchestratorDeepAgent
 from app.core.budget_guard import init_budget_guard
+from app.core.discovery_cache import invalidate_all as invalidate_discovery_caches
 from app.core.executor import OrchestratorDeepAgentExecutor
 from app.core.risk_score_api_client import HttpRiskScoreAPIClient
 from app.core.task_store import create_task_store
@@ -414,6 +415,29 @@ async def list_available_models():
             logger.debug("Could not fetch live models from LLM server: %s", e)
 
     return metadata
+
+
+@app.post("/internal/discovery-cache/invalidate")
+async def invalidate_discovery_cache() -> JSONResponse:
+    """Flush this replica's per-user discovery + registry caches.
+
+    console-backend calls this when an admin changes a group→MCP-server or
+    group→default-agent mapping, so the affected users' entitlements take effect on their
+    next turn instead of waiting out the cache TTL. Idempotent and cheap.
+
+    Auth: protected by the orchestrator's standard OIDC JWT middleware (this is not a
+    public path). The admin gate lives in console-backend — the calling routes require an
+    admin, and console-backend exchanges that admin's token for this service's audience
+    before calling. The action only clears an in-memory cache, so the blast radius of an
+    unexpected authenticated call is a brief cache rebuild.
+
+    Multi-replica note: the cache is in-process, so one call flushes one replica. Behind a
+    load balancer the other replicas fall back to the TTL (or bump
+    ``ENTITLEMENT_POLICY_VERSION`` for a fleet-wide flush). A fan-out/pub-sub broadcast is
+    the follow-up for instant fleet-wide invalidation.
+    """
+    invalidate_discovery_caches()
+    return JSONResponse({"status": "ok"})
 
 
 @click.command()

--- a/packages/orchestrator-agent/tests/test_config.py
+++ b/packages/orchestrator-agent/tests/test_config.py
@@ -29,7 +29,8 @@ class TestAgentSettings:
 
     def test_cache_configuration(self):
         """Test cache configuration."""
-        assert AgentSettings.AGENT_DISCOVERY_CACHE_TTL == 30
+        assert AgentSettings.AGENT_DISCOVERY_CACHE_TTL == 300
+        assert AgentSettings.ENTITLEMENT_POLICY_VERSION == "0"
 
     def test_postgres_checkpoint_configuration(self):
         """Test Postgres checkpoint configuration defaults.

--- a/packages/orchestrator-agent/tests/test_config.py
+++ b/packages/orchestrator-agent/tests/test_config.py
@@ -29,7 +29,7 @@ class TestAgentSettings:
 
     def test_cache_configuration(self):
         """Test cache configuration."""
-        assert AgentSettings.AGENT_DISCOVERY_CACHE_TTL == 300
+        assert AgentSettings.AGENT_DISCOVERY_CACHE_TTL == 60
         assert AgentSettings.ENTITLEMENT_POLICY_VERSION == "0"
 
     def test_postgres_checkpoint_configuration(self):

--- a/packages/orchestrator-agent/tests/test_discovery_cache.py
+++ b/packages/orchestrator-agent/tests/test_discovery_cache.py
@@ -7,12 +7,12 @@ import time
 from app.core import discovery_cache as dc
 from app.core.discovery_cache import (
     TtlTokenCache,
-    entitlement_key,
+    cache_key,
     get_discovery_cache,
     get_user_cache,
     invalidate_all,
+    invalidate_users,
     token_exp,
-    user_key,
 )
 
 
@@ -21,38 +21,26 @@ def _jwt_with_exp(exp: int) -> str:
     return f"header.{payload}.sig"
 
 
-class TestEntitlementKey:
-    def test_stable_across_group_and_tool_order(self):
-        a = entitlement_key("u", ["b", "a"], "cfg", ["t2", "t1"])
-        b = entitlement_key("u", ["a", "b"], "cfg", ["t1", "t2"])
-        assert a == b
+class TestCacheKey:
+    def test_stable_across_group_order(self):
+        assert cache_key("u", ["b", "a"], "cfg") == cache_key("u", ["a", "b"], "cfg")
 
     def test_changes_when_group_added(self):
-        a = entitlement_key("u", ["a", "b"], "cfg", ["t1"])
-        b = entitlement_key("u", ["a", "b", "c"], "cfg", ["t1"])
-        assert a != b
-
-    def test_changes_when_tool_names_change(self):
-        a = entitlement_key("u", ["a"], "cfg", ["t1"])
-        b = entitlement_key("u", ["a"], "cfg", ["t1", "t2"])
-        assert a != b
+        assert cache_key("u", ["a", "b"], "cfg") != cache_key("u", ["a", "b", "c"], "cfg")
 
     def test_changes_with_policy_version(self):
-        a = entitlement_key("u", ["a"], "cfg", ["t1"], policy_version="0")
-        b = entitlement_key("u", ["a"], "cfg", ["t1"], policy_version="1")
-        assert a != b
+        assert cache_key("u", ["a"], "cfg", "0") != cache_key("u", ["a"], "cfg", "1")
 
     def test_changes_with_user(self):
-        assert entitlement_key("u1", [], None, []) != entitlement_key("u2", [], None, [])
+        assert cache_key("u1", [], None) != cache_key("u2", [], None)
 
+    def test_changes_with_config_hash(self):
+        assert cache_key("u", ["a"], "cfg1") != cache_key("u", ["a"], "cfg2")
 
-class TestUserKey:
-    def test_excludes_tool_names_but_keys_groups_and_policy(self):
-        a = user_key("u", ["a"], "cfg", "0")
-        b = user_key("u", ["a"], "cfg", "0")
-        assert a == b
-        assert user_key("u", ["a"], "cfg", "0") != user_key("u", ["a", "b"], "cfg", "0")
-        assert user_key("u", ["a"], "cfg", "0") != user_key("u", ["a"], "cfg", "1")
+    def test_no_tool_names_param(self):
+        # tool_names is intentionally not part of the key (discovery is unfiltered); equal
+        # inputs always collide regardless of any per-user tool whitelist.
+        assert cache_key("u", ["a"], "cfg", "0") == cache_key("u", ["a"], "cfg", "0")
 
 
 class TestTokenExp:
@@ -105,6 +93,47 @@ class TestTtlTokenCache:
         c.put("k", "v", None)
         c.clear()
         assert c.get("k") is None
+
+    def test_invalidate_owner_drops_only_matching(self):
+        c = TtlTokenCache(300)
+        c.put("k1", "v1", None, owner="alice")
+        c.put("k2", "v2", None, owner="bob")
+        c.put("k3", "v3", None, owner="alice")
+        removed = c.invalidate_owner("alice")
+        assert removed == 2
+        assert c.get("k1") is None and c.get("k3") is None
+        assert c.get("k2") == "v2"
+
+    def test_invalidate_owner_unknown_is_noop(self):
+        c = TtlTokenCache(300)
+        c.put("k", "v", None, owner="alice")
+        assert c.invalidate_owner("nobody") == 0
+        assert c.get("k") == "v"
+
+    def test_max_entries_bounds_size(self):
+        c = TtlTokenCache(ttl_seconds=300, max_entries=3)
+        for i in range(10):
+            c.put(f"k{i}", i, None)
+        assert len(c._store) <= 3
+
+
+class TestScopedInvalidation:
+    def test_invalidate_users_targets_only_given_subs(self):
+        get_discovery_cache(300).put("d-alice", ("t", "s"), None, owner="alice")
+        get_discovery_cache().put("d-bob", ("t", "s"), None, owner="bob")
+        get_user_cache(300).put("u-alice", object(), None, owner="alice")
+        get_user_cache().put("u-bob", object(), None, owner="bob")
+
+        removed = invalidate_users(["alice"])
+        assert removed == 2  # one discovery + one user entry for alice
+        assert get_discovery_cache().get("d-alice") is None
+        assert get_user_cache().get("u-alice") is None
+        assert get_discovery_cache().get("d-bob") is not None
+        assert get_user_cache().get("u-bob") is not None
+
+    def teardown_method(self):
+        dc._discovery_cache = None
+        dc._user_cache = None
 
 
 class TestInvalidateAll:

--- a/packages/orchestrator-agent/tests/test_discovery_cache.py
+++ b/packages/orchestrator-agent/tests/test_discovery_cache.py
@@ -1,0 +1,123 @@
+"""Unit tests for the per-user discovery + registry caches."""
+
+import base64
+import json
+import time
+
+from app.core import discovery_cache as dc
+from app.core.discovery_cache import (
+    TtlTokenCache,
+    entitlement_key,
+    get_discovery_cache,
+    get_user_cache,
+    invalidate_all,
+    token_exp,
+    user_key,
+)
+
+
+def _jwt_with_exp(exp: int) -> str:
+    payload = base64.urlsafe_b64encode(json.dumps({"exp": exp}).encode()).decode().rstrip("=")
+    return f"header.{payload}.sig"
+
+
+class TestEntitlementKey:
+    def test_stable_across_group_and_tool_order(self):
+        a = entitlement_key("u", ["b", "a"], "cfg", ["t2", "t1"])
+        b = entitlement_key("u", ["a", "b"], "cfg", ["t1", "t2"])
+        assert a == b
+
+    def test_changes_when_group_added(self):
+        a = entitlement_key("u", ["a", "b"], "cfg", ["t1"])
+        b = entitlement_key("u", ["a", "b", "c"], "cfg", ["t1"])
+        assert a != b
+
+    def test_changes_when_tool_names_change(self):
+        a = entitlement_key("u", ["a"], "cfg", ["t1"])
+        b = entitlement_key("u", ["a"], "cfg", ["t1", "t2"])
+        assert a != b
+
+    def test_changes_with_policy_version(self):
+        a = entitlement_key("u", ["a"], "cfg", ["t1"], policy_version="0")
+        b = entitlement_key("u", ["a"], "cfg", ["t1"], policy_version="1")
+        assert a != b
+
+    def test_changes_with_user(self):
+        assert entitlement_key("u1", [], None, []) != entitlement_key("u2", [], None, [])
+
+
+class TestUserKey:
+    def test_excludes_tool_names_but_keys_groups_and_policy(self):
+        a = user_key("u", ["a"], "cfg", "0")
+        b = user_key("u", ["a"], "cfg", "0")
+        assert a == b
+        assert user_key("u", ["a"], "cfg", "0") != user_key("u", ["a", "b"], "cfg", "0")
+        assert user_key("u", ["a"], "cfg", "0") != user_key("u", ["a"], "cfg", "1")
+
+
+class TestTokenExp:
+    def test_parses_exp(self):
+        exp = int(time.time()) + 1234
+        assert abs((token_exp(_jwt_with_exp(exp)) or 0) - exp) < 1
+
+    def test_none_on_garbage(self):
+        assert token_exp(None) is None
+        assert token_exp("not-a-jwt") is None
+        assert token_exp("a.b.c") is None  # b not valid base64 json
+
+
+class TestTtlTokenCache:
+    def test_get_put_hit(self):
+        c = TtlTokenCache(ttl_seconds=300)
+        c.put("k", ("tools", "subs"), _jwt_with_exp(int(time.time()) + 3600))
+        assert c.get("k") == ("tools", "subs")
+
+    def test_miss_returns_none(self):
+        assert TtlTokenCache(300).get("absent") is None
+
+    def test_ttl_expiry(self):
+        c = TtlTokenCache(ttl_seconds=0.05)
+        c.put("k", "v", _jwt_with_exp(int(time.time()) + 3600))
+        assert c.get("k") == "v"
+        time.sleep(0.1)
+        assert c.get("k") is None
+
+    def test_entry_bounded_by_token_exp(self):
+        # token expires in 40s; with 30s margin the entry must live <= ~10s, not the 300s TTL
+        c = TtlTokenCache(ttl_seconds=300)
+        c.put("k", "v", _jwt_with_exp(int(time.time()) + 40))
+        entry = c._store["k"]
+        assert entry.expires_at <= time.time() + 11  # ~ (40 - 30) margin, well under 300
+
+    def test_skips_caching_when_token_already_expiring(self):
+        c = TtlTokenCache(ttl_seconds=300)
+        c.put("k", "v", _jwt_with_exp(int(time.time()) + 10))  # within the 30s margin
+        assert c.get("k") is None
+
+    def test_no_token_uses_full_ttl(self):
+        c = TtlTokenCache(ttl_seconds=300)
+        c.put("k", "v", None)
+        assert c.get("k") == "v"
+        assert c._store["k"].expires_at > time.time() + 290
+
+    def test_clear(self):
+        c = TtlTokenCache(300)
+        c.put("k", "v", None)
+        c.clear()
+        assert c.get("k") is None
+
+
+class TestInvalidateAll:
+    def test_clears_both_singletons(self):
+        get_discovery_cache(300).put("d", ("t", "s"), None)
+        get_user_cache(300).put("u", object(), None)
+        assert get_discovery_cache().get("d") is not None
+        assert get_user_cache().get("u") is not None
+        invalidate_all()
+        assert get_discovery_cache().get("d") is None
+        assert get_user_cache().get("u") is None
+
+    def teardown_method(self):
+        # reset module singletons so tests don't bleed
+        dc._discovery_cache = None
+        dc._user_cache = None


### PR DESCRIPTION
Adds a per-user discovery/registry cache to the orchestrator and invalidates it across services when an access policy changes. Rebased on current main (after #80/#81/#83).

## Orchestrator
- **`discovery_cache`** — per-user cache of agent discovery + registry lookups, keyed by user and an entitlement-policy version; exposes `invalidate_all()`.
- **`main`** — internal `POST /internal/discovery-cache/invalidate`, behind the standard OIDC JWT middleware (no public-path carve-out, **no shared secret**).
- **`executor`** — read-through / populate the discovery cache.
- **`config`** — `AGENT_DISCOVERY_CACHE_TTL` (env, default 300s) + `ENTITLEMENT_POLICY_VERSION`.

## Console-backend
- **`orchestrator_cache`** — calls the invalidation endpoint, authenticated **service-to-service via the OIDC client-credentials grant** (console-backend mints a token for the orchestrator audience with its own client id/secret). No user token is involved, so it works regardless of whether an **admin or a group manager** triggered the change.
- **`group_router` / `admin_mcp_gateway_server_access_router`** — invalidate the discovery cache when group membership / MCP-gateway server access changes.
- **`app.py`** — import-ordering cleanup.

## Auth design note
Earlier revisions used a shared `INTERNAL_CACHE_INVALIDATION_TOKEN`, then the caller's exchanged token. Both were dropped: the shared secret is operational overhead for a harmless cache-flush, and the caller's token coupled a service-to-service action to whoever triggered it (and `group_router` allows non-admin group managers). Client credentials is the right fit — a trusted service telling another to flush its cache.

## Verification
- Unit: orchestrator `test_discovery_cache` + `test_config` (22 passed); console-backend `test_orchestrator_cache` (4 passed, covers client-credentials Bearer + best-effort swallow).
- **End-to-end (QA, local):** toggling a group's default agents in the Console produced `Invalidated orchestrator discovery cache (...)` in console-backend logs, with the orchestrator JWT-validating the client-credentials token at matching timestamps. No `Failed to invalidate…`. Confirms the client-credentials grant works against local Keycloak and the group-manager path invalidates correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)