### PR TITLE
fix: use async aget_state in agent-common final-state helper

### DIFF
--- a/packages/agent-common/agent_common/a2a/stream_utils.py
+++ b/packages/agent-common/agent_common/a2a/stream_utils.py
@@ -3,11 +3,14 @@
 from typing import Any, Dict
 
 
-def retrieve_final_state(graph: Any, config: Dict[str, Any]) -> Dict[str, Any]:
+async def retrieve_final_state(graph: Any, config: Dict[str, Any]) -> Dict[str, Any]:
     """Retrieve and validate the final state values from a LangGraph graph.
 
-    Wraps the common ``get_state() → validate → .values`` pattern used by
+    Wraps the common ``aget_state() → validate → .values`` pattern used by
     GPAgentRunnable and DynamicLocalAgentRunnable after streaming completes.
+
+    Uses the async ``aget_state``: AsyncPostgresSaver forbids synchronous
+    ``get_state()`` from the running event loop.
 
     Args:
         graph: A compiled LangGraph ``StateGraph`` instance.
@@ -19,7 +22,7 @@ def retrieve_final_state(graph: Any, config: Dict[str, Any]) -> Dict[str, Any]:
     Raises:
         ValueError: If the state is ``None`` or has no values.
     """
-    final_state = graph.get_state(config)
+    final_state = await graph.aget_state(config)
     if final_state is None or not final_state.values:
         raise ValueError("Stream completed but could not retrieve final state")
     return final_state.values

--- a/packages/agent-common/agent_common/agents/dynamic_agent.py
+++ b/packages/agent-common/agent_common/agents/dynamic_agent.py
@@ -1457,7 +1457,7 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                 raise GraphInterrupt(post_state.interrupts)
 
             # Retrieve final state (checkpointer saves it after each node)
-            final_values = retrieve_final_state(agent, standalone_config)
+            final_values = await retrieve_final_state(agent, standalone_config)
             result = self._translate_agent_result(final_values, context_id, task_id)
 
             # Yield terminal result

--- a/packages/agent-common/tests/test_stream_utils.py
+++ b/packages/agent-common/tests/test_stream_utils.py
@@ -276,32 +276,37 @@ class TestExtractTextFromContent:
 
 
 class TestRetrieveFinalState:
-    def test_returns_values_on_success(self):
+    # retrieve_final_state is async and uses aget_state (AsyncPostgresSaver forbids
+    # synchronous get_state from the running event loop).
+    @pytest.mark.asyncio
+    async def test_returns_values_on_success(self):
         class MockState:
             values = {"messages": ["hello"]}
 
         class MockGraph:
-            def get_state(self, config):
+            async def aget_state(self, config):
                 return MockState()
 
-        result = retrieve_final_state(MockGraph(), {"configurable": {}})
+        result = await retrieve_final_state(MockGraph(), {"configurable": {}})
         assert result == {"messages": ["hello"]}
 
-    def test_raises_on_none_state(self):
+    @pytest.mark.asyncio
+    async def test_raises_on_none_state(self):
         class MockGraph:
-            def get_state(self, config):
+            async def aget_state(self, config):
                 return None
 
         with pytest.raises(ValueError, match="could not retrieve final state"):
-            retrieve_final_state(MockGraph(), {})
+            await retrieve_final_state(MockGraph(), {})
 
-    def test_raises_on_empty_values(self):
+    @pytest.mark.asyncio
+    async def test_raises_on_empty_values(self):
         class MockState:
             values = {}
 
         class MockGraph:
-            def get_state(self, config):
+            async def aget_state(self, config):
                 return MockState()
 
         with pytest.raises(ValueError, match="could not retrieve final state"):
-            retrieve_final_state(MockGraph(), {})
+            await retrieve_final_state(MockGraph(), {})

--- a/packages/agent-creator/README.md
+++ b/packages/agent-creator/README.md
@@ -59,7 +59,7 @@ See `.env.template` for all configuration options. Key variables:
 - `AGENT_ID`: Unique identifier for this agent (for provenance tracking)
 - `CONSOLE_BACKEND_URL`: URL of the console backend MCP endpoint
 - `AWS_BEDROCK_REGION`: AWS region for Bedrock access
-- `CHECKPOINT_POSTGRES_HOST`: PostgreSQL host for conversation state
+- `POSTGRES_HOST`: PostgreSQL host for conversation state (the checkpointer reuses the shared `POSTGRES_*` connection; tables live in `POSTGRES_SCHEMA`)
 
 ## Development
 

--- a/packages/agent-creator/agent/core.py
+++ b/packages/agent-creator/agent/core.py
@@ -7,7 +7,7 @@ specialized subagents through natural language conversation.
 import logging
 import os
 
-from agent_common.core.model_factory import MODEL_CONFIG, _has_aws_credentials, create_model, get_default_model
+from agent_common.core.model_factory import MODEL_CONFIG, create_model, get_default_model
 from langchain_core.language_models import BaseChatModel
 from langchain_mcp_adapters.sessions import StreamableHttpConnection
 from ringier_a2a_sdk.agent import LangGraphAgent
@@ -333,7 +333,8 @@ class AgentCreator(PostgreSQLCheckpointerMixin, LangGraphAgent):
     Architecture:
     - Extends LangGraphAgent base class (provider-agnostic)
     - LLM model selected dynamically based on available credentials
-    - Checkpointing: PostgreSQL when CHECKPOINT_POSTGRES_HOST is set, in-memory otherwise
+    - Checkpointing: PostgreSQL when POSTGRES_HOST is set (reuses the shared POSTGRES_*
+      connection / schema), in-memory otherwise
     - MCP tools discovered once at initialization (unauthenticated)
     - User credentials injected at runtime via TokenExchangeCredentialInjector
     """
@@ -398,7 +399,7 @@ class AgentCreator(PostgreSQLCheckpointerMixin, LangGraphAgent):
             "console": StreamableHttpConnection(
                 transport="streamable_http",
                 url=console_mcp_url,
-            )
+            ),
         }
 
     def _get_system_prompt(self) -> str:


### PR DESCRIPTION
## The bug
`retrieve_final_state` in `agent-common` (and its caller in `DynamicLocalAgentRunnable`) used the synchronous `graph.get_state()`. Under `AsyncPostgresSaver`, calling `get_state()` from the running event loop raises — the same issue fixed in the SDK's `langgraph.py` stream path in #80, but this code path (GP / dynamic local agents) was missed.

## Fix
- `stream_utils.retrieve_final_state`: now `async`, uses `await graph.aget_state(config)`.
- `dynamic_agent.py`: `await` the now-async helper.
- `test_stream_utils.py`: async-ify the three tests (32 passed).

## Also (small cleanups)
- `agent-creator/core.py` + `README.md`: update checkpointer docs (`CHECKPOINT_POSTGRES_HOST` → reused `POSTGRES_*`), drop an unused import.


🤖 Generated with [Claude Code](https://claude.com/claude-code)