### PR TITLE
feat(console): UI consistency pass for the major release

### DIFF
--- a/packages/console-frontend/package-lock.json
+++ b/packages/console-frontend/package-lock.json
@@ -27,6 +27,7 @@
         "@tailwindcss/vite": "^4.1.17",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cronstrue": "^2.59.0",
         "date-fns": "^4.1.0",
         "lucide-react": "^0.555.0",
         "next-themes": "^0.4.6",
@@ -4714,6 +4715,15 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/cronstrue": {
+      "version": "2.59.0",
+      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.59.0.tgz",
+      "integrity": "sha512-YKGmAy84hKH+hHIIER07VCAHf9u0Ldelx1uU6EBxsRPDXIA1m5fsKmJfyC3xBhw6cVC/1i83VdbL4PvepTrt8A==",
+      "license": "MIT",
+      "bin": {
+        "cronstrue": "bin/cli.js"
       }
     },
     "node_modules/cross-spawn": {

--- a/packages/console-frontend/package.json
+++ b/packages/console-frontend/package.json
@@ -30,6 +30,7 @@
     "@tailwindcss/vite": "^4.1.17",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cronstrue": "^2.59.0",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.555.0",
     "next-themes": "^0.4.6",

--- a/packages/console-frontend/src/components/CronField.tsx
+++ b/packages/console-frontend/src/components/CronField.tsx
@@ -1,0 +1,68 @@
+import { useMemo } from 'react';
+import { AlertCircle, Clock } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { CRON_PRESETS, describeCron } from '@/lib/cron';
+
+interface CronFieldProps {
+  id?: string;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+/**
+ * Cron expression input with preset quick-picks, live validation, and a
+ * human-readable description of the schedule.
+ */
+export function CronField({ id = 'cron', value, onChange }: CronFieldProps) {
+  const result = useMemo(() => describeCron(value), [value]);
+  const isBlank = value.trim() === '';
+  const showError = !isBlank && !result.ok;
+
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor={id}>
+        Cron expression{' '}
+        <span className="text-muted-foreground text-xs">(e.g. 0 9 * * 1-5)</span>
+      </Label>
+
+      <div className="flex flex-wrap gap-1.5">
+        {CRON_PRESETS.map((p) => (
+          <Button
+            key={p.expr}
+            type="button"
+            variant={value.trim() === p.expr ? 'secondary' : 'outline'}
+            size="sm"
+            className="h-7 px-2 text-xs"
+            onClick={() => onChange(p.expr)}
+          >
+            {p.label}
+          </Button>
+        ))}
+      </div>
+
+      <Input
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="0 9 * * 1-5"
+        className={showError ? 'border-destructive focus-visible:ring-destructive' : undefined}
+        aria-invalid={showError}
+      />
+
+      {result.ok && (
+        <p className="flex items-center gap-1.5 text-xs text-green-600 dark:text-green-500">
+          <Clock className="h-3 w-3 shrink-0" />
+          {result.text}
+        </p>
+      )}
+      {showError && (
+        <p className="flex items-center gap-1.5 text-xs text-destructive">
+          <AlertCircle className="h-3 w-3 shrink-0" />
+          {result.text}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/console-frontend/src/components/EmptyState.tsx
+++ b/packages/console-frontend/src/components/EmptyState.tsx
@@ -1,0 +1,55 @@
+import { type ReactNode } from 'react';
+import { Inbox, type LucideIcon } from 'lucide-react';
+import { TableCell, TableRow } from '@/components/ui/table';
+import { cn } from '@/lib/utils';
+
+interface EmptyStateProps {
+  icon?: LucideIcon;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Consistent empty state: centered icon + title + optional description/action.
+ * Use this instead of bare "No items found" text so empty lists look the same
+ * everywhere.
+ */
+export function EmptyState({
+  icon: Icon = Inbox,
+  title,
+  description,
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center gap-2 py-12 text-center',
+        className,
+      )}
+    >
+      <Icon className="h-8 w-8 text-muted-foreground" />
+      <p className="text-sm font-medium">{title}</p>
+      {description && (
+        <p className="max-w-sm text-sm text-muted-foreground">{description}</p>
+      )}
+      {action}
+    </div>
+  );
+}
+
+/** An `<EmptyState>` rendered as a full-width row inside a shadcn `<TableBody>`. */
+export function TableEmptyRow({
+  colSpan,
+  ...props
+}: EmptyStateProps & { colSpan: number }) {
+  return (
+    <TableRow className="hover:bg-transparent">
+      <TableCell colSpan={colSpan}>
+        <EmptyState {...props} />
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/packages/console-frontend/src/components/catalogs/SourceManager.tsx
+++ b/packages/console-frontend/src/components/catalogs/SourceManager.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useMemo, useRef, useEffect, type KeyboardEvent } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
+import { ConfirmDialog } from '@/components/admin/ConfirmDialog';
 import {
   HardDrive,
   Loader2,
@@ -244,6 +245,7 @@ export function SourceManager({ catalogId, canEdit }: SourceManagerProps) {
 
   // --- Wizard state ---
   const [step, setStep] = useState<WizardStep>('idle');
+  const [sourceToDelete, setSourceToDelete] = useState<{ id: string; label: string } | null>(null);
   const [selectedDrive, setSelectedDrive] = useState<{ id: string; name: string } | null>(null);
   const [folderPath, setFolderPath] = useState<BreadcrumbItem[]>([]);
   const [selectedFolder, setSelectedFolder] = useState<{ id: string; name: string } | null>(null);
@@ -514,7 +516,7 @@ export function SourceManager({ catalogId, canEdit }: SourceManagerProps) {
                       variant="ghost"
                       size="icon"
                       className="h-7 w-7 text-destructive hover:text-destructive"
-                      onClick={() => removeMutation.mutate(s.id)}
+                      onClick={() => setSourceToDelete({ id: s.id, label: sourceLabel(s) })}
                       disabled={removeMutation.isPending}
                     >
                       <Trash2 className="h-3.5 w-3.5" />
@@ -717,6 +719,20 @@ export function SourceManager({ catalogId, canEdit }: SourceManagerProps) {
           No sources configured. Add a Shared Drive or shared folder to start syncing.
         </div>
       )}
+
+      <ConfirmDialog
+        open={sourceToDelete !== null}
+        onOpenChange={(o) => { if (!o) setSourceToDelete(null); }}
+        title="Remove source?"
+        description={`"${sourceToDelete?.label ?? ''}" will be removed from this catalog and will stop syncing. This cannot be undone.`}
+        confirmLabel="Remove"
+        variant="destructive"
+        isLoading={removeMutation.isPending}
+        onConfirm={() => {
+          if (sourceToDelete) removeMutation.mutate(sourceToDelete.id);
+          setSourceToDelete(null);
+        }}
+      />
     </div>
   );
 }

--- a/packages/console-frontend/src/components/catalogs/SyncStatusBar.tsx
+++ b/packages/console-frontend/src/components/catalogs/SyncStatusBar.tsx
@@ -1,5 +1,6 @@
 import { Progress } from '@/components/ui/progress';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { RefreshCw, CheckCircle2, XCircle, Pause, Play, Square, Ban, ChevronDown, ChevronUp } from 'lucide-react';
 import type { CatalogSyncJob } from '@/api/generated/types.gen';
 import { useState } from 'react';
@@ -75,19 +76,34 @@ export function SyncStatusBar({ syncJob, onPause, onResume, onCancel }: SyncStat
         {/* Controls */}
         <div className="flex items-center gap-1">
           {isRunning && onPause && (
-            <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onPause} title="Pause sync">
-              <Pause className="h-3.5 w-3.5" />
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onPause}>
+                  <Pause className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Pause sync</TooltipContent>
+            </Tooltip>
           )}
           {isPaused && onResume && (
-            <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onResume} title="Resume sync">
-              <Play className="h-3.5 w-3.5" />
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onResume}>
+                  <Play className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Resume sync</TooltipContent>
+            </Tooltip>
           )}
           {(isRunning || isPending || isPaused) && onCancel && (
-            <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive hover:text-destructive" onClick={onCancel} title="Cancel sync">
-              <Square className="h-3.5 w-3.5" />
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive hover:text-destructive" onClick={onCancel}>
+                  <Square className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Cancel sync</TooltipContent>
+            </Tooltip>
           )}
         </div>
       </div>

--- a/packages/console-frontend/src/components/chat/components/InterruptConfirmCard.tsx
+++ b/packages/console-frontend/src/components/chat/components/InterruptConfirmCard.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { AlertTriangle, ShieldAlert, ShieldCheck, Check, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useChat } from '../contexts';
 
 /** Human-readable labels for known HITL tool names. Falls back to raw name. */
@@ -196,23 +197,31 @@ function SingleActionCard() {
             {isRiskScored && allowed.has('approve') && (
               <>
                 {riskMeta!.matched_pattern && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => send({ type: 'approve', bypass: true, bypass_pattern: riskMeta!.matched_pattern })}
-                    title="Approve and skip this specific pattern next time"
-                  >
-                    Allow Pattern
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => send({ type: 'approve', bypass: true, bypass_pattern: riskMeta!.matched_pattern })}
+                      >
+                        Allow Pattern
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Approve and skip this specific pattern next time</TooltipContent>
+                  </Tooltip>
                 )}
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => send({ type: 'approve', bypass: true, bypass_all: true })}
-                  title="Approve and never ask again for this tool"
-                >
-                  Always Allow
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => send({ type: 'approve', bypass: true, bypass_all: true })}
+                    >
+                      Always Allow
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Approve and never ask again for this tool</TooltipContent>
+                </Tooltip>
               </>
             )}
             {allowed.has('approve') && (
@@ -281,22 +290,30 @@ function MultiActionCard() {
                   <ActionDetails action={action} />
                 </div>
                 <div className="flex gap-1 shrink-0">
-                  <Button
-                    variant={choice === 'approve' ? 'default' : 'outline'}
-                    size="sm"
-                    onClick={() => setChoices((p) => ({ ...p, [idx]: 'approve' }))}
-                    title="Approve this call"
-                  >
-                    <Check className="w-4 h-4" />
-                  </Button>
-                  <Button
-                    variant={choice === 'reject' ? 'destructive' : 'outline'}
-                    size="sm"
-                    onClick={() => setChoices((p) => ({ ...p, [idx]: 'reject' }))}
-                    title="Reject this call"
-                  >
-                    <X className="w-4 h-4" />
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant={choice === 'approve' ? 'default' : 'outline'}
+                        size="sm"
+                        onClick={() => setChoices((p) => ({ ...p, [idx]: 'approve' }))}
+                      >
+                        <Check className="w-4 h-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Approve this call</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant={choice === 'reject' ? 'destructive' : 'outline'}
+                        size="sm"
+                        onClick={() => setChoices((p) => ({ ...p, [idx]: 'reject' }))}
+                      >
+                        <X className="w-4 h-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Reject this call</TooltipContent>
+                  </Tooltip>
                 </div>
               </div>
               {choice === 'reject' && (

--- a/packages/console-frontend/src/components/chat/components/SettingsModal.tsx
+++ b/packages/console-frontend/src/components/chat/components/SettingsModal.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Link } from 'react-router';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -190,9 +191,14 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
         </div>
 
         <DialogFooter className="flex items-center justify-between sm:justify-between">
-          <div className="text-xs text-muted-foreground" title={`Full Session ID: ${sessionId}`}>
-            Session: {sessionId.slice(0, 8)}...
-          </div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className="text-xs text-muted-foreground">
+                Session: {sessionId.slice(0, 8)}...
+              </div>
+            </TooltipTrigger>
+            <TooltipContent>{`Full Session ID: ${sessionId}`}</TooltipContent>
+          </Tooltip>
           <div className="flex gap-2">
             <Button variant="secondary" onClick={onClose}>
               {hasUserSettings ? 'Close' : 'Cancel'}

--- a/packages/console-frontend/src/components/chat/components/TaskPanel.tsx
+++ b/packages/console-frontend/src/components/chat/components/TaskPanel.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useChat } from '../contexts';
 import {
   capitalize,
@@ -56,15 +57,19 @@ function CopyableId({ label, value }: { label: string; value: string }) {
   };
 
   return (
-    <button
-      className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-      onClick={handleCopy}
-      title={`Click to copy: ${value}`}
-    >
-      <span>{label}:</span>
-      <span className="font-mono">{shortenIdentifier(value)}</span>
-      {copied && <span className="text-green-500">✓</span>}
-    </button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          onClick={handleCopy}
+        >
+          <span>{label}:</span>
+          <span className="font-mono">{shortenIdentifier(value)}</span>
+          {copied && <span className="text-green-500">✓</span>}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{`Click to copy: ${value}`}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/packages/console-frontend/src/components/settings/SecretPermissionsDialog.tsx
+++ b/packages/console-frontend/src/components/settings/SecretPermissionsDialog.tsx
@@ -172,7 +172,7 @@ export function SecretPermissionsDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-3xl max-h-[80vh] flex flex-col">
+      <DialogContent className="sm:max-w-3xl max-h-[80vh] flex flex-col">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Users className="h-5 w-5" />

--- a/packages/console-frontend/src/components/settings/SecretsVaultList.tsx
+++ b/packages/console-frontend/src/components/settings/SecretsVaultList.tsx
@@ -21,6 +21,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import {
   listSecretsApiV1SecretsGetOptions,
   listSecretsApiV1SecretsGetQueryKey,
@@ -175,27 +176,35 @@ export function SecretsVaultList() {
                 </div>
               </div>
               <div className="flex items-center gap-2">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => {
-                    setSelectedSecretId(secret.id);
-                    setSelectedSecretName(secret.name);
-                    setShowPermissionsDialog(true);
-                  }}
-                  title="Manage permissions"
-                >
-                  <Users className="h-4 w-4" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => confirmDelete(secret.id)}
-                  disabled={deleteMutation.isPending}
-                  title="Delete secret"
-                >
-                  <Trash2 className="h-4 w-4 text-destructive" />
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => {
+                        setSelectedSecretId(secret.id);
+                        setSelectedSecretName(secret.name);
+                        setShowPermissionsDialog(true);
+                      }}
+                    >
+                      <Users className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Manage permissions</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => confirmDelete(secret.id)}
+                      disabled={deleteMutation.isPending}
+                    >
+                      <Trash2 className="h-4 w-4 text-destructive" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Delete secret</TooltipContent>
+                </Tooltip>
               </div>
             </div>
           ))}

--- a/packages/console-frontend/src/components/settings/ToolBypassRulesList.tsx
+++ b/packages/console-frontend/src/components/settings/ToolBypassRulesList.tsx
@@ -3,6 +3,8 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { ShieldOff, Trash2, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { ConfirmDialog } from '@/components/admin/ConfirmDialog';
 import { client } from '@/api/generated/client.gen';
 
 interface BypassRule {
@@ -32,6 +34,7 @@ async function removeBypassRule(key: string): Promise<void> {
 export function ToolBypassRulesList() {
   const queryClient = useQueryClient();
   const [removingKey, setRemovingKey] = useState<string | null>(null);
+  const [pendingRemoveKey, setPendingRemoveKey] = useState<string | null>(null);
 
   const { data: rules, isLoading } = useQuery({
     queryKey: ['toolBypassRules'],
@@ -106,23 +109,41 @@ export function ToolBypassRulesList() {
                 )}
               </p>
             </div>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8 text-destructive hover:text-destructive"
-              onClick={() => handleRemove(key)}
-              disabled={isRemoving}
-              title="Remove bypass rule (will ask for approval again)"
-            >
-              {isRemoving ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Trash2 className="h-4 w-4" />
-              )}
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 text-destructive hover:text-destructive"
+                  onClick={() => setPendingRemoveKey(key)}
+                  disabled={isRemoving}
+                >
+                  {isRemoving ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="h-4 w-4" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Remove bypass rule (will ask for approval again)</TooltipContent>
+            </Tooltip>
           </div>
         );
       })}
+
+      <ConfirmDialog
+        open={pendingRemoveKey !== null}
+        onOpenChange={(o) => { if (!o) setPendingRemoveKey(null); }}
+        title="Remove bypass rule?"
+        description="This tool will prompt for approval again based on its risk score."
+        confirmLabel="Remove"
+        variant="destructive"
+        isLoading={removeMutation.isPending}
+        onConfirm={() => {
+          if (pendingRemoveKey) handleRemove(pendingRemoveKey);
+          setPendingRemoveKey(null);
+        }}
+      />
     </div>
   );
 }

--- a/packages/console-frontend/src/components/skeletons.tsx
+++ b/packages/console-frontend/src/components/skeletons.tsx
@@ -1,0 +1,137 @@
+import { Skeleton } from '@/components/ui/skeleton';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { TableCell, TableRow } from '@/components/ui/table';
+
+/**
+ * Shared loading-state skeletons. Use these instead of bare "Loading…" text or
+ * ad-hoc spinners so every page animates a layout-matched placeholder.
+ */
+
+/** Page title + subtitle, with an optional action-button placeholder on the right. */
+export function PageHeaderSkeleton({ action = false }: { action?: boolean }) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div className="space-y-2">
+        <Skeleton className="h-7 w-48" />
+        <Skeleton className="h-4 w-72" />
+      </div>
+      {action && <Skeleton className="h-9 w-32 shrink-0" />}
+    </div>
+  );
+}
+
+/** A bordered table with a header row and `rows` × `columns` cells. */
+export function TableSkeleton({ rows = 6, columns = 4 }: { rows?: number; columns?: number }) {
+  return (
+    <div className="rounded-lg border">
+      <div className="flex gap-4 border-b bg-muted/50 px-4 py-3">
+        {Array.from({ length: columns }).map((_, i) => (
+          <Skeleton key={i} className="h-4 flex-1" />
+        ))}
+      </div>
+      {Array.from({ length: rows }).map((_, r) => (
+        <div key={r} className="flex items-center gap-4 border-b px-4 py-3.5 last:border-0">
+          {Array.from({ length: columns }).map((_, c) => (
+            <Skeleton key={c} className="h-4 flex-1" />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Skeleton rows for use INSIDE an existing shadcn `<TableBody>` (renders real
+ * `<TableRow>`/`<TableCell>` so it stays valid markup).
+ */
+export function TableRowsSkeleton({ rows = 6, columns = 4 }: { rows?: number; columns?: number }) {
+  return (
+    <>
+      {Array.from({ length: rows }).map((_, r) => (
+        <TableRow key={r}>
+          {Array.from({ length: columns }).map((_, c) => (
+            <TableCell key={c}>
+              <Skeleton className="h-4 w-full" />
+            </TableCell>
+          ))}
+        </TableRow>
+      ))}
+    </>
+  );
+}
+
+/** A row of KPI/stat cards (e.g. dashboards). */
+export function StatCardsSkeleton({ count = 4 }: { count?: number }) {
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+      {Array.from({ length: count }).map((_, i) => (
+        <Card key={i}>
+          <CardHeader className="pb-2">
+            <Skeleton className="h-4 w-24" />
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <Skeleton className="h-8 w-20" />
+            <Skeleton className="h-3 w-32" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+/** A card containing a large block — for charts/graphs. */
+export function ChartSkeleton({ height = 300 }: { height?: number }) {
+  return (
+    <Card>
+      <CardHeader className="space-y-2">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-3 w-56" />
+      </CardHeader>
+      <CardContent>
+        <Skeleton className="w-full" style={{ height }} />
+      </CardContent>
+    </Card>
+  );
+}
+
+/** A vertical list of card placeholders (e.g. rate cards, item lists). */
+export function CardListSkeleton({ count = 4 }: { count?: number }) {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: count }).map((_, i) => (
+        <Card key={i}>
+          <CardHeader className="space-y-2">
+            <Skeleton className="h-5 w-48" />
+            <Skeleton className="h-3 w-64" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-16 w-full" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+/** Header + a couple of card blocks — for detail pages. */
+export function DetailSkeleton() {
+  return (
+    <div className="flex flex-col gap-6">
+      <PageHeaderSkeleton action />
+      <Card>
+        <CardHeader className="space-y-2">
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-3 w-56" />
+        </CardHeader>
+        <CardContent className="grid gap-4 sm:grid-cols-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-9 w-full" />
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/console-frontend/src/components/skills/SkillEditorPanel.tsx
+++ b/packages/console-frontend/src/components/skills/SkillEditorPanel.tsx
@@ -39,6 +39,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 /** Parse SKILL.md content into frontmatter fields + body */
 function parseSkillContent(raw: string): { description: string; body: string } {
@@ -300,15 +301,19 @@ export function SkillEditorPanel({
             Files
           </span>
           {!isReadOnly && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-6 w-6 p-0"
-              onClick={() => setShowAddFile(true)}
-              title="Add file"
-            >
-              <Plus className="h-3.5 w-3.5" />
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 w-6 p-0"
+                  onClick={() => setShowAddFile(true)}
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Add file</TooltipContent>
+            </Tooltip>
           )}
         </div>
 

--- a/packages/console-frontend/src/components/subagents/VersionSidebar.tsx
+++ b/packages/console-frontend/src/components/subagents/VersionSidebar.tsx
@@ -15,6 +15,7 @@ import {
   XCircle,
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
@@ -302,29 +303,37 @@ export function VersionSidebar({
                       <div className="flex items-center gap-2">
                         {/* Show release number for approved, hash for others */}
                         {isApproved && version.release_number ? (
-                          <div
-                            className={`flex h-7 min-w-7 px-2 items-center justify-center rounded-full text-sm font-medium ${
-                              isViewing
-                                ? 'bg-blue-500 text-white'
-                                : isDefault
-                                  ? 'bg-primary text-primary-foreground'
-                                  : 'bg-muted text-muted-foreground'
-                            }`}
-                            title={`Release ${version.release_number}`}
-                          >
-                            v{version.release_number}
-                          </div>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <div
+                                className={`flex h-7 min-w-7 px-2 items-center justify-center rounded-full text-sm font-medium ${
+                                  isViewing
+                                    ? 'bg-blue-500 text-white'
+                                    : isDefault
+                                      ? 'bg-primary text-primary-foreground'
+                                      : 'bg-muted text-muted-foreground'
+                                }`}
+                              >
+                                v{version.release_number}
+                              </div>
+                            </TooltipTrigger>
+                            <TooltipContent>{`Release ${version.release_number}`}</TooltipContent>
+                          </Tooltip>
                         ) : (
-                          <div
-                            className={`flex h-7 px-2 items-center justify-center rounded text-xs font-mono ${
-                              isViewing
-                                ? 'bg-blue-500 text-white'
-                                : 'bg-muted text-muted-foreground'
-                            }`}
-                            title={version.version_hash || `Version ${version.version}`}
-                          >
-                            {version.version_hash ? `#${version.version_hash.slice(0, 7)}` : `v${version.version}`}
-                          </div>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <div
+                                className={`flex h-7 px-2 items-center justify-center rounded text-xs font-mono ${
+                                  isViewing
+                                    ? 'bg-blue-500 text-white'
+                                    : 'bg-muted text-muted-foreground'
+                                }`}
+                              >
+                                {version.version_hash ? `#${version.version_hash.slice(0, 7)}` : `v${version.version}`}
+                              </div>
+                            </TooltipTrigger>
+                            <TooltipContent>{version.version_hash || `Version ${version.version}`}</TooltipContent>
+                          </Tooltip>
                         )}
                         {isCurrent && (
                           <Badge variant="default" className="bg-blue-500 text-xs">

--- a/packages/console-frontend/src/lib/cron.ts
+++ b/packages/console-frontend/src/lib/cron.ts
@@ -1,0 +1,34 @@
+import cronstrue from 'cronstrue';
+
+/** Quick-pick presets for the most common schedules. */
+export const CRON_PRESETS: { label: string; expr: string }[] = [
+  { label: 'Every hour', expr: '0 * * * *' },
+  { label: 'Daily 09:00', expr: '0 9 * * *' },
+  { label: 'Weekdays 09:00', expr: '0 9 * * 1-5' },
+  { label: 'Weekly (Mon)', expr: '0 9 * * 1' },
+  { label: 'Monthly (1st)', expr: '0 9 1 * *' },
+];
+
+export interface CronDescription {
+  /** Whether the expression is a non-empty, valid cron string. */
+  ok: boolean;
+  /** Human-readable description when ok, error message when invalid, empty when blank. */
+  text: string;
+}
+
+/** Parse a cron expression into a human-readable description, or an error. */
+export function describeCron(expr: string): CronDescription {
+  const trimmed = expr.trim();
+  if (!trimmed) return { ok: false, text: '' };
+  try {
+    return {
+      ok: true,
+      text: cronstrue.toString(trimmed, {
+        throwExceptionOnParseError: true,
+        use24HourTimeFormat: true,
+      }),
+    };
+  } catch (e) {
+    return { ok: false, text: e instanceof Error ? e.message : 'Invalid cron expression' };
+  }
+}

--- a/packages/console-frontend/src/pages/DeliveryChannelsPage.tsx
+++ b/packages/console-frontend/src/pages/DeliveryChannelsPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Pencil, Trash2, Webhook, Plus, X, Check } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { TableSkeleton } from '@/components/skeletons';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
@@ -32,6 +33,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import {
   getDeliveryChannels,
   updateDeliveryChannel,
@@ -266,7 +268,7 @@ export function DeliveryChannelsPage() {
 
       {/* Table */}
       {isLoading ? (
-        <p className="text-sm text-muted-foreground">Loading…</p>
+        <TableSkeleton columns={5} />
       ) : error ? (
         <p className="text-sm text-destructive">Failed to load delivery channels.</p>
       ) : channels.length === 0 ? (
@@ -324,24 +326,32 @@ export function DeliveryChannelsPage() {
                   </TableCell>
                   <TableCell>
                     <div className="flex items-center gap-1 justify-end">
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8"
-                        title="Edit channel"
-                        onClick={() => setEditChannel(ch)}
-                      >
-                        <Pencil className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8 text-destructive hover:text-destructive"
-                        title="Delete channel"
-                        onClick={() => { setDeleteTarget(ch); setDeleteError(null); }}
-                      >
-                        <X className="h-4 w-4" />
-                      </Button>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8"
+                            onClick={() => setEditChannel(ch)}
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Edit channel</TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8 text-destructive hover:text-destructive"
+                            onClick={() => { setDeleteTarget(ch); setDeleteError(null); }}
+                          >
+                            <X className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Delete channel</TooltipContent>
+                      </Tooltip>
                     </div>
                   </TableCell>
                 </TableRow>

--- a/packages/console-frontend/src/pages/SchedulerJobDetailPage.tsx
+++ b/packages/console-frontend/src/pages/SchedulerJobDetailPage.tsx
@@ -16,6 +16,7 @@ import {
   Sparkles,
   Send,
   Undo2,
+  Pencil,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -23,7 +24,23 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
-import { Separator } from '@/components/ui/separator';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import {
   Select,
   SelectContent,
@@ -31,6 +48,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { config } from '@/config';
 import {
   type JobRunStatus,
@@ -52,6 +70,9 @@ import {
   consoleListMcpToolsOptions,
 } from '@/api/generated/@tanstack/react-query.gen';
 import { useAuth } from '@/contexts/AuthContext';
+import { CronField } from '@/components/CronField';
+import { describeCron } from '@/lib/cron';
+import { DetailSkeleton } from '@/components/skeletons';
 import { io } from 'socket.io-client';
 
 interface SchedulerNotification {
@@ -201,25 +222,29 @@ function JobHeader({
       </div>
 
       <div className="flex gap-2">
-        <Button
-          variant="default"
-          size="sm"
-          disabled={isRunningNow}
-          onClick={onRunNow}
-          title="Trigger a full test run right now — resolves token, calls agent-runner, delivers webhook"
-        >
-          {isRunningNow ? (
-            <>
-              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
-              Running…
-            </>
-          ) : (
-            <>
-              <Play className="mr-1.5 h-4 w-4" />
-              Run now
-            </>
-          )}
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="default"
+              size="sm"
+              disabled={isRunningNow}
+              onClick={onRunNow}
+            >
+              {isRunningNow ? (
+                <>
+                  <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                  Running…
+                </>
+              ) : (
+                <>
+                  <Play className="mr-1.5 h-4 w-4" />
+                  Run now
+                </>
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Trigger a full test run right now — resolves token, calls agent-runner, delivers webhook</TooltipContent>
+        </Tooltip>
         {job.enabled ? (
           <Button
             variant="outline"
@@ -292,6 +317,7 @@ function EditForm({ job }: { job: ScheduledJob }) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [voiceCall, setVoiceCall] = useState((job as any).voice_call ?? false);
   const [dirty, setDirty] = useState(false);
+  const [editing, setEditing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [aiQuery, setAiQuery] = useState('');
   const [aiLoading, setAiLoading] = useState(false);
@@ -376,6 +402,7 @@ function EditForm({ job }: { job: ScheduledJob }) {
         queryKey: ['scheduler-job', job.id],
       });
       setDirty(false);
+      setEditing(false);
     },
     onError: (e: unknown) => {
       setError(e instanceof Error ? e.message : String(e));
@@ -383,6 +410,11 @@ function EditForm({ job }: { job: ScheduledJob }) {
   });
 
   function handleSave() {
+    if (job.schedule_kind === 'cron' && cronExpr.trim() && !describeCron(cronExpr).ok) {
+      setError('Cron expression is invalid');
+      return;
+    }
+
     let check_args: Record<string, unknown> | undefined;
     if (checkArgsText.trim()) {
       try {
@@ -420,29 +452,47 @@ function EditForm({ job }: { job: ScheduledJob }) {
   }
 
   return (
-    <div className="grid gap-4">
-      <div className="flex items-center justify-between">
-        <h2 className="font-semibold">Job configuration</h2>
-        <div className="flex gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={resetForm}
-            disabled={!dirty || mutation.isPending}
-          >
-            <Undo2 className="mr-1.5 h-4 w-4" />
-            Discard
-          </Button>
-          <Button
-            size="sm"
-            onClick={handleSave}
-            disabled={!dirty || mutation.isPending}
-          >
-            <Save className="mr-1.5 h-4 w-4" />
-            {mutation.isPending ? 'Saving…' : 'Save changes'}
-          </Button>
+    <Card>
+      <CardHeader className="flex-row items-start justify-between gap-4 space-y-0">
+        <div className="space-y-1">
+          <CardTitle>Job configuration</CardTitle>
+          <CardDescription>
+            {editing
+              ? 'Editing — change the fields below, then save.'
+              : 'Read-only. Click Edit configuration to make changes.'}
+          </CardDescription>
         </div>
-      </div>
+        <div className="flex shrink-0 gap-2">
+          {editing ? (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => { resetForm(); setEditing(false); }}
+                disabled={mutation.isPending}
+              >
+                <Undo2 className="mr-1.5 h-4 w-4" />
+                Discard
+              </Button>
+              <Button
+                size="sm"
+                onClick={handleSave}
+                disabled={!dirty || mutation.isPending}
+              >
+                <Save className="mr-1.5 h-4 w-4" />
+                {mutation.isPending ? 'Saving…' : 'Save changes'}
+              </Button>
+            </>
+          ) : (
+            <Button variant="outline" size="sm" onClick={() => setEditing(true)}>
+              <Pencil className="mr-1.5 h-4 w-4" />
+              Edit configuration
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        <fieldset disabled={!editing} className="m-0 grid min-w-0 gap-4 border-0 p-0">
 
       <div className="grid gap-4 sm:grid-cols-2">
         <div className="grid gap-1.5">
@@ -465,16 +515,10 @@ function EditForm({ job }: { job: ScheduledJob }) {
       </div>
 
       {job.schedule_kind === 'cron' && (
-        <div className="grid gap-1.5">
-          <Label>
-            Cron expression{' '}
-            <span className="text-muted-foreground text-xs">(e.g. 0 9 * * 1-5)</span>
-          </Label>
-          <Input
-            value={cronExpr}
-            onChange={(e) => { setCronExpr(e.target.value); touch(); }}
-          />
-        </div>
+        <CronField
+          value={cronExpr}
+          onChange={(v) => { setCronExpr(v); touch(); }}
+        />
       )}
 
       {job.schedule_kind === 'interval' && (
@@ -509,6 +553,7 @@ function EditForm({ job }: { job: ScheduledJob }) {
             <Select
               value={subAgentId}
               onValueChange={(v) => { setSubAgentId(v); touch(); }}
+              disabled={!editing}
             >
               <SelectTrigger>
                 <SelectValue placeholder="Select a sub-agent…" />
@@ -597,6 +642,7 @@ function EditForm({ job }: { job: ScheduledJob }) {
             <Select
               value={checkTool}
               onValueChange={(v) => { setCheckTool(v); touch(); }}
+              disabled={!editing}
             >
               <SelectTrigger>
                 <SelectValue placeholder="Select an MCP tool…" />
@@ -692,6 +738,7 @@ function EditForm({ job }: { job: ScheduledJob }) {
             id="voice-call-edit"
             checked={voiceCall}
             onCheckedChange={(v) => { setVoiceCall(v); touch(); }}
+            disabled={!editing}
           />
           <Label htmlFor="voice-call-edit" className="cursor-pointer text-sm">
             Deliver via voice call
@@ -707,6 +754,7 @@ function EditForm({ job }: { job: ScheduledJob }) {
         <Label>Delivery channel</Label>
         <Select
           value={deliveryChannel}
+          disabled={!editing}
           onValueChange={(v) => {
             setDeliveryChannel(v);
             touch();
@@ -737,9 +785,10 @@ function EditForm({ job }: { job: ScheduledJob }) {
       </div>
 
       {error && <p className="text-sm text-destructive">{error}</p>}
+        </fieldset>
 
-      {/* Read-only info */}
-      <div className="grid gap-2 rounded-lg bg-muted/30 p-3 text-sm text-muted-foreground sm:grid-cols-2">
+      {/* Read-only info — always visible */}
+      <div className="mt-4 grid gap-2 rounded-lg bg-muted/30 p-3 text-sm text-muted-foreground sm:grid-cols-2">
         <div>
           <span className="font-medium text-foreground">Created:</span>{' '}
           {formatDate(job.created_at)}
@@ -757,7 +806,8 @@ function EditForm({ job }: { job: ScheduledJob }) {
           {job.consecutive_failures}
         </div>
       </div>
-    </div>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -819,22 +869,31 @@ function RunHistoryTable({ runs }: { runs: ScheduledJobRun[] }) {
               </td>
               <td className="px-4 py-3 text-center">
                 {run.delivered ? (
-                  <div title="Notification sent (best effort — delivery receipt not confirmed)">
-                    <Send className="mx-auto h-4 w-4 text-muted-foreground" />
-                  </div>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div>
+                        <Send className="mx-auto h-4 w-4 text-muted-foreground" />
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent>Notification sent (best effort — delivery receipt not confirmed)</TooltipContent>
+                  </Tooltip>
                 ) : (
                   <span className="text-muted-foreground">—</span>
                 )}
               </td>
               <td className="px-4 py-3 text-center">
                 {run.conversation_id ? (
-                  <a
-                    href={`/app/usage?conversation_id=${run.conversation_id}`}
-                    className="inline-flex items-center gap-1 text-primary hover:underline text-xs"
-                    title="View usage logs for this run"
-                  >
-                    <ExternalLink className="h-3 w-3" />
-                  </a>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <a
+                        href={`/app/usage?conversation_id=${run.conversation_id}`}
+                        className="inline-flex items-center gap-1 text-primary hover:underline text-xs"
+                      >
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                    </TooltipTrigger>
+                    <TooltipContent>View usage logs for this run</TooltipContent>
+                  </Tooltip>
                 ) : (
                   <span className="text-muted-foreground">—</span>
                 )}
@@ -842,15 +901,19 @@ function RunHistoryTable({ runs }: { runs: ScheduledJobRun[] }) {
               {isAdmin && (
                 <td className="px-4 py-3 text-center">
                   {run.conversation_id ? (
-                    <a
-                      href={`https://eu.smith.langchain.com/o/${config.langsmith.organizationId}/projects/p/${config.langsmith.projectId}/t/${run.conversation_id}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 text-primary hover:underline text-xs"
-                      title="View trace in LangSmith"
-                    >
-                      <ExternalLink className="h-3 w-3" />
-                    </a>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <a
+                          href={`https://eu.smith.langchain.com/o/${config.langsmith.organizationId}/projects/p/${config.langsmith.projectId}/t/${run.conversation_id}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-primary hover:underline text-xs"
+                        >
+                          <ExternalLink className="h-3 w-3" />
+                        </a>
+                      </TooltipTrigger>
+                      <TooltipContent>View trace in LangSmith</TooltipContent>
+                    </Tooltip>
                   ) : (
                     <span className="text-muted-foreground">—</span>
                   )}
@@ -880,6 +943,7 @@ export function SchedulerJobDetailPage() {
   const [runNowRunId, setRunNowRunId] = useState<number | null>(null);
   const [runNowResult, setRunNowResult] = useState<RunNowResult | null>(null);
   const [runNowError, setRunNowError] = useState<string | null>(null);
+  const [showDelete, setShowDelete] = useState(false);
 
   async function handleRunNow() {
     setRunNowLoading(true);
@@ -947,9 +1011,7 @@ export function SchedulerJobDetailPage() {
   });
 
   function handleDelete() {
-    if (job && confirm(`Delete job "${job.name}"? This cannot be undone.`)) {
-      deleteMutation.mutate();
-    }
+    setShowDelete(true);
   }
 
   return (
@@ -965,12 +1027,7 @@ export function SchedulerJobDetailPage() {
         Back to Scheduler
       </Button>
 
-      {jobLoading && (
-        <div className="flex items-center gap-2 text-muted-foreground text-sm">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          Loading…
-        </div>
-      )}
+      {jobLoading && <DetailSkeleton />}
 
       {jobError && (
         <div className="flex items-center gap-2 text-destructive text-sm">
@@ -1034,21 +1091,51 @@ export function SchedulerJobDetailPage() {
             </div>
           )}
 
-          <Separator />
-
           <EditForm job={job} />
 
-          <Separator />
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                Run history
+                {runsLoading && (
+                  <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                )}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <RunHistoryTable runs={runs} />
+            </CardContent>
+          </Card>
 
-          <div className="flex flex-col gap-3">
-            <h2 className="font-semibold">
-              Run history
-              {runsLoading && (
-                <Loader2 className="ml-2 inline h-4 w-4 animate-spin text-muted-foreground" />
-              )}
-            </h2>
-            <RunHistoryTable runs={runs} />
-          </div>
+          {/* Delete confirmation */}
+          <AlertDialog open={showDelete} onOpenChange={setShowDelete}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete scheduled job?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  The job <strong>{job.name}</strong> will be permanently deleted.
+                  This action cannot be undone.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={deleteMutation.isPending}>
+                  Cancel
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  disabled={deleteMutation.isPending}
+                  onClick={() => deleteMutation.mutate()}
+                >
+                  {deleteMutation.isPending ? 'Deleting…' : (
+                    <>
+                      <Trash2 className="mr-1.5 h-4 w-4" />
+                      Delete
+                    </>
+                  )}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         </>
       )}
     </div>

--- a/packages/console-frontend/src/pages/SchedulerPage.tsx
+++ b/packages/console-frontend/src/pages/SchedulerPage.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { TableSkeleton } from '@/components/skeletons';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -46,6 +47,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import {
   type ScheduledJob,
   type JobType,
@@ -65,6 +67,8 @@ import {
   consoleListMcpToolsOptions,
 } from '@/api/generated/@tanstack/react-query.gen';
 import { config } from '@/config';
+import { CronField } from '@/components/CronField';
+import { describeCron } from '@/lib/cron';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -269,8 +273,11 @@ function CreateJobDialog({
 
   async function handleSubmit() {
     if (!form.name.trim()) return setError('Name is required');
-    if (form.schedule_kind === 'cron' && !form.cron_expr.trim())
-      return setError('Cron expression is required');
+    if (form.schedule_kind === 'cron') {
+      if (!form.cron_expr.trim()) return setError('Cron expression is required');
+      if (!describeCron(form.cron_expr).ok)
+        return setError('Cron expression is invalid');
+    }
     if (form.schedule_kind === 'interval' && !form.interval_seconds)
       return setError('Interval is required');
     if (form.schedule_kind === 'once' && !form.run_at)
@@ -368,7 +375,7 @@ function CreateJobDialog({
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
+      <DialogContent className="max-h-[90vh] sm:max-w-3xl overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Create Scheduled Job</DialogTitle>
           <DialogDescription>
@@ -425,18 +432,11 @@ function CreateJobDialog({
 
           {/* Schedule detail */}
           {form.schedule_kind === 'cron' && (
-            <div className="grid gap-1.5">
-              <Label htmlFor="cron">
-                Cron expression{' '}
-                <span className="text-muted-foreground text-xs">(e.g. 0 9 * * 1-5)</span>
-              </Label>
-              <Input
-                id="cron"
-                value={form.cron_expr}
-                onChange={(e) => update('cron_expr', e.target.value)}
-                placeholder="0 9 * * 1-5"
-              />
-            </div>
+            <CronField
+              id="cron"
+              value={form.cron_expr}
+              onChange={(v) => update('cron_expr', v)}
+            />
           )}
           {form.schedule_kind === 'interval' && (
             <div className="grid gap-1.5">
@@ -800,32 +800,32 @@ function CreateJobDialog({
                 />
               </div>
 
-              {/* Condition expression */}
-              <div className="grid gap-1.5">
-                <Label htmlFor="condition_expr">
-                  Condition expression{' '}
-                  <span className="text-muted-foreground text-xs">(JSONPath)</span>
-                </Label>
-                <Input
-                  id="condition_expr"
-                  value={form.condition_expr}
-                  onChange={(e) => update('condition_expr', e.target.value)}
-                  placeholder="$.status"
-                />
-              </div>
-
-              {/* Expected value */}
-              <div className="grid gap-1.5">
-                <Label htmlFor="expected_value">
-                  Expected value{' '}
-                  <span className="text-muted-foreground text-xs">(leave empty to check "is not null")</span>
-                </Label>
-                <Input
-                  id="expected_value"
-                  value={form.expected_value}
-                  onChange={(e) => update('expected_value', e.target.value)}
-                  placeholder="success"
-                />
+              {/* Condition expression + expected value */}
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="grid gap-1.5">
+                  <Label htmlFor="condition_expr">
+                    Condition expression{' '}
+                    <span className="text-muted-foreground text-xs">(JSONPath)</span>
+                  </Label>
+                  <Input
+                    id="condition_expr"
+                    value={form.condition_expr}
+                    onChange={(e) => update('condition_expr', e.target.value)}
+                    placeholder="$.status"
+                  />
+                </div>
+                <div className="grid gap-1.5">
+                  <Label htmlFor="expected_value">
+                    Expected value{' '}
+                    <span className="text-muted-foreground text-xs">(leave empty to check "is not null")</span>
+                  </Label>
+                  <Input
+                    id="expected_value"
+                    value={form.expected_value}
+                    onChange={(e) => update('expected_value', e.target.value)}
+                    placeholder="success"
+                  />
+                </div>
               </div>
 
               {/* LLM Condition */}
@@ -978,7 +978,7 @@ export function SchedulerPage() {
 
       {/* Job table */}
       {isLoading ? (
-        <div className="text-muted-foreground text-sm">Loading…</div>
+        <TableSkeleton columns={7} />
       ) : jobs.length === 0 ? (
         <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed py-12 text-center">
           <Calendar className="h-8 w-8 text-muted-foreground" />
@@ -1042,36 +1042,48 @@ export function SchedulerPage() {
                       onClick={(e) => e.stopPropagation()}
                     >
                       {job.enabled ? (
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          title="Pause"
-                          disabled={pauseMutation.isPending}
-                          onClick={() => pauseMutation.mutate(job.id)}
-                        >
-                          <Pause className="h-4 w-4" />
-                        </Button>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              disabled={pauseMutation.isPending}
+                              onClick={() => pauseMutation.mutate(job.id)}
+                            >
+                              <Pause className="h-4 w-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>Pause</TooltipContent>
+                        </Tooltip>
                       ) : (
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          title="Resume"
-                          disabled={resumeMutation.isPending}
-                          onClick={() => resumeMutation.mutate(job.id)}
-                        >
-                          <Play className="h-4 w-4" />
-                        </Button>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              disabled={resumeMutation.isPending}
+                              onClick={() => resumeMutation.mutate(job.id)}
+                            >
+                              <Play className="h-4 w-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>Resume</TooltipContent>
+                        </Tooltip>
                       )}
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        title="Delete"
-                        className="text-destructive hover:text-destructive"
-                        disabled={deleteMutation.isPending}
-                        onClick={() => setDeleteTarget(job)}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-destructive hover:text-destructive"
+                            disabled={deleteMutation.isPending}
+                            onClick={() => setDeleteTarget(job)}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Delete</TooltipContent>
+                      </Tooltip>
                     </div>
                   </td>
                 </tr>

--- a/packages/console-frontend/src/pages/SettingsPage.tsx
+++ b/packages/console-frontend/src/pages/SettingsPage.tsx
@@ -15,6 +15,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { SubAgentActivationList } from '@/components/settings/SubAgentActivationList';
 import { UserPermissionsTable } from '@/components/settings/UserPermissionsTable';
 import { MCPToolToggleList } from '@/components/settings/MCPToolToggleList';
@@ -358,24 +359,28 @@ export function SettingsPage() {
                 <>
                   <span className="text-sm font-mono">{currentUser.phone_number as string}</span>
                   {currentUser?.phone_number_override && (
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-6 w-6"
-                      title="Remove override and use IdP number"
-                      onClick={async () => {
-                        try {
-                          const { client } = await import('@/api/generated/client.gen');
-                          await client.delete({ url: '/api/v1/auth/me/phone/override' });
-                          toast.success('Phone number override removed');
-                          queryClient.invalidateQueries({ queryKey: getCurrentUserApiV1AuthMeGetQueryKey() });
-                        } catch {
-                          toast.error('Failed to remove phone number override');
-                        }
-                      }}
-                    >
-                      <X className="h-3 w-3" />
-                    </Button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-6 w-6"
+                          onClick={async () => {
+                            try {
+                              const { client } = await import('@/api/generated/client.gen');
+                              await client.delete({ url: '/api/v1/auth/me/phone/override' });
+                              toast.success('Phone number override removed');
+                              queryClient.invalidateQueries({ queryKey: getCurrentUserApiV1AuthMeGetQueryKey() });
+                            } catch {
+                              toast.error('Failed to remove phone number override');
+                            }
+                          }}
+                        >
+                          <X className="h-3 w-3" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Remove override and use IdP number</TooltipContent>
+                    </Tooltip>
                   )}
                   <Button variant="outline" size="sm" onClick={() => setVerifyDialogOpen(true)}>
                     Change

--- a/packages/console-frontend/src/pages/SkillRegistryPage.tsx
+++ b/packages/console-frontend/src/pages/SkillRegistryPage.tsx
@@ -72,6 +72,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { SkillImportPanel } from '@/components/skills/SkillImportPanel';
 
 // --- Helpers for SKILL.md structured editing ---
@@ -186,6 +187,8 @@ export function SkillRegistryPage() {
   const [deletingFile, setDeletingFile] = useState<string | null>(null);
   const [renamingFile, setRenamingFile] = useState<string | null>(null);
   const [renameFileValue, setRenameFileValue] = useState('');
+  // File the user wants to switch to, pending confirmation to discard unsaved edits
+  const [pendingFile, setPendingFile] = useState<string | null>(null);
 
   // Update check state
   const [checkingUpdate, setCheckingUpdate] = useState(false);
@@ -764,12 +767,22 @@ export function SkillRegistryPage() {
             )}
           </div>
           <div className="flex items-center gap-1">
-            <Button variant="ghost" size="sm" className="h-7 w-7 p-0" title="Create skill" onClick={handleStartCreate} disabled={!!draftSkill}>
-              <Plus className="h-3.5 w-3.5" />
-            </Button>
-            <Button variant="ghost" size="sm" className="h-7 w-7 p-0" title="Import from external" onClick={() => setShowImport(true)}>
-              <Import className="h-3.5 w-3.5" />
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={handleStartCreate} disabled={!!draftSkill}>
+                  <Plus className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Create skill</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={() => setShowImport(true)}>
+                  <Import className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Import from external</TooltipContent>
+            </Tooltip>
           </div>
         </div>
 
@@ -823,17 +836,21 @@ export function SkillRegistryPage() {
                   </p>
                 </div>
                 {!editingDraftName && (
-                  <span
-                    className="p-0.5 opacity-0 group-hover:opacity-100 hover:text-blue-600 text-muted-foreground shrink-0"
-                    title="Rename"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setSelectedSkillId(null);
-                      setEditingDraftName(true);
-                    }}
-                  >
-                    <PencilLine className="h-3 w-3" />
-                  </span>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span
+                        className="p-0.5 opacity-0 group-hover:opacity-100 hover:text-blue-600 text-muted-foreground shrink-0"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSelectedSkillId(null);
+                          setEditingDraftName(true);
+                        }}
+                      >
+                        <PencilLine className="h-3 w-3" />
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>Rename</TooltipContent>
+                  </Tooltip>
                 )}
               </div>
             </div>
@@ -895,7 +912,12 @@ export function SkillRegistryPage() {
                         {displaySource && (
                           <>
                             <span className="text-muted-foreground/40 text-xs shrink-0">·</span>
-                            <span className={`text-muted-foreground truncate ${isEditing ? 'text-[10px]' : 'text-xs'}`} title={displaySource}>{displaySource}</span>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span className={`text-muted-foreground truncate ${isEditing ? 'text-[10px]' : 'text-xs'}`}>{displaySource}</span>
+                              </TooltipTrigger>
+                              <TooltipContent>{displaySource}</TooltipContent>
+                            </Tooltip>
                           </>
                         )}
                       </div>
@@ -928,22 +950,26 @@ export function SkillRegistryPage() {
                     </span>
                   )}
                   {isEditing && !isSkillImported && !isRenaming && (
-                    <span
-                      className="p-0.5 opacity-0 group-hover:opacity-100 hover:text-primary text-muted-foreground shrink-0"
-                      title="Rename"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        if (selectedSkillId !== skill.slug && selectedSkillId !== skill.id) {
-                          if (draftSkill?.existingId && draftSkill.existingId !== skill.id) setDraftSkillRaw(null);
-                          setSelectedSkillId(skill.slug || skill.id);
-                          setActiveFile('SKILL.md');
-                        }
-                        setRenamingSkillId(skill.id);
-                        setRenameValue(skill.name);
-                      }}
-                    >
-                      <PencilLine className="h-3 w-3" />
-                    </span>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span
+                          className="p-0.5 opacity-0 group-hover:opacity-100 hover:text-primary text-muted-foreground shrink-0"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if (selectedSkillId !== skill.slug && selectedSkillId !== skill.id) {
+                              if (draftSkill?.existingId && draftSkill.existingId !== skill.id) setDraftSkillRaw(null);
+                              setSelectedSkillId(skill.slug || skill.id);
+                              setActiveFile('SKILL.md');
+                            }
+                            setRenamingSkillId(skill.id);
+                            setRenameValue(skill.name);
+                          }}
+                        >
+                          <PencilLine className="h-3 w-3" />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>Rename</TooltipContent>
+                    </Tooltip>
                   )}
                 </div>
                 );
@@ -1012,35 +1038,43 @@ export function SkillRegistryPage() {
             {/* Editor toolbar */}
             <div className="flex items-center justify-between px-4 py-2 border-b bg-muted/30">
               <div className="flex items-center gap-2">
-                <button
-                  className="p-0.5 hover:text-primary text-muted-foreground -ml-1"
-                  title="Back to browse"
-                  onClick={() => {
-                    if (isDraft && !draftSkill.existingId) return; // don't leave unsaved new draft
-                    setSelectedSkillId(null);
-                  }}
-                >
-                  <ChevronLeft className="h-4 w-4" />
-                </button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      className="p-0.5 hover:text-primary text-muted-foreground -ml-1"
+                      onClick={() => {
+                        if (isDraft && !draftSkill.existingId) return; // don't leave unsaved new draft
+                        setSelectedSkillId(null);
+                      }}
+                    >
+                      <ChevronLeft className="h-4 w-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>Back to browse</TooltipContent>
+                </Tooltip>
                 <span className="flex items-center gap-1">
                   <span className="font-medium text-sm">
                     {isDraft ? draftSkill.name : detail?.name}
                   </span>
                   {!isImported && (
-                    <button
-                      className="p-0.5 hover:text-primary text-muted-foreground"
-                      title="Rename"
-                      onClick={() => {
-                        if (isDraft) {
-                          setEditingDraftName(true);
-                        } else {
-                          const d = ensureEditDraft();
-                          if (d) setEditingDraftName(true);
-                        }
-                      }}
-                    >
-                      <PencilLine className="h-3 w-3" />
-                    </button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          className="p-0.5 hover:text-primary text-muted-foreground"
+                          onClick={() => {
+                            if (isDraft) {
+                              setEditingDraftName(true);
+                            } else {
+                              const d = ensureEditDraft();
+                              if (d) setEditingDraftName(true);
+                            }
+                          }}
+                        >
+                          <PencilLine className="h-3 w-3" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>Rename</TooltipContent>
+                    </Tooltip>
                   )}
                 </span>
                 {isDraft && !draftSkill.existingId && (
@@ -1113,32 +1147,37 @@ export function SkillRegistryPage() {
               </div>
               <div className="flex items-center gap-3">
                 {(selectedSkillId || isDraft) && (
-                  <label className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer" title="Run skill files in a sandboxed environment">
-                    <Switch
-                      checked={isDraft ? (draftSkill.sandboxRequired ?? false) : (detail?.sandbox_required ?? false)}
-                      onCheckedChange={async (checked) => {
-                        if (isImported && detail?.id) {
-                          // Imported skills: update sandbox_required directly via API
-                          try {
-                            await updateRegistrySkillApiV1SkillsRegistrySkillIdPut({
-                              path: { skill_id: detail.id },
-                              body: { sandbox_required: checked } as any,
-                              throwOnError: true,
-                            });
-                            invalidateDetail();
-                            toast.success(checked ? 'Sandbox enabled' : 'Sandbox disabled');
-                          } catch {
-                            toast.error('Failed to update sandbox setting');
-                          }
-                        } else {
-                          const d = draftSkill ?? ensureEditDraft();
-                          if (d) setDraftSkill({ ...d, sandboxRequired: checked });
-                        }
-                      }}
-                      className="scale-75"
-                    />
-                    Sandbox
-                  </label>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <label className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer">
+                        <Switch
+                          checked={isDraft ? (draftSkill.sandboxRequired ?? false) : (detail?.sandbox_required ?? false)}
+                          onCheckedChange={async (checked) => {
+                            if (isImported && detail?.id) {
+                              // Imported skills: update sandbox_required directly via API
+                              try {
+                                await updateRegistrySkillApiV1SkillsRegistrySkillIdPut({
+                                  path: { skill_id: detail.id },
+                                  body: { sandbox_required: checked } as any,
+                                  throwOnError: true,
+                                });
+                                invalidateDetail();
+                                toast.success(checked ? 'Sandbox enabled' : 'Sandbox disabled');
+                              } catch {
+                                toast.error('Failed to update sandbox setting');
+                              }
+                            } else {
+                              const d = draftSkill ?? ensureEditDraft();
+                              if (d) setDraftSkill({ ...d, sandboxRequired: checked });
+                            }
+                          }}
+                          className="scale-75"
+                        />
+                        Sandbox
+                      </label>
+                    </TooltipTrigger>
+                    <TooltipContent>Run skill files in a sandboxed environment</TooltipContent>
+                  </Tooltip>
                 )}
                 <div className="flex items-center gap-1.5">
                 {isDraft ? (
@@ -1166,53 +1205,69 @@ export function SkillRegistryPage() {
                   </>
                 ) : isImported ? (
                   <>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-7 text-xs"
-                      onClick={handleCheckUpdate}
-                      disabled={checkingUpdate}
-                      title="Check for upstream updates"
-                    >
-                      {checkingUpdate ? <Loader2 className="h-3 w-3 animate-spin mr-1" /> : <RefreshCw className="h-3 w-3 mr-1" />}
-                      Check Updates
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-7 text-xs"
-                      onClick={handleCopySkill}
-                      disabled={copying}
-                      title="Create an editable copy"
-                    >
-                      {copying ? <Loader2 className="h-3 w-3 animate-spin mr-1" /> : <Copy className="h-3 w-3 mr-1" />}
-                      Copy to Edit
-                    </Button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="h-7 text-xs"
+                          onClick={handleCheckUpdate}
+                          disabled={checkingUpdate}
+                        >
+                          {checkingUpdate ? <Loader2 className="h-3 w-3 animate-spin mr-1" /> : <RefreshCw className="h-3 w-3 mr-1" />}
+                          Check Updates
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Check for upstream updates</TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="h-7 text-xs"
+                          onClick={handleCopySkill}
+                          disabled={copying}
+                        >
+                          {copying ? <Loader2 className="h-3 w-3 animate-spin mr-1" /> : <Copy className="h-3 w-3 mr-1" />}
+                          Copy to Edit
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Create an editable copy</TooltipContent>
+                    </Tooltip>
                   </>
                 ) : null}
                 {selectedSkillId && !isDraft && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 w-7 p-0"
-                    title="Version history"
-                    onClick={handleShowHistory}
-                  >
-                    <History className="h-3.5 w-3.5" />
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 w-7 p-0"
+                        onClick={handleShowHistory}
+                      >
+                        <History className="h-3.5 w-3.5" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Version history</TooltipContent>
+                  </Tooltip>
                 )}
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 w-7 p-0 text-destructive hover:text-destructive"
-                  title="Delete skill"
-                  onClick={() => {
-                    const skill = skills.find((s) => s.id === selectedSkillId || s.slug === selectedSkillId);
-                    if (skill) setDeletingSkill(skill);
-                  }}
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+                      onClick={() => {
+                        const skill = skills.find((s) => s.id === selectedSkillId || s.slug === selectedSkillId);
+                        if (skill) setDeletingSkill(skill);
+                      }}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Delete skill</TooltipContent>
+                </Tooltip>
                 </div>
               </div>
             </div>
@@ -1223,15 +1278,19 @@ export function SkillRegistryPage() {
                 <div className="flex items-center justify-between px-3 py-2 border-b">
                   <span className="text-[10px] font-semibold uppercase text-muted-foreground tracking-wider">Files</span>
                   {!isImported && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="h-5 w-5 p-0"
-                      title="Add file"
-                      onClick={() => { setAddingFile(true); setNewFilePath(''); }}
-                    >
-                      <FilePlus className="h-3 w-3" />
-                    </Button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-5 w-5 p-0"
+                          onClick={() => { setAddingFile(true); setNewFilePath(''); }}
+                        >
+                          <FilePlus className="h-3 w-3" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Add file</TooltipContent>
+                    </Tooltip>
                   )}
                 </div>
                 <div className="flex-1 overflow-y-auto py-1">
@@ -1264,7 +1323,8 @@ export function SkillRegistryPage() {
                                 const flushed = flushDraftEdits();
                                 if (flushed) setDraftSkill(flushed);
                               } else if (isDirty) {
-                                if (!confirm('Discard unsaved changes?')) return;
+                                setPendingFile(f.path);
+                                return;
                               }
                               setEditedContent(null);
                               setEditedDescription(null);
@@ -1277,29 +1337,37 @@ export function SkillRegistryPage() {
                           {!isImported && (
                             <div className="hidden group-hover:flex items-center gap-0.5 shrink-0">
                               {f.path !== 'SKILL.md' && (
-                                <button
-                                  className="p-0.5 hover:text-primary"
-                                  title="Rename"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    setRenamingFile(f.path);
-                                    setRenameFileValue(f.path);
-                                  }}
-                                >
-                                  <PencilLine className="h-2.5 w-2.5" />
-                                </button>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <button
+                                      className="p-0.5 hover:text-primary"
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        setRenamingFile(f.path);
+                                        setRenameFileValue(f.path);
+                                      }}
+                                    >
+                                      <PencilLine className="h-2.5 w-2.5" />
+                                    </button>
+                                  </TooltipTrigger>
+                                  <TooltipContent>Rename</TooltipContent>
+                                </Tooltip>
                               )}
                               {f.path !== 'SKILL.md' && (
-                                <button
-                                  className="p-0.5 hover:text-destructive"
-                                  title="Delete"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    setDeletingFile(f.path);
-                                  }}
-                                >
-                                  <X className="h-2.5 w-2.5" />
-                                </button>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <button
+                                      className="p-0.5 hover:text-destructive"
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        setDeletingFile(f.path);
+                                      }}
+                                    >
+                                      <X className="h-2.5 w-2.5" />
+                                    </button>
+                                  </TooltipTrigger>
+                                  <TooltipContent>Delete</TooltipContent>
+                                </Tooltip>
                               )}
                             </div>
                           )}
@@ -1407,6 +1475,36 @@ export function SkillRegistryPage() {
       </div>
 
       {/* Delete file confirmation */}
+      {/* Discard unsaved changes when switching files */}
+      <AlertDialog open={!!pendingFile} onOpenChange={(o) => { if (!o) setPendingFile(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Discard unsaved changes?</AlertDialogTitle>
+            <AlertDialogDescription>
+              You have unsaved edits in <strong>{activeFile}</strong>. Switching files will
+              discard them.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep editing</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (pendingFile) {
+                  setEditedContent(null);
+                  setEditedDescription(null);
+                  setEditedBody(null);
+                  setActiveFile(pendingFile);
+                }
+                setPendingFile(null);
+              }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Discard changes
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
       <AlertDialog open={!!deletingFile} onOpenChange={() => setDeletingFile(null)}>
         <AlertDialogContent>
           <AlertDialogHeader>
@@ -1455,7 +1553,7 @@ export function SkillRegistryPage() {
 
       {/* Update diff dialog */}
       <Dialog open={!!updateDiff} onOpenChange={() => setUpdateDiff(null)}>
-        <DialogContent className="max-w-4xl max-h-[80vh] flex flex-col">
+        <DialogContent className="sm:max-w-4xl max-h-[80vh] flex flex-col">
           <DialogHeader>
             <DialogTitle>Upstream Changes Available</DialogTitle>
             <DialogDescription>
@@ -1496,7 +1594,7 @@ export function SkillRegistryPage() {
 
       {/* Version history dialog */}
       <Dialog open={showHistory} onOpenChange={(open) => { if (!open) { setShowHistory(false); setSelectedVersion(null); } }}>
-        <DialogContent className="max-w-4xl max-h-[80vh] flex flex-col">
+        <DialogContent className="sm:max-w-4xl max-h-[80vh] flex flex-col">
           <DialogHeader>
             <DialogTitle>Version History</DialogTitle>
             <DialogDescription>

--- a/packages/console-frontend/src/pages/SkillsPage.tsx
+++ b/packages/console-frontend/src/pages/SkillsPage.tsx
@@ -50,6 +50,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { SkillEditorPanel } from '@/components/skills/SkillEditorPanel';
 import { SkillImportPanel } from '@/components/skills/SkillImportPanel';
 
@@ -359,25 +360,33 @@ export function SkillsPage() {
               Skills
             </span>
             <div className="flex items-center gap-0.5">
-              <Button
-                size="sm"
-                variant="ghost"
-                className="h-6 w-6 p-0"
-                onClick={() => { setShowImport(true); setActiveSkill(null); }}
-                title="Import from registry"
-              >
-                <Download className="h-3.5 w-3.5" />
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                className="h-6 w-6 p-0"
-                onClick={() => setShowCreateDialog(true)}
-                title="New skill"
-                disabled={view === 'standard'}
-              >
-                <Plus className="h-3.5 w-3.5" />
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-6 w-6 p-0"
+                    onClick={() => { setShowImport(true); setActiveSkill(null); }}
+                  >
+                    <Download className="h-3.5 w-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Import from registry</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-6 w-6 p-0"
+                    onClick={() => setShowCreateDialog(true)}
+                    disabled={view === 'standard'}
+                  >
+                    <Plus className="h-3.5 w-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>New skill</TooltipContent>
+              </Tooltip>
             </div>
           </div>
           <Select value={selectedAgent} onValueChange={handleAgentChange}>

--- a/packages/console-frontend/src/pages/SubAgentDetailPage.tsx
+++ b/packages/console-frontend/src/pages/SubAgentDetailPage.tsx
@@ -1295,44 +1295,56 @@ export function SubAgentDetailPage() {
                   <>
                     {isEditing ? (
                       <>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={handleCancelEdit}
-                          disabled={updateMutation.isPending}
-                          className="h-7 w-7"
-                          title="Cancel editing"
-                        >
-                          <X className="h-4 w-4" />
-                        </Button>
-                        <Button
-                          size="icon"
-                          onClick={handleSave}
-                          disabled={updateMutation.isPending}
-                          className="h-7 w-7"
-                          title="Save changes"
-                        >
-                          {updateMutation.isPending ? (
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                          ) : (
-                            <Save className="h-4 w-4" />
-                          )}
-                        </Button>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={handleCancelEdit}
+                              disabled={updateMutation.isPending}
+                              className="h-7 w-7"
+                            >
+                              <X className="h-4 w-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>Cancel editing</TooltipContent>
+                        </Tooltip>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              size="icon"
+                              onClick={handleSave}
+                              disabled={updateMutation.isPending}
+                              className="h-7 w-7"
+                            >
+                              {updateMutation.isPending ? (
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                              ) : (
+                                <Save className="h-4 w-4" />
+                              )}
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>Save changes</TooltipContent>
+                        </Tooltip>
                       </>
                     ) : (
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => {
-                          setIsEditing(true);
-                          setActiveFocusArea('config');
-                          setShowConversationList(false);
-                        }}
-                        className="h-7 w-7"
-                        title="Edit configuration"
-                      >
-                        <Edit className="h-4 w-4" />
-                      </Button>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => {
+                              setIsEditing(true);
+                              setActiveFocusArea('config');
+                              setShowConversationList(false);
+                            }}
+                            className="h-7 w-7"
+                          >
+                            <Edit className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Edit configuration</TooltipContent>
+                      </Tooltip>
                     )}
                   </>
                 )}
@@ -1900,14 +1912,18 @@ export function SubAgentDetailPage() {
                                   className="flex items-center gap-2 py-1 px-2 rounded bg-muted/40 text-[11px] group/skill"
                                 >
                                   {skill.scope && skill.scope !== 'sub-agent' ? (
-                                    <a
-                                      href={`/app/skill-registry?skill=${skill.registry_id}`}
-                                      className="font-mono font-medium shrink-0 whitespace-nowrap text-primary hover:underline inline-flex items-center gap-0.5"
-                                      title="View in skill registry"
-                                    >
-                                      {skill.name || '(unnamed)'}
-                                      <ExternalLink className="h-2.5 w-2.5 opacity-60" />
-                                    </a>
+                                    <Tooltip>
+                                      <TooltipTrigger asChild>
+                                        <a
+                                          href={`/app/skill-registry?skill=${skill.registry_id}`}
+                                          className="font-mono font-medium shrink-0 whitespace-nowrap text-primary hover:underline inline-flex items-center gap-0.5"
+                                        >
+                                          {skill.name || '(unnamed)'}
+                                          <ExternalLink className="h-2.5 w-2.5 opacity-60" />
+                                        </a>
+                                      </TooltipTrigger>
+                                      <TooltipContent>View in skill registry</TooltipContent>
+                                    </Tooltip>
                                   ) : (
                                     <code className="font-mono font-medium shrink-0 whitespace-nowrap">{skill.name || '(unnamed)'}</code>
                                   )}
@@ -2198,29 +2214,37 @@ export function SubAgentDetailPage() {
                     )}
                     <div className="flex items-center gap-0.5 opacity-0 group-hover/activation:opacity-100 transition-opacity ml-auto shrink-0">
                       {activation.update_available && (
-                        <button
-                          type="button"
-                          className="text-primary hover:text-primary/80 p-0.5"
-                          title="Update to latest"
-                          onClick={() => setSkillDiffInfo({
-                            registryId: activation.registry_id,
-                            contentHash: activation.content_hash,
-                            name: activation.skill_name,
-                            updateTarget: { type: 'activation', activationId: activation.id },
-                          })}
-                          disabled={updateActivationMutation.isPending}
-                        >
-                          <RefreshCw className="h-3 w-3" />
-                        </button>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              type="button"
+                              className="text-primary hover:text-primary/80 p-0.5"
+                              onClick={() => setSkillDiffInfo({
+                                registryId: activation.registry_id,
+                                contentHash: activation.content_hash,
+                                name: activation.skill_name,
+                                updateTarget: { type: 'activation', activationId: activation.id },
+                              })}
+                              disabled={updateActivationMutation.isPending}
+                            >
+                              <RefreshCw className="h-3 w-3" />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>Update to latest</TooltipContent>
+                        </Tooltip>
                       )}
-                      <button
-                        type="button"
-                        className="text-destructive hover:text-destructive/80 p-0.5"
-                        title="Deactivate"
-                        onClick={() => setDeactivatingActivation(activation)}
-                      >
-                        <Trash2 className="h-3 w-3" />
-                      </button>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            className="text-destructive hover:text-destructive/80 p-0.5"
+                            onClick={() => setDeactivatingActivation(activation)}
+                          >
+                            <Trash2 className="h-3 w-3" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent>Deactivate</TooltipContent>
+                      </Tooltip>
                     </div>
                   </div>
                 ))
@@ -2341,15 +2365,19 @@ export function SubAgentDetailPage() {
         <div className="flex-1 flex flex-col rounded-lg border border-border bg-muted/30 min-w-0 overflow-hidden">
           <div className="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
             <div className="flex items-center gap-2">
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7"
-                onClick={() => setShowConversationList(!showConversationList)}
-                title={showConversationList ? 'Hide conversations' : 'Show conversations'}
-              >
-                <MessageSquare className="h-4 w-4" />
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    onClick={() => setShowConversationList(!showConversationList)}
+                  >
+                    <MessageSquare className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{showConversationList ? 'Hide conversations' : 'Show conversations'}</TooltipContent>
+              </Tooltip>
               <h2 className="text-sm font-semibold">{activeConversation ? activeConversation.title : 'Test Chat'}</h2>
               {activeConversation && (
                 <Badge variant="outline" className="text-xs">
@@ -2361,26 +2389,34 @@ export function SubAgentDetailPage() {
               )}
             </div>
             <div className="flex items-center gap-1">
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7"
-                onClick={handleNewConversation}
-                title="New conversation"
-              >
-                <Plus className="h-4 w-4" />
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    onClick={handleNewConversation}
+                  >
+                    <Plus className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>New conversation</TooltipContent>
+              </Tooltip>
               {/* Show version history button when collapsed */}
               {versionHistory.length > 0 && versionSidebarCollapsed && (
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7"
-                  onClick={() => setVersionSidebarCollapsed(false)}
-                  title="Show version history"
-                >
-                  <PanelRightOpen className="h-4 w-4" />
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7"
+                      onClick={() => setVersionSidebarCollapsed(false)}
+                    >
+                      <PanelRightOpen className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Show version history</TooltipContent>
+                </Tooltip>
               )}
             </div>
           </div>

--- a/packages/console-frontend/src/pages/UsagePage.tsx
+++ b/packages/console-frontend/src/pages/UsagePage.tsx
@@ -44,6 +44,7 @@ import {
 } from '@/lib/billing-units';
 import { useAuth } from '@/contexts/AuthContext';
 import { config } from '@/config';
+import { PageHeaderSkeleton, StatCardsSkeleton, ChartSkeleton, TableSkeleton } from '@/components/skeletons';
 
 export function UsagePage() {
   const { isAdmin } = useAuth();
@@ -249,7 +250,14 @@ export function UsagePage() {
   }, [detailed]);
 
   if (summaryLoading || detailedLoading || logsLoading) {
-    return <div className="flex justify-center items-center h-screen">Loading...</div>;
+    return (
+      <div className="container mx-auto p-6 space-y-6">
+        <PageHeaderSkeleton action />
+        <StatCardsSkeleton count={4} />
+        <ChartSkeleton />
+        <TableSkeleton columns={7} />
+      </div>
+    );
   }
 
   return (
@@ -479,17 +487,21 @@ export function UsagePage() {
                   <Badge variant="secondary" className="flex items-center gap-1">
                     <Filter className="h-3 w-3" />
                     Filtered
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="h-4 w-4 p-0 ml-1 hover:bg-transparent"
-                      onClick={() => {
-                        window.location.href = '/app/usage';
-                      }}
-                      title="Clear filter and show all conversations"
-                    >
-                      <X className="h-3 w-3" />
-                    </Button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-4 w-4 p-0 ml-1 hover:bg-transparent"
+                          onClick={() => {
+                            window.location.href = '/app/usage';
+                          }}
+                        >
+                          <X className="h-3 w-3" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Clear filter and show all conversations</TooltipContent>
+                    </Tooltip>
                   </Badge>
                 )}
               </div>
@@ -634,16 +646,20 @@ export function UsagePage() {
                         {isAdmin && (
                           <TableCell className="text-center">
                             {!isNoConversation && !isCatalogGroup && (
-                              <a
-                                href={`https://eu.smith.langchain.com/o/${config.langsmith.organizationId}/projects/p/${config.langsmith.projectId}/t/${conversationId}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="inline-flex items-center gap-1 text-primary hover:underline text-xs"
-                                title="View trace in LangSmith"
-                                onClick={(e) => e.stopPropagation()}
-                              >
-                                <ExternalLink className="h-3 w-3" />
-                              </a>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <a
+                                    href={`https://eu.smith.langchain.com/o/${config.langsmith.organizationId}/projects/p/${config.langsmith.projectId}/t/${conversationId}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="inline-flex items-center gap-1 text-primary hover:underline text-xs"
+                                    onClick={(e) => e.stopPropagation()}
+                                  >
+                                    <ExternalLink className="h-3 w-3" />
+                                  </a>
+                                </TooltipTrigger>
+                                <TooltipContent>View trace in LangSmith</TooltipContent>
+                              </Tooltip>
                             )}
                           </TableCell>
                         )}
@@ -744,15 +760,19 @@ export function UsagePage() {
                             {isAdmin && (
                               <TableCell className="text-center">
                                 {log.conversation_id && (
-                                  <a
-                                    href={`https://eu.smith.langchain.com/o/${config.langsmith.organizationId}/projects/p/${config.langsmith.projectId}/t/${log.conversation_id}`}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="inline-flex items-center gap-1 text-primary hover:underline text-xs"
-                                    title="View trace in LangSmith"
-                                  >
-                                    <ExternalLink className="h-3 w-3" />
-                                  </a>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <a
+                                        href={`https://eu.smith.langchain.com/o/${config.langsmith.organizationId}/projects/p/${config.langsmith.projectId}/t/${log.conversation_id}`}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="inline-flex items-center gap-1 text-primary hover:underline text-xs"
+                                      >
+                                        <ExternalLink className="h-3 w-3" />
+                                      </a>
+                                    </TooltipTrigger>
+                                    <TooltipContent>View trace in LangSmith</TooltipContent>
+                                  </Tooltip>
                                 )}
                               </TableCell>
                             )}

--- a/packages/console-frontend/src/pages/admin/AnalyticsPage.tsx
+++ b/packages/console-frontend/src/pages/admin/AnalyticsPage.tsx
@@ -11,6 +11,7 @@ import {
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
 import {
   Select,
   SelectContent,
@@ -269,7 +270,7 @@ export function AnalyticsPage() {
         </CardHeader>
         <CardContent>
           {activeUsersLoading ? (
-            <div className="flex h-[250px] items-center justify-center text-muted-foreground">Loading...</div>
+            <Skeleton className="h-[250px] w-full" />
           ) : !activeUsers?.data?.length ? (
             <EmptyChart message="No active user data for this period" />
           ) : (
@@ -322,7 +323,7 @@ export function AnalyticsPage() {
           </CardHeader>
           <CardContent>
             {churnLoading ? (
-              <div className="flex h-[220px] items-center justify-center text-muted-foreground">Loading...</div>
+              <Skeleton className="h-[220px] w-full" />
             ) : !churn?.data?.length ? (
               <EmptyChart message="Not enough data to calculate churn (requires 2+ weeks)" />
             ) : (
@@ -384,7 +385,7 @@ export function AnalyticsPage() {
           </CardHeader>
           <CardContent>
             {costLoading ? (
-              <div className="flex h-[220px] items-center justify-center text-muted-foreground">Loading...</div>
+              <Skeleton className="h-[220px] w-full" />
             ) : !costOverTime?.data?.length ? (
               <EmptyChart message="No cost data recorded for this period" />
             ) : (
@@ -438,7 +439,7 @@ export function AnalyticsPage() {
           </CardHeader>
           <CardContent>
             {engagementLoading ? (
-              <div className="flex h-[220px] items-center justify-center text-muted-foreground">Loading...</div>
+              <Skeleton className="h-[220px] w-full" />
             ) : !engagement?.data?.length ? (
               <EmptyChart message="No engagement data for this period" />
             ) : (
@@ -483,7 +484,7 @@ export function AnalyticsPage() {
           </CardHeader>
           <CardContent>
             {cohortsLoading ? (
-              <div className="flex h-[220px] items-center justify-center text-muted-foreground">Loading...</div>
+              <Skeleton className="h-[220px] w-full" />
             ) : !cohorts?.data?.length ? (
               <EmptyChart message="No cohort data for this period" />
             ) : (

--- a/packages/console-frontend/src/pages/admin/AuditPage.tsx
+++ b/packages/console-frontend/src/pages/admin/AuditPage.tsx
@@ -13,6 +13,8 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { TableRowsSkeleton } from '@/components/skeletons';
+import { TableEmptyRow } from '@/components/EmptyState';
 import {
   Select,
   SelectContent,
@@ -194,17 +196,9 @@ export function AuditPage() {
           </TableHeader>
           <TableBody>
             {isLoading ? (
-              <TableRow>
-                <TableCell colSpan={5} className="text-center py-8">
-                  Loading...
-                </TableCell>
-              </TableRow>
+              <TableRowsSkeleton columns={5} />
             ) : logs.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={5} className="text-center py-8 text-muted-foreground">
-                  No audit logs found
-                </TableCell>
-              </TableRow>
+              <TableEmptyRow colSpan={5} title="No audit logs found" />
             ) : (
               logs.map((log) => (
                 <TableRow key={log.id}>

--- a/packages/console-frontend/src/pages/admin/BugReportsPage.tsx
+++ b/packages/console-frontend/src/pages/admin/BugReportsPage.tsx
@@ -21,6 +21,8 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { TableRowsSkeleton } from '@/components/skeletons';
+import { TableEmptyRow } from '@/components/EmptyState';
 import {
   Select,
   SelectContent,
@@ -46,6 +48,7 @@ import { Pagination } from '@/components/admin/Pagination';
 import { BugReportStatusBadge } from '@/components/admin/BugReportStatusBadge';
 import { ConfirmDialog } from '@/components/admin/ConfirmDialog';
 import { Badge } from '@/components/ui/badge';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 export function BugReportsPage() {
   const queryClient = useQueryClient();
@@ -250,17 +253,9 @@ export function BugReportsPage() {
           </TableHeader>
           <TableBody>
             {isLoading ? (
-              <TableRow>
-                <TableCell colSpan={7} className="text-center py-8 text-muted-foreground">
-                  Loading...
-                </TableCell>
-              </TableRow>
+              <TableRowsSkeleton columns={7} />
             ) : filteredReports.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={7} className="text-center py-8 text-muted-foreground">
-                  No bug reports found
-                </TableCell>
-              </TableRow>
+              <TableEmptyRow colSpan={7} title="No bug reports found" />
             ) : (
               filteredReports.map((report) => (
                 <TableRow key={report.id}>
@@ -278,37 +273,49 @@ export function BugReportsPage() {
                   <TableCell>
                     <div className="flex items-center gap-2">
                       {report.external_link && (
-                        <a
-                          href={report.external_link}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1 text-primary hover:underline text-xs"
-                          title="View linked issue"
-                        >
-                          <ExternalLink className="h-3 w-3" />
-                        </a>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <a
+                              href={report.external_link}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="inline-flex items-center gap-1 text-primary hover:underline text-xs"
+                            >
+                              <ExternalLink className="h-3 w-3" />
+                            </a>
+                          </TooltipTrigger>
+                          <TooltipContent>View linked issue</TooltipContent>
+                        </Tooltip>
                       )}
                       {report.conversation_id && config.langsmith.organizationId && (
-                        <a
-                          href={`https://eu.smith.langchain.com/o/${config.langsmith.organizationId}/projects/p/${config.langsmith.projectId}/t/${report.conversation_id}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1 text-primary hover:underline text-xs"
-                          title="Original conversation trace"
-                        >
-                          <FlaskConical className="h-3 w-3" />
-                        </a>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <a
+                              href={`https://eu.smith.langchain.com/o/${config.langsmith.organizationId}/projects/p/${config.langsmith.projectId}/t/${report.conversation_id}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="inline-flex items-center gap-1 text-primary hover:underline text-xs"
+                            >
+                              <FlaskConical className="h-3 w-3" />
+                            </a>
+                          </TooltipTrigger>
+                          <TooltipContent>Original conversation trace</TooltipContent>
+                        </Tooltip>
                       )}
                       {report.debug_conversation_id && config.langsmith.organizationId && (
-                        <a
-                          href={`https://eu.smith.langchain.com/o/${config.langsmith.organizationId}/projects/p/${config.langsmith.projectId}/t/${report.debug_conversation_id}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1 text-primary hover:underline text-xs"
-                          title="Debug agent trace"
-                        >
-                          <Bug className="h-3 w-3" />
-                        </a>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <a
+                              href={`https://eu.smith.langchain.com/o/${config.langsmith.organizationId}/projects/p/${config.langsmith.projectId}/t/${report.debug_conversation_id}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="inline-flex items-center gap-1 text-primary hover:underline text-xs"
+                            >
+                              <Bug className="h-3 w-3" />
+                            </a>
+                          </TooltipTrigger>
+                          <TooltipContent>Debug agent trace</TooltipContent>
+                        </Tooltip>
                       )}
                     </div>
                   </TableCell>

--- a/packages/console-frontend/src/pages/admin/GroupDetailPage.tsx
+++ b/packages/console-frontend/src/pages/admin/GroupDetailPage.tsx
@@ -35,6 +35,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { ConfirmDialog } from '@/components/admin/ConfirmDialog';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Badge } from '@/components/ui/badge';
@@ -58,6 +59,7 @@ export function GroupDetailPage() {
   const [newMemberRole, setNewMemberRole] = useState<RoleEnum>('read');
 
   const [selectedMembersToRemove, setSelectedMembersToRemove] = useState<Set<string>>(new Set());
+  const [confirmRemoveMembers, setConfirmRemoveMembers] = useState(false);
 
   const [membersPage, setMembersPage] = useState(1);
 
@@ -644,7 +646,7 @@ export function GroupDetailPage() {
             {selectedMembersToRemove.size > 0 && (
               <Button
                 variant="destructive"
-                onClick={handleRemoveSelectedMembers}
+                onClick={() => setConfirmRemoveMembers(true)}
                 disabled={removeMembersMutation.isPending}
               >
                 <X className="h-4 w-4 mr-2" />
@@ -863,6 +865,20 @@ export function GroupDetailPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <ConfirmDialog
+        open={confirmRemoveMembers}
+        onOpenChange={setConfirmRemoveMembers}
+        title="Remove selected members?"
+        description={`${selectedMembersToRemove.size} member${selectedMembersToRemove.size === 1 ? '' : 's'} will be removed from this group.`}
+        confirmLabel="Remove"
+        variant="destructive"
+        isLoading={removeMembersMutation.isPending}
+        onConfirm={() => {
+          handleRemoveSelectedMembers();
+          setConfirmRemoveMembers(false);
+        }}
+      />
     </div>
   );
 }

--- a/packages/console-frontend/src/pages/admin/GroupsPage.tsx
+++ b/packages/console-frontend/src/pages/admin/GroupsPage.tsx
@@ -22,6 +22,8 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { TableRowsSkeleton } from '@/components/skeletons';
+import { TableEmptyRow } from '@/components/EmptyState';
 import {
   Dialog,
   DialogContent,
@@ -194,17 +196,9 @@ export function GroupsPage() {
           </TableHeader>
           <TableBody>
             {isLoading ? (
-              <TableRow>
-                <TableCell colSpan={5} className="text-center py-8">
-                  Loading...
-                </TableCell>
-              </TableRow>
+              <TableRowsSkeleton columns={5} />
             ) : groups.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={5} className="text-center py-8 text-muted-foreground">
-                  No groups found
-                </TableCell>
-              </TableRow>
+              <TableEmptyRow colSpan={5} title="No groups found" />
             ) : (
               groups.map((group) => (
                 <TableRow key={group.id}>

--- a/packages/console-frontend/src/pages/admin/OutboundScimPage.tsx
+++ b/packages/console-frontend/src/pages/admin/OutboundScimPage.tsx
@@ -9,6 +9,8 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Switch } from '@/components/ui/switch';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { TableRowsSkeleton } from '@/components/skeletons';
+import { TableEmptyRow } from '@/components/EmptyState';
 import {
   Dialog,
   DialogContent,
@@ -18,6 +20,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { ConfirmDialog } from '@/components/admin/ConfirmDialog';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 interface OutboundScimEndpoint {
   id: string;
@@ -258,18 +261,9 @@ export function OutboundScimPage() {
           </TableHeader>
           <TableBody>
             {isLoading ? (
-              <TableRow>
-                <TableCell colSpan={6} className="text-center py-8">
-                  Loading...
-                </TableCell>
-              </TableRow>
+              <TableRowsSkeleton columns={6} />
             ) : endpoints.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={6} className="text-center py-8 text-muted-foreground">
-                  <Globe className="h-8 w-8 mx-auto mb-2 opacity-50" />
-                  No outbound SCIM endpoints configured
-                </TableCell>
-              </TableRow>
+              <TableEmptyRow colSpan={6} icon={Globe} title="No outbound SCIM endpoints configured" />
             ) : (
               endpoints.map((ep) => (
                 <TableRow key={ep.id}>
@@ -291,36 +285,53 @@ export function OutboundScimPage() {
                   <TableCell className="text-sm">{formatDate(ep.created_at)}</TableCell>
                   <TableCell>
                     <div className="flex gap-1">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => pushAllMutation.mutate(ep.id)}
-                        disabled={pushAllMutation.isPending || !ep.enabled}
-                        title="Push all users and groups"
-                      >
-                        <RefreshCw className="h-4 w-4" /> Full Sync
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => testMutation.mutate(ep.id)}
-                        disabled={testMutation.isPending}
-                        title="Test connection"
-                      >
-                        <TestTube className="h-4 w-4" /> Test
-                      </Button>
-                      <Button variant="outline" size="sm" onClick={() => openEditDialog(ep)} title="Edit">
-                        <Pencil className="h-4 w-4" /> Edit
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="text-destructive hover:text-destructive"
-                        onClick={() => setDeleteDialog({ open: true, endpoint: ep })}
-                        title="Delete"
-                      >
-                        <Trash2 className="h-4 w-4" /> Delete
-                      </Button>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => pushAllMutation.mutate(ep.id)}
+                            disabled={pushAllMutation.isPending || !ep.enabled}
+                          >
+                            <RefreshCw className="h-4 w-4" /> Full Sync
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Push all users and groups</TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => testMutation.mutate(ep.id)}
+                            disabled={testMutation.isPending}
+                          >
+                            <TestTube className="h-4 w-4" /> Test
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Test connection</TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button variant="outline" size="sm" onClick={() => openEditDialog(ep)}>
+                            <Pencil className="h-4 w-4" /> Edit
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Edit</TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="text-destructive hover:text-destructive"
+                            onClick={() => setDeleteDialog({ open: true, endpoint: ep })}
+                          >
+                            <Trash2 className="h-4 w-4" /> Delete
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Delete</TooltipContent>
+                      </Tooltip>
                     </div>
                   </TableCell>
                 </TableRow>

--- a/packages/console-frontend/src/pages/admin/RateCardsPage.tsx
+++ b/packages/console-frontend/src/pages/admin/RateCardsPage.tsx
@@ -28,6 +28,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { CardListSkeleton } from '@/components/skeletons';
 import { Badge } from '@/components/ui/badge';
 
 interface GroupedModel {
@@ -213,7 +214,7 @@ export function RateCardsPage() {
 
       {/* Grouped Models */}
       {entriesLoading ? (
-        <div className="text-center py-8">Loading...</div>
+        <CardListSkeleton />
       ) : groupedModels.length === 0 ? (
         <Card>
           <CardContent className="pt-6">
@@ -548,7 +549,7 @@ function ModelPricingDialog({ open, onOpenChange, onSubmit, existingModel }: {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="sm:max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{isEdit ? 'Edit' : 'Add'} Model Pricing</DialogTitle>
           <DialogDescription>

--- a/packages/console-frontend/src/pages/admin/ScimTokensPage.tsx
+++ b/packages/console-frontend/src/pages/admin/ScimTokensPage.tsx
@@ -15,6 +15,8 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { TableRowsSkeleton } from '@/components/skeletons';
+import { TableEmptyRow } from '@/components/EmptyState';
 import {
   Dialog,
   DialogContent,
@@ -180,17 +182,9 @@ export function ScimTokensPage() {
           </TableHeader>
           <TableBody>
             {isLoading ? (
-              <TableRow>
-                <TableCell colSpan={7} className="text-center py-8">
-                  Loading...
-                </TableCell>
-              </TableRow>
+              <TableRowsSkeleton columns={7} />
             ) : tokens.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={7} className="text-center py-8 text-muted-foreground">
-                  No SCIM tokens created yet
-                </TableCell>
-              </TableRow>
+              <TableEmptyRow colSpan={7} title="No SCIM tokens created yet" />
             ) : (
               tokens.map((token) => {
                 const status = getTokenStatus(token);

--- a/packages/console-frontend/src/pages/admin/ToolRiskScoresPage.tsx
+++ b/packages/console-frontend/src/pages/admin/ToolRiskScoresPage.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { TableSkeleton } from '@/components/skeletons';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
@@ -17,6 +18,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { client } from '@/api/generated/client.gen';
 
 interface RiskFactor {
@@ -228,10 +230,7 @@ export function ToolRiskScoresPage() {
 
       {/* Table */}
       {isLoading ? (
-        <div className="flex items-center gap-2 text-muted-foreground py-8 justify-center">
-          <Loader2 className="h-5 w-5 animate-spin" />
-          Loading risk scores...
-        </div>
+        <TableSkeleton columns={6} />
       ) : scores.length === 0 ? (
         <Card>
           <CardContent className="py-8 text-center text-muted-foreground">
@@ -284,30 +283,38 @@ export function ToolRiskScoresPage() {
                   </td>
                   <td className="px-4 py-2 text-right">
                     <div className="flex gap-1 justify-end">
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-7 w-7"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          openEditDialog(score);
-                        }}
-                        title="Edit score"
-                      >
-                        <Pencil className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-7 w-7 text-destructive hover:text-destructive"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setConfirmDelete(score);
-                        }}
-                        title="Invalidate (force re-score)"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              openEditDialog(score);
+                            }}
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Edit score</TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 text-destructive hover:text-destructive"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setConfirmDelete(score);
+                            }}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Invalidate (force re-score)</TooltipContent>
+                      </Tooltip>
                     </div>
                   </td>
                 </tr>

--- a/packages/console-frontend/src/pages/admin/UsersPage.tsx
+++ b/packages/console-frontend/src/pages/admin/UsersPage.tsx
@@ -13,6 +13,8 @@ import type { UserWithGroups, ActionEnum } from '@/api/generated';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { TableRowsSkeleton } from '@/components/skeletons';
+import { TableEmptyRow } from '@/components/EmptyState';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import {
   DropdownMenu,
@@ -239,17 +241,9 @@ export function UsersPage() {
           </TableHeader>
           <TableBody>
             {isLoading ? (
-              <TableRow>
-                <TableCell colSpan={7} className="text-center py-8">
-                  Loading...
-                </TableCell>
-              </TableRow>
+              <TableRowsSkeleton columns={7} />
             ) : users.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={7} className="text-center py-8 text-muted-foreground">
-                  No users found
-                </TableCell>
-              </TableRow>
+              <TableEmptyRow colSpan={7} title="No users found" />
             ) : (
               users.map((user) => (
                 <TableRow key={user.id}>


### PR DESCRIPTION
Cross-cutting console-frontend consistency cleanup ahead of the new major version. Frontend-only; no backend changes.

## What changed

**Dialogs & destructive actions**
- Fixed a dialog-width bug where a base `max-w-*` was silently capped by the component's default `sm:max-w-lg`; switched to `sm:max-w-*` on the Scheduler, Rate Cards, Skill Registry (×2) and Secret Permissions dialogs.
- Widened the Scheduler **New Job** modal and paired the watch condition/expected-value fields.
- Replaced both native `confirm()` dialogs (Scheduler detail delete, Skill Registry "discard changes") with the app's styled dialogs.
- Added a confirmation step to three deletes that previously fired instantly with no prompt: **catalog source**, **tool bypass rule**, **group-member** removal (shared `ConfirmDialog`, destructive variant).

**Scheduler detail page**
- Rebuilt with card sections and an explicit **read-only → edit** mode ("Edit configuration"); fields/dropdowns are locked while viewing. Delete now uses the styled `AlertDialog` instead of a native confirm.

**Cron UX**
- New `CronField` (+ `lib/cron` via `cronstrue`): preset quick-picks, live validation, and a human-readable schedule description, used in both the create and edit flows.

**Loading & empty states**
- New `skeletons.tsx`; ~13 pages moved from bare-text/ad-hoc spinners to layout-matched skeletons.
- New `EmptyState`/`TableEmptyRow`; six admin tables now show a consistent icon + message empty state.

**Tooltips**
- Converted ~60 native `title=` tooltips across ~20 files to the styled shadcn `<Tooltip>`.

Also removes a stray debug `console.log` and fixes a React key-prop warning on the Usage page.

## Verification
- `tsc -b` and full `vite build` pass.
- Browser smoke test (read-only/edit toggle, cron validation, widened modal, styled confirm dialog, dark tooltips, skeleton loading) — all pass, no console errors.

## Notes
- One intentional exception: a `<SelectTrigger title="Adjust panel width">` in Sub-Agent Detail was left as a native title (wrapping a Select trigger in a Tooltip trigger is fragile).
- New tooltips use the shadcn default `delayDuration={0}` (instant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)