### PR TITLE
fix(docstore): stop corrupting exports when content is a v2 plain str

### DIFF
--- a/packages/agent-common/agent_common/core/document_store_tools.py
+++ b/packages/agent-common/agent_common/core/document_store_tools.py
@@ -154,7 +154,9 @@ async def _read_personal_file_impl(
         if not content_lines:
             return f"File is empty: {file_path}"
 
-        content = "\n".join(content_lines)
+        # deepagents v2 stores `content` as a plain str; v1 (legacy) as list[str].
+        # Guard so we don't "\n".join() a string (which would split it per-character).
+        content = "\n".join(content_lines) if isinstance(content_lines, list) else str(content_lines)
         logger.info(f"Read personal file with permission: {file_path}")
         return content
 
@@ -469,8 +471,10 @@ async def _export_file_impl(
         if not content_lines:
             return f"Error: File '{file_path}' is empty"
 
-        # Join content lines (same format as FilesystemMiddleware)
-        file_content = "\n".join(content_lines)
+        # Join content lines (same format as FilesystemMiddleware).
+        # deepagents v2 stores `content` as a plain str; v1 (legacy) as list[str].
+        # Guard so we don't "\n".join() a string (which would split it per-character).
+        file_content = "\n".join(content_lines) if isinstance(content_lines, list) else str(content_lines)
 
     except Exception as e:
         logger.error(f"Failed to read persisted file '{file_path}' from filesystem: {e}")

--- a/packages/agent-common/tests/test_export_file.py
+++ b/packages/agent-common/tests/test_export_file.py
@@ -1,0 +1,57 @@
+"""Tests for _export_file_impl (the docstore_export tool implementation).
+
+Regression coverage for the bug where exporting a file whose stored `content`
+is a deepagents v2 plain `str` (rather than the legacy v1 `list[str]`) produced
+a corrupted upload — `"\n".join(some_string)` splits the string per-character,
+inserting a newline between every character.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent_common.core.document_store_tools import _export_file_impl
+
+
+def _make_store_item(content):
+    item = MagicMock()
+    item.value = {"content": content}
+    return item
+
+
+async def _run_export(content):
+    """Export a /memories/ file with the given stored content; return uploaded bytes."""
+    store = AsyncMock()
+    store.aget.return_value = _make_store_item(content)
+
+    storage = AsyncMock()
+    storage.generate_presigned_url.return_value = "https://example.com/presigned"
+
+    result = await _export_file_impl(
+        file_path="/memories/notes.md",
+        user_id="user-1",
+        store=store,
+        storage=storage,
+        s3_bucket="bucket",
+    )
+
+    assert "Download link" in result
+    storage.upload.assert_awaited_once()
+    uploaded = storage.upload.await_args.kwargs["content"]
+    return uploaded.decode("utf-8")
+
+
+class TestExportFileContentFormats:
+    @pytest.mark.asyncio
+    async def test_v2_string_content_is_not_split_per_character(self):
+        # deepagents v2 (default) stores content as a plain str.
+        uploaded = await _run_export("# Title\nHello world\nSecond line")
+        assert uploaded == "# Title\nHello world\nSecond line"
+        # Guard against the regression: no newline injected between every char.
+        assert "\nH\ne\nl\nl\no" not in uploaded
+
+    @pytest.mark.asyncio
+    async def test_v1_list_content_is_joined_with_newlines(self):
+        # Legacy v1 format stores content as list[str] (lines).
+        uploaded = await _run_export(["# Title", "Hello world", "Second line"])
+        assert uploaded == "# Title\nHello world\nSecond line"


### PR DESCRIPTION
## Problem

`docstore_export` was producing corrupted markdown — every character on its own line (vertical text). This was **not** a viewer rendering artifact: the exported S3 object itself contains a literal `\n` between every character.

## Root cause

`_export_file_impl` assumed the stored `content` was always `list[str]` and ran `"\n".join(content_lines)`. But the deepagents storage backend defaults to the **v2** format, where `content` is a plain `str`. Calling `"\n".join("some string")` iterates the string character-by-character and inserts a newline between each one.

The codebase already guards for this dual format in `_semantic_search_file_impl` (`isinstance(content_lines, list)`), but the export path and `read_personal_file` (with permission) were missed.

## Fix

- Guard both unguarded sites with `isinstance(content_lines, list)`, matching the existing guard.
- Add regression tests covering both v2 (`str`) and v1 (`list[str]`) stored content, asserting the uploaded bytes are correct.

## Notes

- Files exported **before** this fix are already corrupted at rest in S3 and need re-exporting — the original line breaks aren't recoverable from the bad object.

## Test plan

- [x] `uv run pytest tests/test_export_file.py` — 2 passed
- [x] Verified the new tests fail against the pre-fix `"\n".join(...)` behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)