### PR TITLE
fix(gateway): Vertex runtime credentials, embeddings & rate-card admin

### DIFF
--- a/packages/console-backend/AGENTS.md
+++ b/packages/console-backend/AGENTS.md
@@ -418,6 +418,21 @@ has_access = await user_group_service.check_resource_permission(
 
 When sending a steering message via `_send_steering_message_to_agent()`, the code uses `break` after the first event from `a2a_client.send_message()` — NOT `pass` to drain. The agent-console shares the same A2A SDK `Client` instance between the primary stream (`_send_message_to_agent`) and steering. The A2A SDK's `EventQueue.tap()` creates a child queue that receives all parent events. If leaked parent events containing raw `Task` objects were consumed through the shared `Client`, its `ClientTaskManager` would raise "Task is already set" errors. The `break` takes only the ack event and lets SSE teardown close the child queue. Note: consuming from the child never removes events from the parent queue (they're independent `asyncio.Queue` instances). See the root copilot instructions "Continuous Interaction Turns" section for the full mechanism.
 
+### Rate-Card Provider Must Equal the litellm Provider Family (cost tracking ↔ rate cards)
+
+Rate cards key on `(provider, model_name=alias)`. Billing resolves provider in the cost logger
+(`litellm-proxy/custom_logger.py` `_build_record`): `custom_llm_provider`, else the gateway
+model-id prefix (`deployment_id.split("/")[0]`). The rate-card provider MUST equal that family
+(e.g. `vertex_ai`, `bedrock`) or usage never matches the rate card → the model silently bills
+**$0**. Usage logging only *reads* rate cards (`calculate_cost`) — it never creates them; only
+explicit register/edit (`admin_model_gateway_router`) and the Rate Cards page do.
+
+Footgun: a Vertex **location** (`vertex_location` `eu`/`global`) is not a provider. The console
+registration form's Provider field was free-text and a location was typed there, creating orphan
+`eu`/`global` rate cards. The frontend (`ModelGatewayPage.tsx` `deriveProvider`) now derives the
+provider from the model-id prefix and enforces it at submit, but any backend code that creates or
+looks up rate cards must preserve this provider==prefix invariant.
+
 ### Repository Pattern with Automatic Audit Logging (repositories/base.py)
 
 ALL database write operations (INSERT/UPDATE/DELETE) MUST use the repository pattern. The `AuditedRepository` base class automatically logs every mutation with before/after state. Direct SQL writes bypass the audit trail. Repositories call `audit_service.log_action()` automatically in `create()`, `update()`, and `delete()` methods.

--- a/packages/console-backend/console_backend/config.py
+++ b/packages/console-backend/console_backend/config.py
@@ -117,6 +117,18 @@ class ModelGatewayConfig(BaseModel):
 
     url: str = Field(default_factory=lambda: os.getenv("LLM_GATEWAY_URL", "http://litellm-proxy.nannos.svc"))
     master_key: SecretStr = Field(default_factory=lambda: SecretStr(os.getenv("LITELLM_MASTER_KEY", "")))
+    # Default Vertex AI *serving region* suggested for newly registered Vertex models — the region
+    # the model is served from (e.g. the `eu` multi-region endpoint), NOT the GCP project's home
+    # region (GCP_LOCATION) nor the project id (vertex_project). Mirrors the proxy's
+    # DEFAULT_VERTEXAI_LOCATION so the console suggests the same region the proxy falls back to for
+    # models that don't pin their own vertex_location. EU matches our data-residency posture; a
+    # wrong region makes some models (e.g. gemini embeddings) 404. Override per deployment.
+    default_vertex_location: str = Field(default_factory=lambda: os.getenv("DEFAULT_VERTEXAI_LOCATION", "eu"))
+    # Default GCP project suggested for new Vertex models (the deployment's project id, from
+    # GCP_PROJECT_ID). Only a UI placeholder hint — the proxy resolves the real project from its
+    # pod credentials (ADC), so this is normally left blank. Empty when unset; never hardcode a
+    # project id in code (it is deployment-specific).
+    default_vertex_project: str = Field(default_factory=lambda: os.getenv("GCP_PROJECT_ID", ""))
     # Providers this deployment has integrated (has credentials for on the proxy).
     # The model-catalog picker is pre-filtered to these litellm_provider values.
     # NOTE: LiteLLM tags a model by its *implementation*, so the same vendor spans

--- a/packages/console-backend/console_backend/models/model_gateway.py
+++ b/packages/console-backend/console_backend/models/model_gateway.py
@@ -45,6 +45,12 @@ class GatewayModel(BaseModel):
     # Azure deployments map to a known model via model_info.base_model (cost/metadata). Surfaced
     # so the admin edit form can round-trip it instead of silently dropping it on update.
     base_model: str | None = None
+    # Routing params surfaced so the edit form round-trips them instead of dropping them on
+    # update (same rationale as base_model). NOT credentials — the proxy is the auth authority,
+    # so registrations carry no per-model creds (vertex_credentials/keys are never stored here).
+    vertex_location: str | None = None
+    vertex_project: str | None = None
+    aws_region_name: str | None = None
     input_cost_per_token: float | None = None
     output_cost_per_token: float | None = None
     supports_reasoning: bool | None = None
@@ -71,6 +77,10 @@ class CatalogModel(BaseModel):
     provider: str | None = None
     mode: str = "chat"
     input_cost_per_token: float | None = None
+    # Per-image input cost — the cross-provider signal that an embedding model accepts images
+    # (set for Gemini, Vertex multimodalembedding, Bedrock Nova/Titan even where the boolean
+    # capability flags are absent). The picker uses it to derive the 'image' input mode.
+    input_cost_per_image: float | None = None
     output_cost_per_token: float | None = None
     cache_read_input_token_cost: float | None = None
     cache_creation_input_token_cost: float | None = None
@@ -79,6 +89,17 @@ class CatalogModel(BaseModel):
     supports_reasoning: bool = False
     supports_audio_input: bool = False
     supports_pdf_input: bool = False
+
+
+class GatewayUiConfig(BaseModel):
+    """Deployment-specific defaults the registration UI needs (env-driven, read-only)."""
+
+    default_vertex_location: str = Field(
+        ..., description="Suggested Vertex serving region for new Vertex models (e.g. 'eu')"
+    )
+    default_vertex_project: str = Field(
+        "", description="Suggested GCP project id for new Vertex models; '' when unset (no hardcoded default)"
+    )
 
 
 class CostPrefill(BaseModel):

--- a/packages/console-backend/console_backend/repositories/rate_card_repository.py
+++ b/packages/console-backend/console_backend/repositories/rate_card_repository.py
@@ -109,6 +109,34 @@ class RateCardRepository(AuditedRepository):
         # Get or create rate_card
         rate_card_id = await self._get_or_create_rate_card_id(db, provider, model_name, model_name_pattern)
 
+        # No-op guard: if the current active rate for this card + billing unit already equals the
+        # new price, skip the write. Re-registering/saving a model with unchanged prices would
+        # otherwise insert an identical superseding version every time, bloating the history (the
+        # "current" rate is the latest effective_from, so duplicates are silent but accumulate).
+        current = await db.execute(
+            text("""
+                SELECT id, price_per_million
+                FROM rate_card_entries
+                WHERE rate_card_id = :rate_card_id
+                  AND billing_unit = :billing_unit
+                  AND effective_from <= :effective_from
+                  AND (effective_until IS NULL OR effective_until > :effective_from)
+                ORDER BY effective_from DESC
+                LIMIT 1
+            """),
+            {"rate_card_id": rate_card_id, "billing_unit": billing_unit, "effective_from": effective_from},
+        )
+        existing = current.mappings().first()
+        if existing is not None and Decimal(str(existing["price_per_million"])) == Decimal(str(price_per_million)):
+            logger.debug(
+                "Rate unchanged for %s/%s %s (%s) — skipping duplicate entry",
+                provider,
+                model_name,
+                billing_unit,
+                price_per_million,
+            )
+            return existing["id"]
+
         # Insert entry
         insert = text("""
             INSERT INTO rate_card_entries (

--- a/packages/console-backend/console_backend/routers/admin_model_gateway_router.py
+++ b/packages/console-backend/console_backend/routers/admin_model_gateway_router.py
@@ -8,15 +8,18 @@ never usable before it is billable. Master-key access stays server-side.
 
 import logging
 from decimal import Decimal
+from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
+from ..config import config
 from ..db.session import DbSession
 from ..dependencies import require_admin
 from ..models.model_gateway import (
     CatalogModel,
     CostPrefill,
     GatewayModel,
+    GatewayUiConfig,
     ModelRegistrationRequest,
     ModelRegistrationResponse,
     SetDefaultRequest,
@@ -32,12 +35,34 @@ router = APIRouter(prefix="/api/v1/admin/model-gateway", tags=["admin-model-gate
 
 # cost-per-token (gateway) → price-per-million (rate card), with the billing-unit
 # names the proxy CustomLogger emits.
-_COST_FIELD_TO_UNIT = {
+_FlowDir = Literal["input", "output", "other"]
+_COST_FIELD_TO_UNIT: dict[str, tuple[str, _FlowDir]] = {
     "input_cost_per_token": ("base_input_tokens", "input"),
     "output_cost_per_token": ("base_output_tokens", "output"),
     "cache_read_input_token_cost": ("cache_read_input_tokens", "input"),
     "cache_creation_input_token_cost": ("cache_creation_input_tokens", "input"),
+    "input_cost_per_image": ("input_images", "input"),
 }
+
+# billing_unit → flow_direction, for rate-card rows (which store only unit + price). Unknown
+# units default to "input" (the common case; only base_output_tokens is output-side).
+_UNIT_TO_FLOW = {unit: flow for (unit, flow) in _COST_FIELD_TO_UNIT.values()}
+
+
+def _with_default_vertex_location(litellm_params: dict, provider: str) -> dict:
+    """Pin the deployment's default Vertex serving region when a Vertex model omits one.
+
+    LiteLLM resolves an unpinned vertex_location for DB-registered models to its own default
+    (us-central1) — NOT the proxy's DEFAULT_VERTEXAI_LOCATION — so a blank location silently routes
+    to the wrong region and 404s models served elsewhere (e.g. EU-only Gemini embeddings). Pinning
+    config.model_gateway.default_vertex_location (env DEFAULT_VERTEXAI_LOCATION) keeps the UI's
+    "leave blank → deployment default" promise true. A region, not a credential — safe to inject.
+    """
+    model = str(litellm_params.get("model") or "")
+    is_vertex = provider.startswith("vertex_ai") or model.startswith("vertex_ai/")
+    if is_vertex and not litellm_params.get("vertex_location"):
+        return {**litellm_params, "vertex_location": config.model_gateway.default_vertex_location}
+    return litellm_params
 
 
 # NOTE: Registrations carry NO per-model provider credentials. The proxy is the auth
@@ -86,6 +111,9 @@ async def list_models(request: Request, db: DbSession, user: User = Depends(requ
                 default_roles=alias_to_roles.get(name, []),
                 db_model=bool(info.get("db_model")),
                 base_model=info.get("base_model"),
+                vertex_location=params.get("vertex_location"),
+                vertex_project=params.get("vertex_project"),
+                aws_region_name=params.get("aws_region_name"),
                 input_cost_per_token=info.get("input_cost_per_token"),
                 output_cost_per_token=info.get("output_cost_per_token"),
                 supports_reasoning=info.get("supports_reasoning"),
@@ -93,6 +121,16 @@ async def list_models(request: Request, db: DbSession, user: User = Depends(requ
             )
         )
     return out
+
+
+@router.get("/config", response_model=GatewayUiConfig)
+async def gateway_ui_config(user: User = Depends(require_admin)):
+    """Deployment defaults the registration form needs (env-driven). Keeps the UI's suggested
+    Vertex region in sync with the proxy's DEFAULT_VERTEXAI_LOCATION instead of hardcoding it."""
+    return GatewayUiConfig(
+        default_vertex_location=config.model_gateway.default_vertex_location,
+        default_vertex_project=config.model_gateway.default_vertex_project,
+    )
 
 
 @router.get("/catalog", response_model=list[CatalogModel])
@@ -107,17 +145,37 @@ async def model_catalog(request: Request, user: User = Depends(require_admin)):
 
 
 @router.get("/models/{model_name}/cost-prefill", response_model=CostPrefill)
-async def cost_prefill(model_name: str, request: Request, user: User = Depends(require_admin)):
-    """Seed the rate-card form from the gateway's known cost (best-effort).
+async def cost_prefill(model_name: str, request: Request, db: DbSession, user: User = Depends(require_admin)):
+    """Seed the rate-card form (best-effort).
 
-    Returns empty pricing when the gateway doesn't know the model (bleeding-edge) —
-    the admin then enters rates manually.
+    Prefers the model's stored rate card so EDITING a model starts from its real, previously-saved
+    rates (they live in the rate card, not the gateway's model_info). Falls back to the gateway's
+    known cost for models we don't bill yet (fresh registration). Empty when neither knows the
+    model — the admin then enters rates manually.
     """
     try:
         model = await get_model_gateway_service(request).get_model(model_name)
     except ModelGatewayError as e:
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(e))
     info = (model or {}).get("model_info") or {}
+    params = (model or {}).get("litellm_params") or {}
+
+    # 1. Stored rate card — authoritative for already-billed models (the edit path). Keyed on the
+    #    same provider family billing uses (see AGENTS.md provider-keying note).
+    provider = info.get("litellm_provider") or params.get("custom_llm_provider")
+    if provider:
+        rates = await request.app.state.rate_card_service.repository.get_all_active_rates(
+            db=db, provider=provider, model_name=model_name
+        )
+        rate_pricing = {
+            unit: RateCardPricingEntry(price_per_million=price, flow_direction=_UNIT_TO_FLOW.get(unit, "input"))
+            for unit, price in rates.items()
+            if price and price > 0
+        }
+        if rate_pricing:
+            return CostPrefill(pricing=rate_pricing, source="rate_card")
+
+    # 2. Fallback: the gateway's known cost (fresh registration, model not yet billed).
     pricing: dict[str, RateCardPricingEntry] = {}
     for cost_field, (unit, flow) in _COST_FIELD_TO_UNIT.items():
         val = info.get(cost_field)
@@ -159,8 +217,9 @@ async def register_model(
     # model declares its accepted payloads (orchestrator/sub-agents depend on it),
     # mode so chat vs embedding is explicit (the chat picker filters on mode=chat).
     model_info = {**body.model_info, "input_modes": body.input_modes, "mode": body.mode}
+    litellm_params = _with_default_vertex_location(body.litellm_params, body.provider)
     try:
-        result = await svc.register_model(body.model_name, body.litellm_params, model_info)
+        result = await svc.register_model(body.model_name, litellm_params, model_info)
     except ModelGatewayError as e:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
@@ -204,8 +263,9 @@ async def edit_model(
     await db.commit()
 
     model_info = {**body.model_info, "input_modes": body.input_modes, "mode": body.mode}
+    litellm_params = _with_default_vertex_location(body.litellm_params, body.provider)
     try:
-        await svc.update_model(model_id, body.litellm_params, model_info)
+        await svc.update_model(model_id, litellm_params, model_info)
     except ModelGatewayError as e:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,

--- a/packages/console-backend/console_backend/routers/admin_model_gateway_router.py
+++ b/packages/console-backend/console_backend/routers/admin_model_gateway_router.py
@@ -40,19 +40,14 @@ _COST_FIELD_TO_UNIT = {
 }
 
 
-def _with_provider_creds(litellm_params: dict) -> dict:
-    """Inject proxy-side credential refs the registration form doesn't supply.
-
-    Runtime-registered Vertex models must carry ``vertex_credentials`` so the proxy resolves
-    GCP creds from its ``GCP_KEY`` env — ADC is intentionally not wired (it hangs the proxy's
-    startup health check). Config-defined Vertex models already set this; the registration form
-    only sends vertex_location/vertex_project, so without this a runtime Vertex model falls back
-    to ADC and its test ping fails with "default credentials were not found".
-    """
-    params = dict(litellm_params)
-    if str(params.get("model", "")).startswith("vertex_ai/") and "vertex_credentials" not in params:
-        params["vertex_credentials"] = "os.environ/GCP_KEY"
-    return params
+# NOTE: Registrations carry NO per-model provider credentials. The proxy is the auth
+# authority for every provider: Vertex via pod ADC (GOOGLE_APPLICATION_CREDENTIALS, a file
+# projected from the GCP_KEY secret), Bedrock via the pod IAM role, Azure via the proxy's
+# AZURE_OPENAI_API_KEY env. In particular, do NOT inject vertex_credentials="os.environ/GCP_KEY":
+# DB-registered (runtime) models do not resolve os.environ/* refs (the proxy config is
+# settings-only, no model_list), so the literal string reaches json.loads() and fails with
+# "Unable to load vertex credentials ... JSONDecodeError". (Earlier code did this to work around
+# ADC not being wired; ADC is wired now — see gitops litellm-proxy.yaml.)
 
 
 def get_model_gateway_service(request: Request) -> ModelGatewayService:
@@ -165,7 +160,7 @@ async def register_model(
     # mode so chat vs embedding is explicit (the chat picker filters on mode=chat).
     model_info = {**body.model_info, "input_modes": body.input_modes, "mode": body.mode}
     try:
-        result = await svc.register_model(body.model_name, _with_provider_creds(body.litellm_params), model_info)
+        result = await svc.register_model(body.model_name, body.litellm_params, model_info)
     except ModelGatewayError as e:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
@@ -210,7 +205,7 @@ async def edit_model(
 
     model_info = {**body.model_info, "input_modes": body.input_modes, "mode": body.mode}
     try:
-        await svc.update_model(model_id, _with_provider_creds(body.litellm_params), model_info)
+        await svc.update_model(model_id, body.litellm_params, model_info)
     except ModelGatewayError as e:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,

--- a/packages/console-backend/console_backend/services/model_gateway_service.py
+++ b/packages/console-backend/console_backend/services/model_gateway_service.py
@@ -16,6 +16,24 @@ from ..config import config
 
 logger = logging.getLogger(__name__)
 
+
+def _provider_error_detail(resp: httpx.Response) -> str:
+    """Pull a concise, human-readable reason out of a LiteLLM/provider error response.
+
+    LiteLLM wraps provider errors as ``{"error": {"message": ...}}``; the message often quotes the
+    provider verbatim (e.g. a Vertex 404 naming the model + location). Returns a trimmed message,
+    or '' when none is parseable. Safe to surface to admins ONLY for calls that carry no credentials
+    (test/inference) — never for register/update, whose errors can echo the submitted secrets.
+    """
+    try:
+        body = resp.json()
+    except ValueError:
+        return resp.text.strip()[:300]
+    err = body.get("error", body) if isinstance(body, dict) else body
+    msg = err.get("message") if isinstance(err, dict) else None
+    return (msg or "").strip()[:300]
+
+
 # LiteLLM's bundled model catalog (cost + capabilities for 100+ models). Pin the ref
 # to the deployed proxy version for accuracy; overridable via env.
 _COSTMAP_REF = os.getenv("LITELLM_COSTMAP_REF", "main")
@@ -98,6 +116,7 @@ class ModelGatewayService:
         json: dict | None = None,
         timeout: float | None = None,
         optional: bool = False,
+        expose_error: bool = False,
     ) -> dict:
         """Call the gateway management API. ``optional=True`` marks an endpoint that may not
         exist on every proxy version (the caller has a fallback): its failures are logged at
@@ -107,7 +126,12 @@ class ModelGatewayService:
         aws_secret_access_key, vertex_credentials, …). LiteLLM validation errors can reflect the
         submitted payload, so whenever the request body carries ``litellm_params`` the response
         body is suppressed from logs — derived from the payload, not a per-call flag, so a future
-        credential-bearing endpoint is covered automatically and can't forget to opt in."""
+        credential-bearing endpoint is covered automatically and can't forget to opt in.
+
+        ``expose_error=True`` additionally returns the provider's error *message* in the raised
+        exception (for the admin UI). Only safe for calls whose request carries no credentials
+        AND whose error bodies are plain provider/inference errors (the model-test path) — it is
+        ignored for credential-bearing requests, which always stay opaque."""
         carries_credentials = isinstance(json, dict) and "litellm_params" in json
         try:
             client = self._get_client()
@@ -118,11 +142,18 @@ class ModelGatewayService:
             return resp.json() if resp.content else {}
         except httpx.HTTPStatusError as e:
             log = logger.debug if optional else logger.error
+            status = e.response.status_code
             if carries_credentials:
-                log("Gateway %s %s → %s (body suppressed: may echo credentials)", method, path, e.response.status_code)
-            else:
-                log("Gateway %s %s → %s: %s", method, path, e.response.status_code, e.response.text[:300])
-            raise ModelGatewayError(f"Gateway returned {e.response.status_code}") from e
+                # Register/update echo the submitted litellm_params (incl. secrets) on validation
+                # errors, so the body never reaches logs or the admin. Opaque, expose_error ignored.
+                log("Gateway %s %s → %s (body suppressed: may echo credentials)", method, path, status)
+                raise ModelGatewayError(f"Gateway returned {status}") from e
+            # No credentials in this request — log the truncated body for diagnosis (unchanged).
+            log("Gateway %s %s → %s: %s", method, path, status, e.response.text[:300])
+            # Surface the provider's reason to the admin only when the caller opted in (model test):
+            # those errors are plain inference failures (e.g. wrong vertex_location → 404), no secrets.
+            detail = _provider_error_detail(e.response) if expose_error else ""
+            raise ModelGatewayError(f"Gateway returned {status}" + (f": {detail}" if detail else "")) from e
         except httpx.HTTPError as e:
             log = logger.debug if optional else logger.error
             log("Gateway %s %s unreachable: %s", method, path, e)
@@ -235,6 +266,7 @@ class ModelGatewayService:
                     "provider": info.get("litellm_provider"),
                     "mode": mode,
                     "input_cost_per_token": info.get("input_cost_per_token"),
+                    "input_cost_per_image": info.get("input_cost_per_image"),
                     "output_cost_per_token": info.get("output_cost_per_token"),
                     "cache_read_input_token_cost": info.get("cache_read_input_token_cost"),
                     "cache_creation_input_token_cost": info.get("cache_creation_input_token_cost"),
@@ -270,10 +302,11 @@ class ModelGatewayService:
             body: dict = {"model": model_name, "input": ["ping"]}
             if profile_for(litellm_model, provider).send_dimensions:
                 body["dimensions"] = _DEFAULT_DIMENSION
-            return await self._request("POST", "/v1/embeddings", json=body, timeout=30.0)
+            return await self._request("POST", "/v1/embeddings", json=body, timeout=30.0, expose_error=True)
         return await self._request(
             "POST",
             "/v1/chat/completions",
             json={"model": model_name, "messages": [{"role": "user", "content": "ping"}], "max_tokens": 4},
             timeout=30.0,
+            expose_error=True,
         )

--- a/packages/console-backend/tests/test_rate_card_noop_guard.py
+++ b/packages/console-backend/tests/test_rate_card_noop_guard.py
@@ -1,0 +1,105 @@
+"""Tests for the rate-card write-time no-op guard.
+
+`RateCardRepository.create_entry` skips the insert when the current active rate for a
+(rate card, billing_unit) already equals the new price — so re-registering or re-saving a model
+with unchanged prices doesn't accumulate identical superseding versions (history bloat). A genuine
+price change still writes a new version, and the current rate resolves to the latest effective_from.
+"""
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+from console_backend.models.user import User
+from console_backend.repositories.rate_card_repository import RateCardRepository
+from console_backend.services.audit_service import AuditService
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+T0 = datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+
+def _repo() -> RateCardRepository:
+    repo = RateCardRepository()
+    repo.set_audit_service(AuditService())
+    return repo
+
+
+async def _count(db: AsyncSession, provider: str, model: str, unit: str) -> int:
+    result = await db.execute(
+        text(
+            """
+            SELECT count(*) FROM rate_card_entries rce
+            JOIN rate_cards rc ON rc.id = rce.rate_card_id
+            WHERE rc.provider = :p AND rc.model_name = :m AND rce.billing_unit = :bu
+            """
+        ),
+        {"p": provider, "m": model, "bu": unit},
+    )
+    return int(result.scalar() or 0)
+
+
+@pytest.mark.asyncio
+async def test_duplicate_same_price_is_skipped(pg_session: AsyncSession, test_user: User):
+    """Re-creating an entry at the same active price is a no-op: no row added, existing id returned."""
+    repo = _repo()
+    provider, model, unit = "test-vertex", "noop-guard-model", "base_input_tokens"
+
+    id1 = await repo.create_entry(
+        db=pg_session, actor=test_user, provider=provider, model_name=model,
+        billing_unit=unit, flow_direction="input", price_per_million=Decimal("3.00"), effective_from=T0,
+    )
+    # Same price (and an equivalent Decimal form), later effective_from → guard skips the insert.
+    id2 = await repo.create_entry(
+        db=pg_session, actor=test_user, provider=provider, model_name=model,
+        billing_unit=unit, flow_direction="input", price_per_million=Decimal("3.000000"),
+        effective_from=T0 + timedelta(days=1),
+    )
+
+    assert id2 == id1
+    assert await _count(pg_session, provider, model, unit) == 1
+
+
+@pytest.mark.asyncio
+async def test_price_change_creates_new_version(pg_session: AsyncSession, test_user: User):
+    """A different price writes a new version; the current rate is the latest effective_from."""
+    repo = _repo()
+    provider, model, unit = "test-vertex", "price-change-model", "base_input_tokens"
+
+    id1 = await repo.create_entry(
+        db=pg_session, actor=test_user, provider=provider, model_name=model,
+        billing_unit=unit, flow_direction="input", price_per_million=Decimal("3.00"), effective_from=T0,
+    )
+    id2 = await repo.create_entry(
+        db=pg_session, actor=test_user, provider=provider, model_name=model,
+        billing_unit=unit, flow_direction="input", price_per_million=Decimal("5.00"),
+        effective_from=T0 + timedelta(days=1),
+    )
+
+    assert id2 != id1
+    assert await _count(pg_session, provider, model, unit) == 2
+
+    rates = await repo.get_all_active_rates(pg_session, provider, model, as_of=T0 + timedelta(days=2))
+    assert rates[unit] == Decimal("5.00")
+
+
+@pytest.mark.asyncio
+async def test_guard_is_per_billing_unit(pg_session: AsyncSession, test_user: User):
+    """The same price on a different billing unit is NOT a duplicate — each unit is independent."""
+    repo = _repo()
+    provider, model = "test-vertex", "per-unit-model"
+
+    id_in = await repo.create_entry(
+        db=pg_session, actor=test_user, provider=provider, model_name=model,
+        billing_unit="base_input_tokens", flow_direction="input", price_per_million=Decimal("2.00"),
+        effective_from=T0,
+    )
+    id_out = await repo.create_entry(
+        db=pg_session, actor=test_user, provider=provider, model_name=model,
+        billing_unit="base_output_tokens", flow_direction="output", price_per_million=Decimal("2.00"),
+        effective_from=T0,
+    )
+
+    assert id_out != id_in
+    assert await _count(pg_session, provider, model, "base_input_tokens") == 1
+    assert await _count(pg_session, provider, model, "base_output_tokens") == 1

--- a/packages/console-frontend/src/api/model-gateway.ts
+++ b/packages/console-frontend/src/api/model-gateway.ts
@@ -35,6 +35,9 @@ export interface GatewayModel {
   default_roles?: DefaultRole[];
   db_model?: boolean;
   base_model?: string | null;
+  vertex_location?: string | null;
+  vertex_project?: string | null;
+  aws_region_name?: string | null;
   input_cost_per_token?: number | null;
   output_cost_per_token?: number | null;
   supports_reasoning?: boolean | null;
@@ -69,6 +72,7 @@ export interface CatalogModel {
   provider?: string | null;
   mode: string;
   input_cost_per_token?: number | null;
+  input_cost_per_image?: number | null;
   output_cost_per_token?: number | null;
   cache_read_input_token_cost?: number | null;
   cache_creation_input_token_cost?: number | null;
@@ -146,6 +150,21 @@ export async function listModelCatalog(): Promise<CatalogModel[]> {
   const { data, error } = await (client as any).get({ url: `${BASE}/catalog` });
   if (error) throw error;
   return data as CatalogModel[];
+}
+
+export interface GatewayUiConfig {
+  /** Deployment default Vertex serving region (env-driven), suggested for new Vertex models. */
+  default_vertex_location: string;
+  /** Deployment default GCP project (env-driven); '' when unset. Placeholder hint only. */
+  default_vertex_project?: string;
+}
+
+/** Deployment defaults the registration form needs (env-driven). */
+export async function getGatewayConfig(): Promise<GatewayUiConfig> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (client as any).get({ url: `${BASE}/config` });
+  if (error) throw error;
+  return data as GatewayUiConfig;
 }
 
 export async function listGatewayModels(): Promise<GatewayModel[]> {

--- a/packages/console-frontend/src/pages/admin/ModelGatewayPage.tsx
+++ b/packages/console-frontend/src/pages/admin/ModelGatewayPage.tsx
@@ -16,6 +16,7 @@ import {
 import { toast } from 'sonner';
 
 import {
+  getGatewayConfig,
   listGatewayModels,
   listModelCatalog,
   registerGatewayModel,
@@ -42,6 +43,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ConfirmDialog } from '@/components/admin/ConfirmDialog';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -132,6 +134,17 @@ function deriveAlias(modelId: string): string {
   return parts.join('.');
 }
 
+// The litellm provider family is the gateway model id prefix (the part before the first "/"),
+// e.g. "vertex_ai/gemini-embedding-2" → "vertex_ai", "bedrock/eu.anthropic.claude-…" → "bedrock".
+// This is exactly how the cost logger resolves provider for billing (custom_llm_provider, else
+// the deployment-id prefix), so deriving it here keeps the rate card keyed on the same provider
+// usage is logged under. Critically, it prevents a region/location (Vertex "eu"/"global") from
+// being typed into the free-text provider field and silently mis-keying billing to $0.
+// Empty when the id has no prefix (e.g. a bare Azure deployment name) — admin sets it then.
+function deriveProvider(modelId: string): string {
+  return modelId.includes('/') ? modelId.slice(0, modelId.indexOf('/')) : '';
+}
+
 const CATALOG_LIMIT = 50; // cap the rendered match list; the rest surface as you keep typing
 
 // Which default roles a model can hold: chat models → the standard chat default plus the
@@ -143,6 +156,13 @@ function defaultRolesFor(m: GatewayModel): DefaultRole[] {
   }
   return ['chat', 'chat:low', 'chat:premium'];
 }
+
+// An embedding model accepts images when LiteLLM lists a per-image input cost — the one
+// signal set across providers (Gemini, Vertex multimodalembedding, Bedrock Nova/Titan), even
+// where supports_vision/supported_modalities are absent. Drives the 'image' input mode, which
+// in turn unlocks the multimodal_embedding default (see defaultRolesFor).
+const embeddingInputModes = (entry?: CatalogModel): string[] =>
+  entry && (entry.input_cost_per_image ?? 0) > 0 ? ['text', 'image'] : ['text'];
 
 // Embedding-role switches trigger a re-index, so they go through a confirmation dialog;
 // chat/tier defaults apply immediately.
@@ -181,6 +201,8 @@ export function ModelGatewayPage() {
     role: DefaultRole;
     modelName: string;
   } | null>(null);
+  // Model pending removal, awaiting confirmation (shared ConfirmDialog, not a native confirm()).
+  const [pendingDelete, setPendingDelete] = useState<GatewayModel | null>(null);
 
   const { data: models = [], isLoading } = useQuery({
     queryKey: ['gateway-models'],
@@ -192,6 +214,16 @@ export function ModelGatewayPage() {
     queryKey: ['gateway-catalog'],
     queryFn: listModelCatalog,
   });
+
+  // Deployment defaults (env-driven). The Vertex serving region the proxy falls back to — shown
+  // as the location placeholder so the admin isn't nudged toward a wrong region.
+  const { data: gatewayConfig } = useQuery({
+    queryKey: ['gateway-config'],
+    queryFn: getGatewayConfig,
+  });
+  const defaultVertexLocation = gatewayConfig?.default_vertex_location || 'eu';
+  // Deployment project id (env-driven) as a placeholder hint — never a hardcoded project.
+  const defaultVertexProject = gatewayConfig?.default_vertex_project || 'my-gcp-project';
 
   // Picker matches: scoped to the chosen mode, substring-filtered on what's typed, capped.
   const q = form.litellm_model.trim().toLowerCase();
@@ -213,6 +245,7 @@ export function ModelGatewayPage() {
       ['base_output_tokens', perM(entry.output_cost_per_token)],
       ['cache_read_input_tokens', perM(entry.cache_read_input_token_cost)],
       ['cache_creation_input_tokens', perM(entry.cache_creation_input_token_cost)],
+      ['input_images', perM(entry.input_cost_per_image)],
     ];
     for (const [unit, val] of map) if (val) prices[unit] = val;
     const isEmbedding = entry.mode === 'embedding';
@@ -223,7 +256,7 @@ export function ModelGatewayPage() {
       model_name: !editingId && !aliasEdited ? deriveAlias(entry.model_id) : f.model_name,
       provider: entry.provider ?? f.provider,
       mode: isEmbedding ? 'embedding' : 'chat',
-      input_modes: isEmbedding ? ['text'] : modes,
+      input_modes: isEmbedding ? embeddingInputModes(entry) : modes,
       prices: { ...f.prices, ...prices },
     }));
   };
@@ -249,15 +282,20 @@ export function ModelGatewayPage() {
 
   const openEdit = async (m: GatewayModel) => {
     setEditingId(m.model_id ?? null);
-    setCredsOpen(false);
+    const awsRegion = m.aws_region_name ?? '';
+    const vertexLocation = m.vertex_location ?? '';
+    const vertexProject = m.vertex_project ?? '';
+    // Expand the Advanced section up front when the model carries routing params, so the admin
+    // sees the values that will round-trip (they're hidden behind the collapsible otherwise).
+    setCredsOpen(Boolean(awsRegion || vertexLocation || vertexProject));
     setAliasEdited(true); // existing alias is fixed (input is disabled on edit)
     setForm({
       model_name: m.model_name,
       litellm_model: m.litellm_model ?? '',
       provider: m.provider ?? '',
-      aws_region_name: '',
-      vertex_location: '',
-      vertex_project: '',
+      aws_region_name: awsRegion,
+      vertex_location: vertexLocation,
+      vertex_project: vertexProject,
       base_model: m.base_model ?? '',
       mode: m.mode === 'embedding' ? 'embedding' : 'chat',
       input_modes: m.input_modes && m.input_modes.length ? m.input_modes : ['text', 'image'],
@@ -405,6 +443,12 @@ export function ModelGatewayPage() {
       toast.error('Alias, gateway model id, and provider are required');
       return;
     }
+    // The rate card MUST be keyed on the same provider usage is billed under. The cost logger
+    // resolves provider from the model-id prefix, so when the id has one we take it as
+    // authoritative — overriding whatever is in the free-text field. This is what stops a Vertex
+    // location ("eu"/"global") in the provider field from creating an orphan rate card that never
+    // matches usage (→ silent $0 billing).
+    const provider = deriveProvider(form.litellm_model) || form.provider;
     // Embeddings bill input only; chat bills input/output (+ optional cache).
     const units =
       form.mode === 'embedding'
@@ -420,16 +464,16 @@ export function ModelGatewayPage() {
       return;
     }
     const litellm_params: Record<string, unknown> = { model: form.litellm_model, max_retries: 0 };
-    if (isVertexProvider(form.provider)) {
+    if (isVertexProvider(provider)) {
       if (form.vertex_location) litellm_params.vertex_location = form.vertex_location;
       if (form.vertex_project) litellm_params.vertex_project = form.vertex_project;
-    } else if (isBedrockProvider(form.provider) && form.aws_region_name) {
+    } else if (isBedrockProvider(provider) && form.aws_region_name) {
       litellm_params.aws_region_name = form.aws_region_name;
     }
 
     // base_model only matters when the routed model id isn't a known model (Azure deployments).
     const model_info: Record<string, unknown> = {};
-    if (isAzureProvider(form.provider) && form.base_model.trim()) {
+    if (isAzureProvider(provider) && form.base_model.trim()) {
       model_info.base_model = form.base_model.trim();
     }
 
@@ -439,7 +483,7 @@ export function ModelGatewayPage() {
       ...(Object.keys(model_info).length ? { model_info } : {}),
       mode: form.mode,
       input_modes: form.input_modes,
-      provider: form.provider,
+      provider,
       pricing,
     };
     saveMutation.mutate(body);
@@ -570,14 +614,7 @@ export function ModelGatewayPage() {
                       <Button
                         size="sm"
                         variant="ghost"
-                        onClick={() => {
-                          if (
-                            confirm(
-                              `Remove ${m.model_name} from the gateway? Its Rate Card is kept for historical billing.`,
-                            )
-                          )
-                            deleteMutation.mutate(m.model_id!);
-                        }}
+                        onClick={() => setPendingDelete(m)}
                       >
                         <Trash2 className="mr-1 h-3 w-3" /> Remove
                       </Button>
@@ -603,6 +640,30 @@ export function ModelGatewayPage() {
 
           <div className="space-y-4">
             <div className="grid gap-1.5">
+              <Label>Mode</Label>
+              <div className="flex gap-2">
+                {(['chat', 'embedding'] as const).map((mode) => (
+                  <Badge
+                    key={mode}
+                    variant={form.mode === mode ? 'default' : 'outline'}
+                    className="cursor-pointer"
+                    onClick={() =>
+                      setForm((f) => ({
+                        ...f,
+                        mode,
+                        input_modes:
+                          mode === 'embedding'
+                            ? embeddingInputModes(catalog.find((c) => c.model_id === f.litellm_model))
+                            : f.input_modes,
+                      }))
+                    }
+                  >
+                    {mode}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+            <div className="grid gap-1.5">
               <Label>Gateway model id{catalog.length > 0 ? ` (${form.mode} models — type to filter)` : ''}</Label>
               <div className="relative">
                 <Input
@@ -615,7 +676,10 @@ export function ModelGatewayPage() {
                     const v = e.target.value;
                     const entry = catalog.find((c) => c.model_id === v);
                     if (entry) applyCatalogEntry(entry);
-                    else setForm({ ...form, litellm_model: v });
+                    // No catalog match (e.g. local dev with an empty catalog): still derive the
+                    // provider from the id prefix so it stays correct without manual entry — a
+                    // region typed here is what mis-keyed billing before.
+                    else setForm({ ...form, litellm_model: v, provider: deriveProvider(v) || form.provider });
                   }}
                 />
                 {pickerOpen && catalog.length > 0 && visibleMatches.length > 0 && (
@@ -665,27 +729,6 @@ export function ModelGatewayPage() {
                 </p>
               )}
             </div>
-            <div className="grid gap-1.5">
-              <Label>Mode</Label>
-              <div className="flex gap-2">
-                {(['chat', 'embedding'] as const).map((mode) => (
-                  <Badge
-                    key={mode}
-                    variant={form.mode === mode ? 'default' : 'outline'}
-                    className="cursor-pointer"
-                    onClick={() =>
-                      setForm((f) => ({
-                        ...f,
-                        mode,
-                        input_modes: mode === 'embedding' ? ['text'] : f.input_modes,
-                      }))
-                    }
-                  >
-                    {mode}
-                  </Badge>
-                ))}
-              </div>
-            </div>
 
             <div className="grid gap-1.5">
               <Label>Provider (rate-card key)</Label>
@@ -734,18 +777,26 @@ export function ModelGatewayPage() {
                       <div className="grid gap-1.5">
                         <Label>Vertex location (optional)</Label>
                         <Input
-                          placeholder="europe-west4"
+                          placeholder={defaultVertexLocation}
                           value={form.vertex_location}
                           onChange={(e) => setForm({ ...form, vertex_location: e.target.value })}
                         />
+                        <p className="text-[11px] text-muted-foreground">
+                          Serving region, not the GCP project. Leave blank to use the deployment
+                          default ({defaultVertexLocation}). Some models (e.g. Gemini embeddings) 404
+                          outside it.
+                        </p>
                       </div>
                       <div className="grid gap-1.5">
                         <Label>Vertex project (optional)</Label>
                         <Input
-                          placeholder="rcplus-alloy-gcp"
+                          placeholder={defaultVertexProject}
                           value={form.vertex_project}
                           onChange={(e) => setForm({ ...form, vertex_project: e.target.value })}
                         />
+                        <p className="text-[11px] text-muted-foreground">
+                          GCP project id. Leave blank to use the proxy's default project.
+                        </p>
                       </div>
                     </div>
                   )}
@@ -843,6 +894,21 @@ export function ModelGatewayPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* Remove a registered model — shared ConfirmDialog (consistent with other admin pages). */}
+      <ConfirmDialog
+        open={!!pendingDelete}
+        onOpenChange={(o) => !o && setPendingDelete(null)}
+        title={`Remove ${pendingDelete?.model_name ?? 'model'}?`}
+        description="This removes the model from the gateway. Its Rate Card is kept for historical billing."
+        confirmLabel="Remove"
+        variant="destructive"
+        isLoading={deleteMutation.isPending}
+        onConfirm={() => {
+          if (pendingDelete?.model_id) deleteMutation.mutate(pendingDelete.model_id);
+          setPendingDelete(null);
+        }}
+      />
     </div>
   );
 }

--- a/packages/console-frontend/src/pages/admin/RateCardsPage.tsx
+++ b/packages/console-frontend/src/pages/admin/RateCardsPage.tsx
@@ -1,12 +1,12 @@
 import { useState, useMemo, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { Plus, Edit2, Trash2, Copy, Info } from 'lucide-react';
+import { Plus, Edit2, Trash2, Copy, Info, Search, ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
 import { toast } from 'sonner';
 import {
-  listRateCardEntriesApiV1AdminRateCardsGetOptions,
   createRateCardEntryApiV1AdminRateCardsEntryPostMutation,
   expireRateCardEntryApiV1AdminRateCardsExpireRateIdPostMutation,
 } from '@/api/generated/@tanstack/react-query.gen';
+import { listRateCardEntriesApiV1AdminRateCardsGet } from '@/api/generated/sdk.gen';
 import type { RateCardEntry, RateCardEntryCreate } from '@/api/generated';
 import { Button } from '@/components/ui/button';
 
@@ -27,7 +27,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent } from '@/components/ui/card';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { CardListSkeleton } from '@/components/skeletons';
 import { Badge } from '@/components/ui/badge';
 
@@ -35,43 +36,58 @@ interface GroupedModel {
   provider: string;
   model_name: string;
   model_name_pattern: string | null;
+  // ALL active entries for this model (kept so edit/delete can expire every version — this is
+  // what compacts the historical duplicates over time). `latestEntries` is the deduped view.
   entries: RateCardEntry[];
+  latestEntries: RateCardEntry[];
   inputPrice?: number;
   outputPrice?: number;
   otherPrices: Array<{ billing_unit: string; price: number }>;
 }
 
+const PAGE_SIZE = 8;
+
+// Fetch every active entry (the list endpoint caps at 100/page, and there can be more —
+// especially with historical versions — so page through to the end). Grouping/search/pagination
+// then happen client-side over models.
+async function fetchAllActiveEntries(): Promise<RateCardEntry[]> {
+  const limit = 100;
+  const all: RateCardEntry[] = [];
+  for (let page = 1; ; page++) {
+    const { data, error } = await listRateCardEntriesApiV1AdminRateCardsGet({
+      query: { active_only: true, page, limit },
+    });
+    if (error) throw error;
+    const batch = data?.entries ?? [];
+    all.push(...batch);
+    if (batch.length === 0 || all.length >= (data?.total ?? all.length)) break;
+  }
+  return all;
+}
+
+const prettyUnit = (u: string) => u.split('_').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+
 export function RateCardsPage() {
   const [selectedProvider, setSelectedProvider] = useState<string>('all');
+  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
   const [addModelOpen, setAddModelOpen] = useState(false);
   const [editModel, setEditModel] = useState<GroupedModel | null>(null);
 
   const queryClient = useQueryClient();
 
-  // Fetch all entries to get available providers (unfiltered)
-  const { data: allEntriesData } = useQuery({
-    ...listRateCardEntriesApiV1AdminRateCardsGetOptions({
-      query: {
-        active_only: true,
-      },
-    }),
-  });
-
-  // Fetch filtered entries for display
-  const { data: entriesData, isLoading: entriesLoading } = useQuery({
-    ...listRateCardEntriesApiV1AdminRateCardsGetOptions({
-      query: {
-        provider: selectedProvider !== 'all' ? selectedProvider : undefined,
-        active_only: true,
-      },
-    }),
+  // One fetch of ALL active entries; provider filter, search and pagination are client-side over
+  // the grouped models (so a model never gets split across a server page and silently hidden).
+  const { data: entries = [], isLoading: entriesLoading } = useQuery({
+    queryKey: ['rate-card-entries-all'],
+    queryFn: fetchAllActiveEntries,
   });
 
   const createEntryMutation = useMutation({
     ...createRateCardEntryApiV1AdminRateCardsEntryPostMutation(),
     onSuccess: () => {
       toast.success('Rate card created successfully');
-      queryClient.invalidateQueries({ queryKey: ['listRateCardEntriesApiV1AdminRateCardsGet'] });
+      queryClient.invalidateQueries({ queryKey: ['rate-card-entries-all'] });
       setAddModelOpen(false);
       setEditModel(null);
     },
@@ -84,57 +100,82 @@ export function RateCardsPage() {
     ...expireRateCardEntryApiV1AdminRateCardsExpireRateIdPostMutation(),
     onSuccess: () => {
       toast.success('Rate card entries expired');
-      queryClient.invalidateQueries({ queryKey: ['listRateCardEntriesApiV1AdminRateCardsGet'] });
+      queryClient.invalidateQueries({ queryKey: ['rate-card-entries-all'] });
     },
     onError: () => {
       toast.error('Failed to expire rate cards');
     },
   });
 
-  const entries = entriesData?.entries ?? [];
+  const allProviders = useMemo(
+    () => Array.from(new Set(entries.map((e: RateCardEntry) => e.provider))).sort(),
+    [entries],
+  );
 
-  // Get all available providers from unfiltered data
-  const allProviders = useMemo(() => {
-    const allEntries = allEntriesData?.entries ?? [];
-    return Array.from(new Set(allEntries.map((e: RateCardEntry) => e.provider))).sort();
-  }, [allEntriesData]);
-
-  // Group entries by model
+  // Group entries by model. Keep every entry (for expire-all on edit/delete) but build a deduped
+  // `latestEntries` (one per billing_unit, newest effective_from wins) for a clean display — the
+  // table can accumulate historical versions that all read as active.
   const groupedModels = useMemo(() => {
-    const groups = new Map<string, GroupedModel>();
-    
-    entries.forEach((entry: RateCardEntry) => {
+    const groups = new Map<string, GroupedModel & { _latest: Map<string, RateCardEntry> }>();
+
+    for (const entry of entries) {
       const key = `${entry.provider}::${entry.model_name}`;
-      
-      if (!groups.has(key)) {
-        groups.set(key, {
+      let group = groups.get(key);
+      if (!group) {
+        group = {
           provider: entry.provider,
           model_name: entry.model_name,
           model_name_pattern: entry.model_name_pattern ?? null,
           entries: [],
+          latestEntries: [],
           otherPrices: [],
-        });
+          _latest: new Map(),
+        };
+        groups.set(key, group);
       }
-      
-      const group = groups.get(key)!;;
       group.entries.push(entry);
-      
-      // Categorize prices by flow_direction
-      if (entry.flow_direction === 'input' && entry.billing_unit === 'base_input_tokens') {
-        group.inputPrice = parseFloat(entry.price_per_million);
-      } else if (entry.flow_direction === 'output' && entry.billing_unit === 'base_output_tokens') {
-        group.outputPrice = parseFloat(entry.price_per_million);
-      } else {
-        // All other billing unit types (cache_read_input_tokens, cache_creation_input_tokens, reasoning_tokens, etc.)
-        group.otherPrices.push({
-          billing_unit: entry.billing_unit,
-          price: parseFloat(entry.price_per_million),
-        });
-      }
-    });
-    
-    return Array.from(groups.values());
+      const prev = group._latest.get(entry.billing_unit);
+      if (!prev || entry.effective_from > prev.effective_from) group._latest.set(entry.billing_unit, entry);
+    }
+
+    return Array.from(groups.values())
+      .map((g) => {
+        const latest = Array.from(g._latest.values());
+        const input = g._latest.get('base_input_tokens');
+        const output = g._latest.get('base_output_tokens');
+        return {
+          provider: g.provider,
+          model_name: g.model_name,
+          model_name_pattern: g.model_name_pattern,
+          entries: g.entries,
+          latestEntries: latest,
+          inputPrice: input ? parseFloat(input.price_per_million) : undefined,
+          outputPrice: output ? parseFloat(output.price_per_million) : undefined,
+          otherPrices: latest
+            .filter((e) => e.billing_unit !== 'base_input_tokens' && e.billing_unit !== 'base_output_tokens')
+            .map((e) => ({ billing_unit: e.billing_unit, price: parseFloat(e.price_per_million) })),
+        } as GroupedModel;
+      })
+      .sort((a, b) => `${a.provider}/${a.model_name}`.localeCompare(`${b.provider}/${b.model_name}`));
   }, [entries]);
+
+  // Provider filter + free-text search (model name or provider), then paginate the model cards.
+  const filteredModels = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return groupedModels.filter(
+      (m) =>
+        (selectedProvider === 'all' || m.provider === selectedProvider) &&
+        (!q || m.model_name.toLowerCase().includes(q) || m.provider.toLowerCase().includes(q)),
+    );
+  }, [groupedModels, selectedProvider, search]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredModels.length / PAGE_SIZE));
+  const pageModels = filteredModels.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  // Snap back to a valid page when filters/search shrink the result set.
+  useEffect(() => {
+    if (page > totalPages) setPage(1);
+  }, [page, totalPages]);
 
   const handleExpireModel = (model: GroupedModel) => {
     const effectiveUntil = new Date().toISOString();
@@ -188,161 +229,83 @@ export function RateCardsPage() {
         </CardContent>
       </Card>
 
-      {/* Filters */}
-      <Card>
-        <CardHeader className="pb-4">
-          <CardTitle>Filters</CardTitle>
-          <CardDescription>Filter rate cards by provider</CardDescription>
-        </CardHeader>
-        <CardContent className="pb-6">
-          <div className="w-64">
-            <Label htmlFor="provider-filter">Provider</Label>
-            <Select value={selectedProvider} onValueChange={setSelectedProvider}>
-              <SelectTrigger id="provider-filter" className="mt-1.5">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All Providers</SelectItem>
-                {allProviders.map((p) => (
-                  <SelectItem key={p} value={p}>{p}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        </CardContent>
-      </Card>
+      {/* Filters: free-text search + provider */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+          <Input
+            placeholder="Search by model or provider…"
+            value={search}
+            onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+            className="pl-9"
+          />
+        </div>
+        <div className="w-full sm:w-56">
+          <Select value={selectedProvider} onValueChange={(v) => { setSelectedProvider(v); setPage(1); }}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All providers</SelectItem>
+              {allProviders.map((p) => (
+                <SelectItem key={p} value={p}>{p}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
 
-      {/* Grouped Models */}
+      {/* Compact, collapsible model cards (paginated) */}
       {entriesLoading ? (
         <CardListSkeleton />
-      ) : groupedModels.length === 0 ? (
+      ) : filteredModels.length === 0 ? (
         <Card>
           <CardContent className="pt-6">
             <div className="text-center text-muted-foreground">
-              No rate cards found. Add a model to get started.
+              {groupedModels.length === 0
+                ? 'No rate cards found. Add a model to get started.'
+                : 'No models match your filters.'}
             </div>
           </CardContent>
         </Card>
       ) : (
-        <div className="space-y-4">
-          {groupedModels.map((model) => (
-            <Card key={`${model.provider}::${model.model_name}`}>
-              <CardHeader>
-                <div className="flex justify-between items-start">
-                  <div>
-                    <CardTitle className="flex items-center gap-2">
-                      <Badge variant="outline">{model.provider}</Badge>
-                      <span className="font-mono">{model.model_name}</span>
-                    </CardTitle>
-                    <CardDescription className="mt-2">
-                      {model.model_name_pattern ? (
-                        <div className="flex items-center gap-2">
-                          <span>Matches pattern:</span>
-                          <code className="text-xs bg-muted px-2 py-1 rounded">{model.model_name_pattern}</code>
-                        </div>
-                      ) : (
-                        <span>Active pricing configuration</span>
-                      )}
-                    </CardDescription>
-                  </div>
-                  <div className="flex gap-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => { setEditModel(model); setAddModelOpen(true); }}
-                    >
-                      <Edit2 className="w-4 h-4 mr-1" />
-                      Edit
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => handleCopyModel(model)}
-                    >
-                      <Copy className="w-4 h-4 mr-1" />
-                      Copy
-                    </Button>
-                    <Button
-                      variant="destructive"
-                      size="sm"
-                      onClick={() => handleExpireModel(model)}
-                    >
-                      <Trash2 className="w-4 h-4 mr-1" />
-                      Delete
-                    </Button>
-                  </div>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-6">
-                  {/* Base Input/Output Prices */}
-                  <div>
-                    <div className="text-sm font-medium text-muted-foreground mb-3">Base Pricing</div>
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                      {/* Input Price */}
-                      <div className="border rounded-lg p-4 bg-blue-50/50 dark:bg-blue-950/20">
-                        <div className="text-sm font-medium text-blue-700 dark:text-blue-400 mb-1">Input</div>
-                        <div className="text-2xl font-bold text-blue-900 dark:text-blue-300">
-                          {model.inputPrice !== undefined 
-                            ? `$${model.inputPrice.toFixed(2)}`
-                            : <span className="text-muted-foreground text-base">Not set</span>
-                          }
-                        </div>
-                        <div className="text-xs text-muted-foreground mt-1">per 1M units</div>
-                      </div>
-
-                      {/* Output Price */}
-                      <div className="border rounded-lg p-4 bg-green-50/50 dark:bg-green-950/20">
-                        <div className="text-sm font-medium text-green-700 dark:text-green-400 mb-1">Output</div>
-                        <div className="text-2xl font-bold text-green-900 dark:text-green-300">
-                          {model.outputPrice !== undefined 
-                            ? `$${model.outputPrice.toFixed(2)}`
-                            : <span className="text-muted-foreground text-base">Not set</span>
-                          }
-                        </div>
-                        <div className="text-xs text-muted-foreground mt-1">per 1M units</div>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Other Billing Unit Types - Separated by Input/Output */}
-                  {model.otherPrices.length > 0 && (
-                    <div>
-                      <div className="text-sm font-medium text-muted-foreground mb-3">Additional Unit Types</div>
-                      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                        {model.entries
-                          .filter(entry => entry.billing_unit !== 'base_input_tokens' && entry.billing_unit !== 'base_output_tokens')
-                          .map((entry) => {
-                            const bgColor = entry.flow_direction === 'input' 
-                              ? 'bg-blue-50/50 dark:bg-blue-950/20 border-blue-200 dark:border-blue-800'
-                              : entry.flow_direction === 'output'
-                              ? 'bg-green-50/50 dark:bg-green-950/20 border-green-200 dark:border-green-800'
-                              : 'bg-gray-50/50 dark:bg-gray-950/20';
-                            
-                            const textColor = entry.flow_direction === 'input'
-                              ? 'text-blue-700 dark:text-blue-400'
-                              : entry.flow_direction === 'output'
-                              ? 'text-green-700 dark:text-green-400'
-                              : 'text-muted-foreground';
-                            
-                            return (
-                              <div key={entry.billing_unit} className={`border rounded-lg p-4 ${bgColor}`}>
-                                <div className={`text-sm font-medium mb-1 ${textColor}`}>
-                                  {entry.billing_unit.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')}
-                                </div>
-                                <div className="text-2xl font-bold">${parseFloat(entry.price_per_million).toFixed(2)}</div>
-                                <div className="text-xs text-muted-foreground mt-1">per 1M units</div>
-                              </div>
-                            );
-                          })}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+        <>
+          <div className="text-xs text-muted-foreground">
+            {filteredModels.length} model{filteredModels.length === 1 ? '' : 's'}
+          </div>
+          <div className="space-y-2">
+            {pageModels.map((model) => (
+              <RateCardModelCard
+                key={`${model.provider}::${model.model_name}`}
+                model={model}
+                onEdit={() => { setEditModel(model); setAddModelOpen(true); }}
+                onCopy={() => handleCopyModel(model)}
+                onDelete={() => handleExpireModel(model)}
+              />
+            ))}
+          </div>
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-3 pt-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page <= 1}
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+              >
+                <ChevronLeft className="w-4 h-4" />
+              </Button>
+              <span className="text-sm text-muted-foreground">Page {page} of {totalPages}</span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= totalPages}
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              >
+                <ChevronRight className="w-4 h-4" />
+              </Button>
+            </div>
+          )}
+        </>
       )}
 
       {/* Add/Edit Model Dialog */}
@@ -377,6 +340,127 @@ export function RateCardsPage() {
   );
 }
 
+// A single compact, collapsible rate-card model row. Collapsed shows a one-line price summary;
+// expanded reveals the full base + additional-unit-type breakdown and (via the header) actions.
+function RateCardModelCard({
+  model,
+  onEdit,
+  onCopy,
+  onDelete,
+}: {
+  model: GroupedModel;
+  onEdit: () => void;
+  onCopy: () => void;
+  onDelete: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  const summary: string[] = [];
+  if (model.inputPrice !== undefined) summary.push(`in $${model.inputPrice.toFixed(2)}`);
+  if (model.outputPrice !== undefined) summary.push(`out $${model.outputPrice.toFixed(2)}`);
+  if (model.otherPrices.length) summary.push(`+${model.otherPrices.length} more`);
+
+  // Full version history per billing unit (newest first) for the expanded view. The current
+  // version of each unit is the one in `latestEntries` (latest effective_from); the rest are
+  // prior rates kept for historical billing.
+  const currentIds = new Set(model.latestEntries.map((e) => e.id));
+  const unitOrder = (u: string) => (u === 'base_input_tokens' ? 0 : u === 'base_output_tokens' ? 1 : 2);
+  const history = Array.from(
+    model.entries.reduce((map, e) => {
+      (map.get(e.billing_unit) ?? map.set(e.billing_unit, []).get(e.billing_unit)!).push(e);
+      return map;
+    }, new Map<string, RateCardEntry[]>()),
+  )
+    .map(([unit, versions]) => ({
+      unit,
+      flow: versions[0].flow_direction,
+      versions: [...versions].sort((a, b) => (a.effective_from < b.effective_from ? 1 : -1)),
+    }))
+    .sort((a, b) => unitOrder(a.unit) - unitOrder(b.unit) || a.unit.localeCompare(b.unit));
+
+  return (
+    <Card>
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <div className="flex items-center justify-between gap-3 p-3">
+          <CollapsibleTrigger className="flex items-center gap-3 flex-1 min-w-0 text-left">
+            <ChevronDown
+              className={`w-4 h-4 shrink-0 text-muted-foreground transition-transform ${open ? '' : '-rotate-90'}`}
+            />
+            <Badge variant="outline" className="shrink-0">{model.provider}</Badge>
+            <span className="font-mono text-sm truncate">{model.model_name}</span>
+            {model.model_name_pattern && (
+              <Badge variant="secondary" className="shrink-0 text-[10px]">pattern</Badge>
+            )}
+            <span className="text-xs text-muted-foreground truncate ml-1">
+              {summary.join(' · ') || 'No pricing set'}
+            </span>
+          </CollapsibleTrigger>
+          <div className="flex gap-1 shrink-0">
+            <Button variant="ghost" size="sm" onClick={onEdit} aria-label="Edit"><Edit2 className="w-4 h-4" /></Button>
+            <Button variant="ghost" size="sm" onClick={onCopy} aria-label="Copy"><Copy className="w-4 h-4" /></Button>
+            <Button variant="ghost" size="sm" onClick={onDelete} aria-label="Delete">
+              <Trash2 className="w-4 h-4 text-destructive" />
+            </Button>
+          </div>
+        </div>
+        <CollapsibleContent>
+          <div className="border-t px-4 py-4 space-y-4">
+            {model.model_name_pattern && (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <span>Matches pattern:</span>
+                <code className="text-xs bg-muted px-2 py-1 rounded">{model.model_name_pattern}</code>
+              </div>
+            )}
+            <div className="text-sm font-medium text-muted-foreground">Pricing history</div>
+            <div className="space-y-3">
+              {history.map(({ unit, flow, versions }) => {
+                const flowText =
+                  flow === 'input'
+                    ? 'text-blue-700 dark:text-blue-400'
+                    : flow === 'output'
+                    ? 'text-green-700 dark:text-green-400'
+                    : 'text-muted-foreground';
+                return (
+                  <div key={unit}>
+                    <div className={`text-xs font-medium mb-1 ${flowText}`}>{prettyUnit(unit)}</div>
+                    <div className="space-y-1">
+                      {versions.map((v) => {
+                        const isCurrent = currentIds.has(v.id);
+                        return (
+                          <div
+                            key={v.id}
+                            className={`flex items-center justify-between gap-3 rounded-md border px-3 py-1.5 text-sm ${
+                              isCurrent ? 'bg-muted/40' : 'opacity-60'
+                            }`}
+                          >
+                            <span className="font-mono">
+                              ${parseFloat(v.price_per_million).toFixed(2)}
+                              <span className="text-xs text-muted-foreground"> /1M</span>
+                            </span>
+                            <span className="flex-1 text-right text-xs text-muted-foreground">
+                              from {new Date(v.effective_from).toLocaleDateString()}
+                              {v.effective_until ? ` · until ${new Date(v.effective_until).toLocaleDateString()}` : ''}
+                            </span>
+                            {isCurrent ? (
+                              <Badge variant="secondary" className="shrink-0 text-[10px]">current</Badge>
+                            ) : (
+                              <span className="shrink-0 text-[10px] text-muted-foreground">superseded</span>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </Card>
+  );
+}
+
 // Model Pricing Dialog Component - Handles both add and edit
 function ModelPricingDialog({ open, onOpenChange, onSubmit, existingModel }: {
   open: boolean;
@@ -404,8 +488,8 @@ function ModelPricingDialog({ open, onOpenChange, onSubmit, existingModel }: {
         const inputBreakdown: Array<{ billing_unit: string; price: string }> = [];
         const outputBreakdown: Array<{ billing_unit: string; price: string }> = [];
         
-        // Find entries by flow_direction from the full entries list
-        existingModel.entries.forEach(entry => {
+        // Deduped latest entries (the raw list can hold many historical versions per unit).
+        existingModel.latestEntries.forEach(entry => {
           // Skip base input/output prices as they're handled separately
           if (entry.billing_unit === 'base_input_tokens' || entry.billing_unit === 'base_output_tokens') {
             return;

--- a/packages/litellm-proxy/README.md
+++ b/packages/litellm-proxy/README.md
@@ -22,6 +22,17 @@ is **deployment-specific and not committed here** — it's mounted at runtime:
 - Provider auth for whatever you route: AWS creds + `AWS_BEDROCK_REGION` (Bedrock), `AZURE_API_BASE`/`AZURE_OPENAI_API_KEY` (Azure OpenAI, `azure/*`), `AZURE_AI_API_BASE`/`AZURE_AI_API_KEY` (Azure AI Studio, `azure_ai/*`), `GCP_PROJECT_ID`/`GCP_KEY` (Vertex).
 - `CONSOLE_BACKEND_URL` + `GATEWAY_INGEST_TOKEN` — cost-ingestion target and its shared secret.
 
+**Vertex auth is ADC, and the proxy is the authority.** Vertex credentials are resolved
+via `google.auth.default()` from `GOOGLE_APPLICATION_CREDENTIALS` (the `GCP_KEY` JSON written to a
+file): k8s projects the secret to `/secrets/gcp/sa.json`, and `scripts/start-local.sh` mounts the
+same file locally — so dev and prod authenticate identically. Consequently **model registrations
+must carry no per-model `vertex_credentials`** (console-backend sends none). Runtime-registered
+(DB) models do **not** resolve `os.environ/*` refs — the proxy config is settings-only with no
+`model_list` — so an injected `vertex_credentials: os.environ/GCP_KEY` reaches `json.loads()` and
+fails with "Unable to load vertex credentials … JSONDecodeError". Only config-defined `model_list`
+entries resolve `os.environ/GCP_KEY`; DB models rely solely on ADC. (Pointing ADC at a real file
+also avoids the GCE-metadata-probe startup hang you get when only `GCP_KEY` is set.)
+
 ## Build
 ```sh
 just build-pkg litellm-proxy            # local image

--- a/scripts/start-local.sh
+++ b/scripts/start-local.sh
@@ -816,6 +816,20 @@ if [[ "$_HAS_AWS" == true ]]; then
   fi
 fi
 
+# Pod-level Vertex auth via ADC, mirroring deployment (k8s projects GCP_KEY to a file and points
+# GOOGLE_APPLICATION_CREDENTIALS at it; see the gitops litellm-proxy.yaml). Write the SA JSON to a
+# temp file and mount it so google.auth.default() resolves Vertex creds for BOTH config-defined and
+# runtime-registered (DB) models — the latter do NOT resolve os.environ/GCP_KEY, exactly as in
+# deployment, which is why console registrations must carry no vertex_credentials. Pointing ADC at
+# a real file also avoids the GCE-metadata-probe hang you get when only GCP_KEY is set. (The GCP_KEY
+# env below stays for config-defined model_list entries that still reference os.environ/GCP_KEY.)
+_GW_GCP_ENV=()
+if [[ -n "${GCP_KEY:-}" ]]; then
+  _GW_GCP_SA=$(mktemp /tmp/nannos-litellm-gcp-XXXXXX).json
+  printf '%s' "$GCP_KEY" > "$_GW_GCP_SA"
+  _GW_GCP_ENV=(-v "$_GW_GCP_SA:/secrets/gcp/sa.json:ro" -e GOOGLE_APPLICATION_CREDENTIALS=/secrets/gcp/sa.json)
+fi
+
 docker rm -f "$_GW_CONTAINER" >/dev/null 2>&1 || true
 docker run -d --name "$_GW_CONTAINER" \
   -p "${LLM_GATEWAY_PORT}:4000" \
@@ -836,6 +850,7 @@ docker run -d --name "$_GW_CONTAINER" \
   -e AZURE_AI_API_KEY="${AZURE_AI_API_KEY:-}" \
   -e GCP_PROJECT_ID="${GCP_PROJECT_ID:-}" \
   -e GCP_KEY="${GCP_KEY:-}" \
+  "${_GW_GCP_ENV[@]}" \
   -e DEFAULT_VERTEXAI_LOCATION="${DEFAULT_VERTEXAI_LOCATION:-eu}" \
   -e CONSOLE_BACKEND_URL="http://host.docker.internal:5001" \
   -e GATEWAY_INGEST_TOKEN="$GATEWAY_INGEST_TOKEN" \


### PR DESCRIPTION
## Summary

Fixes around runtime Vertex AI models on the LiteLLM Model Gateway and the console admin UI (Model Gateway + Rate Cards).

### Vertex / gateway routing
- **Remove provider-credentials injection for runtime Vertex models** — DB-registered models don't resolve `os.environ/*` refs, so injecting `vertex_credentials="os.environ/GCP_KEY"` reached `json.loads()` and failed. Auth is the proxy's job (pod ADC), so registrations carry no per-model creds.
- **Default Vertex serving region** via `DEFAULT_VERTEXAI_LOCATION` (eu), surfaced to the UI and injected on register when omitted — LiteLLM otherwise defaults DB models to `us-central1`, which 404s EU-only models (e.g. Gemini embeddings).

### Model Gateway admin
- **Multimodal embeddings**: derive eligibility from LiteLLM `input_cost_per_image`, so Gemini Embedding 2 can be set as the multimodal-embedding default; map per-image cost into the rate-card form.
- **Provider keying**: derive the provider from the gateway model-id prefix (and enforce at submit), so a Vertex *location* typed into the free-text provider field can no longer mis-key rate cards (`eu`/`global`) and silently bill $0.
- **Edit dialog** round-trips pricing (seeded from the stored rate card, not just the gateway cost map) and Vertex/Bedrock routing params (location/project/region). Project placeholder comes from `GCP_PROJECT_ID`; no hardcoded project id in code.
- **Error handling**: surface the provider's error message on test/inference 404s while keeping credential-bearing register/update responses fully suppressed.
- **Delete** uses the shared `ConfirmDialog` instead of a native `confirm()`.

### Rate Cards page
- Fetch all active entries (paginate past the 100-row cap) and group by rate card, so models no longer fall outside the first page and vanish.
- Compact, collapsible cards with **search** and **pagination**; expanded view shows the full per-billing-unit **pricing history** (current vs superseded).

### Rate-card writes
- **No-op guard**: skip inserting a new version when the current active rate for a `(rate card, billing_unit)` already equals the price — prevents duplicate-version bloat from re-registering/saving unchanged prices. Covered by unit tests.

## Testing
- `pytest` rate-card suites pass, incl. new `test_rate_card_noop_guard.py` (3 tests).
- Frontend `tsc -b` clean.
- Manually verified in the local console: multimodal default selectable, blank-location Vertex registration succeeds (region pinned to `eu`), edit dialog pre-populates pricing + region, delete confirmation modal, and the Rate Cards search/pagination/history view (Gemini embeddings now visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)