### PR TITLE
fix: recover from stream stalls + surface extended-thinking reasoning

### DIFF
--- a/packages/agent-common/AGENTS.md
+++ b/packages/agent-common/AGENTS.md
@@ -188,6 +188,24 @@ Sandbox-enabled agents call `_build_graph()` in every `_astream_impl()` call wit
 
 When a sub-agent has resolved skills AND an inherited backend factory (from orchestrator), the code must **add or replace** the `/skills/` route with the sub-agent's own `SkillsStoreBackend`. The orchestrator's `CompositeBackend` has no `/skills/` route (it doesn't use skills), so this effectively adds the route. This ensures each sub-agent reads its own resolved skills in isolation.
 
+### `_GatewayChatOpenAI` preserves `reasoning_content` (core/model_factory.py)
+
+`create_model()` returns a `ChatOpenAI` **subclass**, not plain `ChatOpenAI`. Reason: `langchain_openai` >= 1.2 targets the official OpenAI spec only and **silently drops** non-standard streaming delta fields — notably `reasoning_content` (and `thinking_blocks`), which our LiteLLM gateway emits for extended-thinking models. Without the subclass the model genuinely reasons (the gateway streams it; LiteLLM spend logs show `reasoning_tokens > 0`) but the reasoning never reaches the app, so no thinking is ever surfaced (the `AIMessageChunk`s are plain `content=str`, `additional_kwargs={}`). See langchain issues #34328 / #35059 — the maintainers' recommended fix is a provider-specific subclass.
+
+`_gateway_chat_openai_cls()` overrides `_convert_chunk_to_generation_chunk` to graft the per-chunk `reasoning_content` back into `additional_kwargs` (additive only; base content/tool-call/usage conversion is untouched). The orchestrator then emits it as a thinking block (orchestrator-agent `agent.py`, reading `additional_kwargs["reasoning_content"]` — NOT the content-block path, since the gateway delivers reasoning as a string delta, not a content block).
+
+**Do NOT** "fix" missing thinking by extracting reasoning from message *content* — it isn't there. And keep the `langchain-openai` pin from floating: the loose `>=0.1.0` constraint is what let `uv` resolve 1.2.x and regress this in the first place.
+
+### Structured-output / tool-call streaming is buffered at the gateway (not token-by-token)
+
+Plain assistant `content` (and `reasoning_content`, via the subclass above) **streams incrementally**. Structured output does **not**: when the final answer is delivered through a structured-response **tool call** (`SubAgentResponseSchema` / `FinalResponseSchema`) or `response_format`/json_schema, the provider/proxy **buffers the entire `tool_use` input and flushes it in one burst** when the call completes. Measured directly against the gateway: 478 tool-argument deltas all arrived in a ~0.2s burst after ~22s of generation with nothing streamed. The app's `StructuredResponseStreamer` + `StreamBuffer` then replay that burst as ~40-char chunks, so the UI shows the answer appear ~all-at-once after a long pause — it only *looks* like streaming.
+
+This is **server-side**, upstream of any client, and confirmed by open upstream issues:
+- LiteLLM [#7374](https://github.com/BerriAI/litellm/issues/7374) — `response_format` streaming returns empty/buffered vs native.
+- langchain [#34328](https://github.com/langchain-ai/langchain/issues/34328) / [#35059](https://github.com/langchain-ai/langchain/issues/35059) — `ChatOpenAI` drops non-standard streamed fields; its converter also ignores the beta `content.delta` structured-stream events (`if chunk.get("type") == "content.delta": return None`).
+
+**Switching langchain client does not help.** A different client (e.g. `langchain-litellm`) pointed at the same proxy receives the same bursted SSE — it can only assemble the deltas the gateway sends, and the gateway sends them all at once. (`langchain-litellm` *would* extract `reasoning_content` natively — a drop-in alternative to `_GatewayChatOpenAI` — but that's a reasoning cleanup, not a streaming fix, and adopting it conflicts with the proxy-routing/cost-attribution design.) The only way to get genuine token-by-token streaming of the final answer is to deliver it as plain `content` instead of a structured-response tool-call field, carrying `task_state`/`include_subagent_output` on a side channel — a deferred protocol change, not a gateway/client tweak.
+
 ## Testing
 
 **Prefer the runTests MCP tool over terminal commands when running tests.**

--- a/packages/agent-common/agent_common/core/model_factory.py
+++ b/packages/agent-common/agent_common/core/model_factory.py
@@ -29,6 +29,40 @@ from ringier_a2a_sdk.utils.gateway import gateway_base_url as _gateway_base_url
 logger = logging.getLogger(__name__)
 
 
+_gateway_chat_model_cls = None
+
+
+def _gateway_chat_openai_cls():
+    """Lazily build (and cache) the gateway-aware ``ChatOpenAI`` subclass.
+
+    langchain_openai's ``ChatOpenAI`` (>=1.2) targets the official OpenAI spec only and
+    DROPS non-standard streaming delta fields — notably ``reasoning_content`` /
+    ``thinking_blocks``, which our LiteLLM gateway emits for extended-thinking models.
+    Without this, the model genuinely reasons (the gateway streams it) but the reasoning
+    never reaches the app, so no thinking is ever surfaced. We graft the per-chunk
+    ``reasoning_content`` back into ``additional_kwargs`` so callers can render it; the
+    base conversion (content, tool calls, usage) is left untouched.
+    """
+    global _gateway_chat_model_cls
+    if _gateway_chat_model_cls is None:
+        from langchain_openai import ChatOpenAI
+
+        class _GatewayChatOpenAI(ChatOpenAI):
+            def _convert_chunk_to_generation_chunk(self, chunk, default_chunk_class, base_generation_info):
+                gen = super()._convert_chunk_to_generation_chunk(chunk, default_chunk_class, base_generation_info)
+                if gen is not None:
+                    choices = chunk.get("choices") or chunk.get("chunk", {}).get("choices") or []
+                    if choices:
+                        delta = choices[0].get("delta") or {}
+                        reasoning = delta.get("reasoning_content")
+                        if reasoning:
+                            gen.message.additional_kwargs["reasoning_content"] = reasoning
+                return gen
+
+        _gateway_chat_model_cls = _GatewayChatOpenAI
+    return _gateway_chat_model_cls
+
+
 class NoDefaultModelError(RuntimeError):
     """Raised when a runtime caller needs the fleet default chat model but none is configured.
 
@@ -107,7 +141,8 @@ def create_model(
     drops it for models that don't support reasoning (`drop_params`), so no per-model
     capability check is needed here.
     """
-    from langchain_openai import ChatOpenAI
+    # Gateway-aware subclass: preserves reasoning_content that base ChatOpenAI (>=1.2) drops.
+    ChatOpenAI = _gateway_chat_openai_cls()
 
     from ringier_a2a_sdk.cost_tracking.attribution import build_attribution_http_client
 

--- a/packages/console-frontend/src/components/chat/contexts/ChatContext.tsx
+++ b/packages/console-frontend/src/components/chat/contexts/ChatContext.tsx
@@ -609,7 +609,20 @@ export function ChatProvider({ children, playgroundMode }: ChatProviderProps) {
             showMessageToast(resolvedConversationId, content);
           };
 
-          if (streamedText && streamedText.trim()) {
+          // The backend tags the terminal status with `final_answer_source: "fallback"`
+          // when the streamed artifact is only a partial prefix of the real answer —
+          // notably delegations where the orchestrator streams an empty/stub message
+          // (e.g. include_subagent_output with message='') and the full answer is
+          // assembled into the terminal message. In that case the terminal message is
+          // authoritative, so we must NOT finalize from the (stub) streamed text, or the
+          // real answer (carried in data.status.message below) would be dropped.
+          const statusMeta = ((data as any)?.metadata
+            || (data.status as any)?.metadata
+            || (data.status?.message as any)?.metadata) as Record<string, unknown> | undefined;
+          const fallbackSupersedes =
+            normalizedStatus === 'completed' && statusMeta?.final_answer_source === 'fallback';
+
+          if (streamedText && streamedText.trim() && !fallbackSupersedes) {
             // Orchestrator streamed its own response token-by-token
             finalizeMessage(streamedText);
             finalizedFromStream = true;

--- a/packages/orchestrator-agent/app/core/agent.py
+++ b/packages/orchestrator-agent/app/core/agent.py
@@ -15,6 +15,7 @@ Architecture:
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import AsyncIterable
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -28,7 +29,7 @@ from agent_common.backends.attachments_store import (
     reset_current_attachments_backend,
     set_current_attachments_backend,
 )
-from agent_common.core.stream_watchdog import watch_stream
+from agent_common.core.stream_watchdog import StreamStallError, inter_chunk_timeout, watch_stream
 from agent_common.middleware.ptc_guard import PTC_CODE_INTERPRETER_TOOL_NAME
 from agent_common.models.base import DEFAULT_THINKING_LEVEL, ModelType, ThinkingLevel
 from langchain.messages import HumanMessage
@@ -444,12 +445,50 @@ class OrchestratorDeepAgent:
             # CRITICAL: Pass BOTH config and context parameters:
             # - config: Infrastructure (checkpointing via thread_id, metadata for LangSmith)
             # - context: Runtime data (tools, user preferences, sub-agents)
-            async for part in watch_stream(
-                graph.astream(  # type: ignore
-                    input_data, config, stream_mode=["custom", "messages"], context=runtime_context, version="v2"
-                ),
-                label="orchestrator",
-            ):
+            # Auto-resume-once wrapper (defense-in-depth for a genuine orchestrator
+            # model hang). The inter-chunk watchdog should not trip during a long
+            # sub-agent step now that sub-agent dispatch emits keepalives (see
+            # DynamicToolDispatchMiddleware), but if the orchestrator's OWN model
+            # stream hangs we transparently resume from the checkpoint a single time
+            # (input=None) with a more generous idle budget, surfacing a "recovering"
+            # status. A second stall propagates to the warm hand-off handler below
+            # instead of cold-failing.
+            stall_resume_budget_multiplier = float(os.getenv("LLM_STALL_RESUME_BUDGET_MULTIPLIER", "3"))
+
+            async def _astream_with_resume():
+                stream_input = input_data
+                chunk_budget: float | None = None  # None → watchdog env default on the first pass
+                resumed = False
+                while True:
+                    try:
+                        async for raw_part in watch_stream(
+                            graph.astream(  # type: ignore
+                                stream_input,
+                                config,
+                                stream_mode=["custom", "messages"],
+                                context=runtime_context,
+                                version="v2",
+                            ),
+                            label="orchestrator",
+                            chunk_timeout=chunk_budget,
+                        ):
+                            yield raw_part
+                        return
+                    except StreamStallError as stall:
+                        if resumed:
+                            raise
+                        resumed = True
+                        logger.warning(
+                            "[ORCHESTRATOR] Stream stalled (%s); auto-resuming once from checkpoint", stall
+                        )
+                        # Synthetic custom part: tells the consumer loop below to reset
+                        # its parse/buffer state and surface a "recovering" status. Then
+                        # resume pending checkpoint work with a more generous idle budget.
+                        yield {"type": "custom", "ns": (), "data": ("stream_recovering", {})}
+                        stream_input = None
+                        chunk_budget = inter_chunk_timeout() * stall_resume_budget_multiplier
+
+            async for part in _astream_with_resume():
                 chunk_count += 1
                 part_type = part["type"]
 
@@ -468,6 +507,23 @@ class OrchestratorDeepAgent:
                     # via artifact_update events through the middleware.
                     if _metadata.get("thread_id") != orchestrator_thread_id:
                         continue
+
+                    # --- Extended-thinking reasoning ---
+                    # The gateway streams Claude's reasoning as a non-standard
+                    # ``reasoning_content`` delta which base ChatOpenAI drops; our
+                    # gateway-aware subclass (see model_factory) preserves it in
+                    # ``additional_kwargs``. Surface it as an orchestrator thinking block.
+                    reasoning_delta = (msg_chunk.additional_kwargs or {}).get("reasoning_content")
+                    if reasoning_delta:
+                        yield AgentStreamResponse(
+                            state=TaskState.TASK_STATE_WORKING,
+                            content=reasoning_delta,
+                            metadata={
+                                "streaming_chunk": True,
+                                "intermediate_output": True,
+                                "agent_name": "orchestrator",
+                            },
+                        )
 
                     # --- Tool call detection for status history ---
                     # Capture tool calls for activity-log display. Internal/leaked
@@ -575,6 +631,28 @@ class OrchestratorDeepAgent:
                         logger.warning(f"Ignoring unexpected custom event: {type(event)}, value: {event}")
                         continue
                     event_type, event_data = event
+
+                    if event_type == "stream_recovering":
+                        # Synthetic event from _astream_with_resume on a one-shot
+                        # auto-resume. Reset per-stream parse/buffer state so the
+                        # resumed (regenerated) segment streams cleanly without
+                        # colliding with the aborted stream's partial deltas, and
+                        # surface a warm "still working" status to the user.
+                        response_streamer = StructuredResponseStreamer("FinalResponseSchema")
+                        stream_buffer = StreamBuffer()
+                        yield AgentStreamResponse(
+                            state=TaskState.TASK_STATE_WORKING,
+                            content="Still working… recovering a slow step.",
+                            metadata={"activity_log": True},
+                        )
+                        continue
+
+                    if event_type == "keepalive":
+                        # Sub-agent dispatch heartbeat. Its only job is to be a graph
+                        # stream part so the inter-chunk watchdog timer resets while a
+                        # long, legitimately-silent sub-agent step runs. Nothing is
+                        # surfaced to the user — merely consuming it here is enough.
+                        continue
 
                     if event_type == "a2a_status":
                         # PROGRESSIVE STATUS UPDATE from A2A middleware
@@ -760,6 +838,25 @@ class OrchestratorDeepAgent:
                     state=TaskState.TASK_STATE_FAILED,
                     content="We are unable to process your request at the moment. Please try again.",
                 )
+
+        except StreamStallError as stall:
+            # The stream stalled again after the one-shot auto-resume (or a first-token
+            # stall before any progress). The graph is checkpointed at the last
+            # completed step, so hand off warmly as input_required — the user's next
+            # message resumes from the checkpoint — instead of the cold generic failure
+            # in the broad handler below.
+            logger.warning(
+                "[ORCHESTRATOR] Stream stalled after auto-resume (%s); handing off to user for continuation",
+                stall,
+            )
+            yield AgentStreamResponse(
+                state=TaskState.TASK_STATE_INPUT_REQUIRED,
+                content=(
+                    "This is taking longer than I expected and I paused partway through. "
+                    "I've saved my progress — reply “continue” and I'll pick up where I left off."
+                ),
+                interrupt_reason="stream_stall",
+            )
 
         except GraphRecursionError as e:
             # Recursion limit reached — the graph state is already checkpointed at the

--- a/packages/orchestrator-agent/app/middleware/dynamic_tool_dispatch.py
+++ b/packages/orchestrator-agent/app/middleware/dynamic_tool_dispatch.py
@@ -53,6 +53,7 @@ from agent_common.a2a.stream_events import (
 from agent_common.agents.dynamic_agent import DynamicLocalAgentRunnable
 from agent_common.agents.foundry_agent import FoundryLocalAgentRunnable
 from agent_common.core.model_factory import create_model, get_default_fast_model, require_default_model
+from agent_common.core.stream_watchdog import inter_chunk_timeout
 from langchain.agents.middleware.types import (
     AgentMiddleware,
     AgentState,
@@ -117,6 +118,7 @@ async def _iter_subagent_stream_with_stall_timeout(
     subagent_thread_id: str,
     tick_seconds: float = SUBAGENT_STREAM_TICK_SECONDS,
     hard_cap_seconds: float = SUBAGENT_STREAM_STALL_TIMEOUT_SECONDS,
+    on_heartbeat: Optional[Callable[[float], Any]] = None,
 ) -> AsyncIterable[Any]:
     """Wrap a sub-agent async stream with a per-item stall timeout.
 
@@ -133,6 +135,12 @@ async def _iter_subagent_stream_with_stall_timeout(
     that share the same ``subagent_thread_id`` (the orchestrator fans out
     parallel ``task`` tool calls), so operators can group log lines by dispatch
     and downstream alerting can correlate logs to events.
+
+    ``on_heartbeat`` is invoked once per tick (with the cumulative seconds waited)
+    while the sub-agent is silent but still within the hard cap. The caller uses
+    it to emit a keepalive on the orchestrator's stream_writer so the orchestrator's
+    own inter-chunk watchdog (which only sees graph stream parts) does not trip on a
+    legitimately long, silent sub-agent step. May be sync or async.
     """
     iterator = aiter(stream_iter)
     loop = asyncio.get_event_loop()
@@ -223,6 +231,13 @@ async def _iter_subagent_stream_with_stall_timeout(
                     item_count,
                     hard_cap_seconds,
                 )
+                if on_heartbeat is not None:
+                    try:
+                        hb_result = on_heartbeat(waited)
+                        if inspect.iscoroutine(hb_result):
+                            await hb_result
+                    except Exception as hb_exc:  # keepalive is best-effort, never fatal
+                        logger.debug("[STREAMING] heartbeat callback failed: %s", hb_exc)
                 # Leave `pending` in place across the heartbeat — do NOT cancel it.
                 continue
 
@@ -1810,11 +1825,37 @@ class DynamicToolDispatchMiddleware(AgentMiddleware[AgentState, GraphRuntimeCont
             # each tick and yields an ErrorEvent through the existing error path
             # after the hard cap.
             sub_thread_id = agent_config.get("configurable", {}).get("thread_id", "?")
+
+            async def _emit_keepalive(waited: float) -> None:
+                # While the sub-agent is busy but silent (long model generation, a
+                # multi-pass eval, etc.) it produces no TaskUpdate/ArtifactUpdate, so
+                # the orchestrator graph yields no stream parts and its inter-chunk
+                # watchdog would trip. Push a lightweight keepalive part so the
+                # watchdog timer resets; the orchestrator consumer ignores it. The
+                # tick (< the watchdog budget) guarantees a reset before the trip.
+                if not stream_writer:
+                    return
+                try:
+                    result = stream_writer(
+                        ("keepalive", {"source": subagent_type, "waited_s": round(waited, 1)})
+                    )
+                    if inspect.iscoroutine(result):
+                        await result
+                except Exception as e:
+                    logger.debug(f"Failed to emit sub-agent keepalive: {e}")
+
+            # Fire the keepalive at most half the orchestrator watchdog's inter-chunk
+            # budget so a silent-but-busy sub-agent always produces ≥2 resets before the
+            # watchdog could trip — independent of how SUBAGENT_STREAM_TICK_SECONDS and
+            # LLM_INTER_CHUNK_TIMEOUT are individually configured.
+            keepalive_tick = min(SUBAGENT_STREAM_TICK_SECONDS, max(1.0, inter_chunk_timeout() / 2))
             wrapped_stream = _iter_subagent_stream_with_stall_timeout(
                 runnable.astream(agent_state, agent_config),  # type: ignore[arg-type]
                 subagent_type=subagent_type,
                 orchestrator_conversation_id=orchestrator_conversation_id,
                 subagent_thread_id=sub_thread_id,
+                tick_seconds=keepalive_tick,
+                on_heartbeat=_emit_keepalive,
             )
 
             async for item in wrapped_stream:

--- a/packages/orchestrator-agent/tests/test_subagent_stream_stall_timeout.py
+++ b/packages/orchestrator-agent/tests/test_subagent_stream_stall_timeout.py
@@ -199,6 +199,65 @@ async def test_heartbeat_tick_does_not_cancel_in_flight_read(caplog):
 
 
 @pytest.mark.asyncio
+async def test_on_heartbeat_invoked_per_tick_with_waited_seconds():
+    """While the sub-agent is silent but under the hard cap, ``on_heartbeat`` is
+    called once per tick with the cumulative seconds waited — this is what the
+    caller uses to emit a keepalive that resets the orchestrator watchdog. The
+    callback may be async."""
+    upstream = _NeverYields()
+    waited_values: list[float] = []
+
+    async def on_heartbeat(waited: float) -> None:
+        waited_values.append(waited)
+
+    collected = []
+    async for item in _iter_subagent_stream_with_stall_timeout(
+        upstream,
+        subagent_type="busy-agent",
+        orchestrator_conversation_id="conv-hb",
+        subagent_thread_id="t-hb",
+        tick_seconds=0.05,
+        hard_cap_seconds=0.18,  # ≥ 3 ticks → at least one heartbeat before the cap
+        on_heartbeat=on_heartbeat,
+    ):
+        collected.append(item)
+
+    # Heartbeat fired at least once before the hard cap, with a positive waited time.
+    assert waited_values, "expected on_heartbeat to be called at least once"
+    assert all(w > 0 for w in waited_values)
+    # Still ends with the single ErrorEvent (heartbeats are a side channel, not items).
+    assert len(collected) == 1 and isinstance(collected[0], ErrorEvent)
+    assert upstream.closed is True
+
+
+@pytest.mark.asyncio
+async def test_on_heartbeat_failure_is_swallowed():
+    """A throwing heartbeat callback must not break the stall loop — keepalive
+    emission is best-effort."""
+    upstream = _NeverYields()
+
+    def boom(_waited: float) -> None:
+        raise RuntimeError("stream_writer exploded")
+
+    collected = []
+    async for item in _iter_subagent_stream_with_stall_timeout(
+        upstream,
+        subagent_type="busy-agent",
+        orchestrator_conversation_id="conv-boom",
+        subagent_thread_id="t-boom",
+        tick_seconds=0.05,
+        hard_cap_seconds=0.18,
+        on_heartbeat=boom,
+    ):
+        collected.append(item)
+
+    # Despite the callback raising every tick, the loop still completes with the
+    # single ErrorEvent and closes the upstream.
+    assert len(collected) == 1 and isinstance(collected[0], ErrorEvent)
+    assert upstream.closed is True
+
+
+@pytest.mark.asyncio
 async def test_stall_timeout_completes_cleanly_when_upstream_finishes():
     """A normal stream that ends via StopAsyncIteration produces no ErrorEvent."""
 


### PR DESCRIPTION
## What & why

Three related fixes to orchestrator streaming, surfaced while debugging an inter-chunk-timeout that cold-failed a translation turn.

### 1. Graceful stream-stall recovery (`orchestrator` + `agent-common`)
The client watchdog raised `StreamStallError` straight into the generic handler → cold *"An unexpected error occurred"*.
- **Keepalive heartbeat** — the inter-chunk watchdog tripped during long, legitimately-silent sub-agent steps (e.g. multi-pass `eval`). The sub-agent consumer loop already had a 30s "still waiting" heartbeat but only *logged* it; it now emits a lightweight `keepalive` stream part each tick (clamped below the watchdog budget) so the timer resets while real work continues. Genuine hangs still trip the 300s hard cap → warm `ErrorEvent`.
- **Auto-resume once** — a genuine orchestrator-model stall now resumes once from the checkpoint with a more generous budget; a second stall hands off warmly as `input_required` ("reply continue") instead of cold-failing.

### 2. Surface extended-thinking reasoning (`agent-common` + `orchestrator`)
`langchain_openai` ≥1.2 drops the gateway's non-standard `reasoning_content` delta (it targets the official OpenAI spec only — see langchain #34328/#35059), so the orchestrator's thinking never reached the UI even though the gateway streams it (`reasoning_tokens > 0`). `create_model` now returns a `_GatewayChatOpenAI` subclass that grafts `reasoning_content` back into `additional_kwargs`; the orchestrator emits it as a thinking block. **Validated live** — the thinking block now renders, attributed to `orchestrator`.

### 3. Render final answer when only a stub was streamed (`console-frontend`)
On delegation turns the orchestrator can stream an empty/stub message and assemble the real answer into the terminal completed message, tagged `final_answer_source: "fallback"`. The chat ignored that flag and dropped the real answer. It now lets the terminal message supersede the stub.

## Validation
- Stall recovery validated live (brand-studio-translator + file-analyzer): 60–73s silent sub-agent gaps no longer trip the watchdog; 0 cold errors.
- Thinking validated live (reasoning block renders).
- `test_subagent_stream_stall_timeout.py` +2 heartbeat tests; full stall + stream-handler suites green (53 passed).

## Documented for later
`agent-common/AGENTS.md` now records that **structured-output / tool-call streaming is buffered server-side at the gateway** (measured: 478 tool-arg deltas in a ~0.2s burst after ~22s). Switching langchain client doesn't help (buffering is upstream of the client). Genuine token-by-token streaming of the final answer would require delivering it as plain `content` instead of a structured-response tool-call field — a **deferred protocol change**, not in this PR.

## Follow-ups (not included)
- Pin `langchain-openai` (currently `>=0.1.0`) so the `reasoning_content` regression can't silently return.
- Optional: plain-content final-answer streaming (see AGENTS.md note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)