### PR TITLE
fix(agent-common): drop min/max from tool-risk schema for Bedrock

### DIFF
--- a/packages/agent-common/agent_common/core/tool_risk_scorer.py
+++ b/packages/agent-common/agent_common/core/tool_risk_scorer.py
@@ -49,15 +49,18 @@ class RiskyValuesOutput(BaseModel):
 class ToolRiskOutput(BaseModel):
     """Structured LLM output for tool risk scoring."""
 
+    # NOTE: No ge/le constraints here. Pydantic would emit them as JSON-schema
+    # `minimum`/`maximum`, which Bedrock's structured-output schema rejects
+    # ("For 'number' type, properties maximum, minimum are not supported").
+    # The valid range is documented in the description and clamped after the call.
     base_score: float = Field(
-        description="Inherent risk of this tool when no risky arg patterns match (0.0-1.0). "
+        description="Inherent risk of this tool when no risky arg patterns match. "
+        "Must be between 0.0 and 1.0. "
         "0.0 = completely safe (read-only info retrieval), "
         "0.3 = low risk (data reads with filters), "
         "0.5 = moderate (writes to user's own data), "
         "0.7 = elevated (writes to shared resources), "
         "1.0 = critical (destructive, irreversible, or security-sensitive operations).",
-        ge=0.0,
-        le=1.0,
     )
     risk_factors: dict[str, RiskyValuesOutput] = Field(
         default_factory=dict,
@@ -231,7 +234,7 @@ async def _score_tool_via_llm(
 
     now = datetime.now(timezone.utc)
     entry = ToolRiskEntry(
-        base_score=result.base_score,
+        base_score=max(0.0, min(1.0, result.base_score)),
         risk_factors=risk_factors,
         allowed_actions=["approve", "edit", "reject"],  # Default; overridden by DB if exists
         schema_hash="",  # Set by caller


### PR DESCRIPTION
## Problem

Prod error on `claude-haiku-4-5` via the LiteLLM gateway:

```
litellm.BadRequestError: BedrockException - {"message":"The model returned the following errors:
output_config.format.schema: For 'number' type, properties maximum, minimum are not supported"}
```

The Dynamic-HITL tool risk scorer calls `model.with_structured_output(ToolRiskOutput)`. `ToolRiskOutput.base_score` declared `ge=0.0, le=1.0`, which Pydantic emits into the JSON schema as `minimum`/`maximum`. Bedrock's structured-output schema validator rejects those keywords on `number` types, so the LLM call 400s and **every tool falls back to the deterministic risk heuristic** (`_deterministic_fallback`).

The logged tool name (`SubAgentResponseSchema`) is just whatever tool was being scored — the rejected schema was the scorer's own `ToolRiskOutput`.

## Fix

- Remove `ge`/`le` from `base_score`. The valid 0.0–1.0 range stays documented in the field `description` (which the model sees), with a comment explaining the Bedrock constraint.
- Clamp `result.base_score` to `[0.0, 1.0]` when building the `ToolRiskEntry`, since the schema no longer enforces it.

## Notes

`tool_risk_scorer.py` is the only `with_structured_output` call in agent-common and `base_score` was the only constrained numeric field, so there are no other instances of this trap in the package.

The existing `ToolSchemaCleaningMiddleware` (ringier-a2a-sdk) *can* strip `minimum`/`maximum` at its `AGGRESSIVE` level, but it would not have caught this: it only escalates on Gemini errors, and it operates on the agent's bound `request.tools` — not on standalone `with_structured_output` schemas like this one.

## Verification

```
$ python -c "import json; from agent_common.core.tool_risk_scorer import ToolRiskOutput; \
  s=json.dumps(ToolRiskOutput.model_json_schema()); print('minimum' in s, 'maximum' in s)"
False False
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)