### PR TITLE
fix(gateway): LiteLLM v1.90.0-rc.1 for Vertex multi-region caching + Gemini conversation-cache gate

### DIFF
--- a/packages/agent-common/agent_common/core/graph_utils.py
+++ b/packages/agent-common/agent_common/core/graph_utils.py
@@ -73,6 +73,7 @@ from agent_common.middleware.conversation_context_tools_middleware import (
 )
 from agent_common.middleware.loop_detection_middleware import RepeatedToolCallMiddleware
 from agent_common.middleware.prompt_caching import LiteLLMPromptCachingMiddleware
+from agent_common.core.model_factory import is_gemini_model
 from agent_common.core.ptc_discovery import (
     PTC_DESCRIBE_TOOL_NAME,
     PTC_SEARCH_TOOL_NAME,
@@ -1208,7 +1209,18 @@ def build_common_middleware_stack(
             # provider-specific middlewares can't fire here — the client is never a
             # ChatBedrockConverse/ChatAnthropic instance, and their model_settings path
             # is a no-op for ChatOpenAI.
-            LiteLLMPromptCachingMiddleware(),
+            #
+            # Gemini (Vertex/AI-Studio) uses *extractive* context caching: LiteLLM physically
+            # MOVES cache_control-tagged messages out of the live request into a Vertex
+            # CachedContent (see vertex_ai/context_caching separate_cached_messages), unlike the
+            # inline Anthropic ephemeral / Bedrock cachePoint breakpoints. Tagging the last
+            # conversation message there pulls the current turn into the cache — on a
+            # single-message turn it empties `contents` entirely (LiteLLM: "No contents in
+            # messages"). So for Gemini we cache only the static system prefix and skip the
+            # incremental conversation breakpoint; every other provider keeps it.
+            LiteLLMPromptCachingMiddleware(
+                cache_conversation=not is_gemini_model(getattr(model, "model_name", "") or "")
+            ),
         ]
         middleware += [
             PatchToolCallsMiddleware(),

--- a/packages/agent-common/agent_common/core/model_factory.py
+++ b/packages/agent-common/agent_common/core/model_factory.py
@@ -162,10 +162,12 @@ def create_model(
     # NOTE: Native Gemini server-side web search (googleSearch) is NOT enabled here.
     # Enabling it for a tool-using deep agent requires `include_server_side_tool_invocations`
     # (so LiteLLM doesn't drop the search tool when function tools are present). But that flag
-    # turns on Gemini 3 "context circulation" (Vertex cached content), and gateway LiteLLM
-    # v1.89.2 still sends tools+system inline alongside the cached content, so Vertex 400s:
+    # turns on Gemini 3 "context circulation" (Vertex cached content), and the gateway LiteLLM
+    # then sent tools+system inline alongside the cached content, so Vertex 400s:
     # "Tool config, tools and system instruction should not be set ... when using cached content."
-    # Verified 2026-06-24. Revisit once the gateway LiteLLM is upgraded past that bug.
+    # Verified on v1.89.2 (2026-06-24). The gateway has since been bumped to v1.90.0-rc.1 (for an
+    # unrelated multi-region caching fix); whether that bump also resolves this tools+cached-content
+    # 400 is UNVERIFIED — re-test before enabling server-side tools.
 
     logger.info("Creating gateway model alias=%s thinking=%s streaming=%s", model_type, effort, streaming)
     return ChatOpenAI(

--- a/packages/litellm-proxy/Dockerfile
+++ b/packages/litellm-proxy/Dockerfile
@@ -4,10 +4,17 @@
 # callback). The `config.yaml` (model_list, regions, costs) is deployment-specific
 # and is mounted at runtime (a ConfigMap in k8s, a bind-mount locally) — never baked.
 #
-# Base is the upstream LiteLLM image, pinned to an exact version+digest (was the moving
-# `main-stable` tag, which resolved to v1.89.2 — this is that same image). Reproducible
+# Base is the upstream LiteLLM image, pinned to an exact version+digest. Reproducible
 # builds matter here: Vertex `eu` multi-region routing is version-dependent.
-FROM ghcr.io/berriai/litellm:v1.89.2@sha256:713e2a036aecc8f2cb24cdf0bdeffd893b4f37190d4b21eb9e26ac648939c67a
+#
+# Bumped v1.89.2 -> v1.90.0-rc.1 to pick up the Vertex multi-region context-caching fix
+# (BerriAI/litellm#29573, merged 2026-06-09): the cachedContents call hardcoded
+# `https://{location}-aiplatform.googleapis.com`, which 404s for the `eu`/`us` multi-regions
+# (only the inference path used the correct `aiplatform.{geo}.rep.googleapis.com` REP host —
+# hence completions worked but any cache_control on a Vertex Gemini model 404'd). The fix was
+# NOT backported to the 1.89.x stable line (still broken in v1.89.4), so the earliest published
+# tag carrying it is the v1.90.0 release candidate. Revisit to v1.90.0 final once it ships.
+FROM ghcr.io/berriai/litellm:v1.90.0-rc.1@sha256:7315a3a1573d9ff0ed78068b73260e960486ff62922ee6a78f1a2be0f1e5e249
 
 WORKDIR /app
 

--- a/packages/litellm-proxy/README.md
+++ b/packages/litellm-proxy/README.md
@@ -102,9 +102,12 @@ Two correctness contracts must hold regardless of which proxy serves traffic:
   so this works on any LiteLLM proxy. Records with no `user_sub` are skipped (can't be billed).
 
 **Caveat — LiteLLM version.** `_billing_unit_breakdown` parses LiteLLM's normalized usage
-shapes (cache-inclusive vs additive token accounting), which is why the image is pinned to
-**v1.89.2**. On a materially different version the cache/reasoning bucketing can drift →
-mis-billing. Match that version or validate the breakdown against a known call.
+shapes (cache-inclusive vs additive token accounting), which is why the image is pinned to an
+exact version (**v1.90.0-rc.1** — bumped from v1.89.2 for the Vertex multi-region context-caching
+fix, BerriAI/litellm#29573; see the Dockerfile). On a materially different version the
+cache/reasoning bucketing can drift → mis-billing, so this bump MUST be validated: run a known
+call (ideally one that exercises cache-read/cache-creation) and confirm the billing-unit
+breakdown still matches before promoting past dev. Match this version or re-validate.
 
 **Escape hatch.** If touching your proxy image is off the table, skip the in-process callback
 and instead consume LiteLLM's native spend logs (DB / generic webhook), transforming them into

--- a/packages/orchestrator-agent/app/core/graph_factory.py
+++ b/packages/orchestrator-agent/app/core/graph_factory.py
@@ -521,7 +521,9 @@ class GraphFactory:
             self._models[cache_key] = self._create_model(model_type, thinking_level)
         return self._models[cache_key]
 
-    def _create_middleware_stack(self, model: BaseChatModel | None = None) -> list[Any]:
+    def _create_middleware_stack(
+        self, model: BaseChatModel | None = None, is_gemini: bool = False
+    ) -> list[Any]:
         """Create the complete middleware stack for a graph.
 
         Middleware Execution Order (LangChain convention):
@@ -667,10 +669,14 @@ class GraphFactory:
             # appended below (steering, user preferences, playbook). The marker is
             # injected as an OpenAI-format cache_control content block, which LiteLLM
             # translates to the provider's native format (Bedrock cachePoint /
-            # Anthropic ephemeral) and ignores for non-caching providers — so no
-            # provider gate is needed under the gateway architecture,
-            # where the client is always ChatOpenAI rather than ChatBedrockConverse.
-            LiteLLMPromptCachingMiddleware(),
+            # Anthropic ephemeral) and ignores for non-caching providers.
+            #
+            # cache_conversation (the second breakpoint on the last message) is disabled for
+            # Gemini: Vertex uses *extractive* caching — LiteLLM moves the tagged message into a
+            # CachedContent rather than marking it inline — so tagging the live turn empties the
+            # request `contents` ("No contents in messages"). Gemini caches the system prefix
+            # only; the inline-breakpoint providers (Anthropic/Bedrock) keep conversation caching.
+            LiteLLMPromptCachingMiddleware(cache_conversation=not is_gemini),
             steering_middleware,
             user_preferences_middleware,
             playbook_middleware,
@@ -775,9 +781,10 @@ class GraphFactory:
         #   gateway maps it to Gemini googleSearch, BUT Vertex forbids mixing server-side search
         #   with function declarations, so LiteLLM silently DROPS it (we always send tools).
         # - Forcing it through needs include_server_side_tool_invocations, which triggers Gemini 3
-        #   "context circulation" (Vertex cached content); gateway LiteLLM v1.89.2 then 400s
+        #   "context circulation" (Vertex cached content); the gateway LiteLLM then 400s
         #   ("Tool config, tools and system instruction should not be set ... when using cached
-        #   content"). Verified 2026-06-24. Until the gateway LiteLLM is upgraded past that bug,
+        #   content"). Verified on v1.89.2 (2026-06-24); the gateway is now on v1.90.0-rc.1 but
+        #   whether that resolves this 400 is UNVERIFIED. Until re-tested past that bug,
         #   Gemini grounds via the orchestrator's own fetch tools, not server-side search.
         # Web search is instead exposed as the `console_web_search` MCP tool (console-backend),
         # which runs an isolated, function-tool-free search call — the only path that grounds
@@ -793,7 +800,7 @@ class GraphFactory:
             thinking_enabled=bool(thinking_level),
             has_builtin_tools=is_gemini,
         )
-        middleware = self._create_middleware_stack(model=model)
+        middleware = self._create_middleware_stack(model=model, is_gemini=is_gemini)
         static_tools_list = self.get_static_tools(with_response_tool=requires_response_tool)
 
         system_prompt = (

--- a/packages/orchestrator-agent/tests/test_graph_factory.py
+++ b/packages/orchestrator-agent/tests/test_graph_factory.py
@@ -169,6 +169,27 @@ class TestMiddlewareStack:
 
     @patch("app.core.graph_factory._has_aws_credentials", return_value=True)
     @patch("langgraph.store.postgres.aio.AsyncPostgresStore")
+    def test_conversation_caching_disabled_for_gemini(self, mock_pg_store, _mock_creds, mock_config):
+        """Gemini gets system-prefix caching only — the conversation breakpoint is off.
+
+        Vertex uses *extractive* context caching (LiteLLM moves the tagged message into a
+        CachedContent), so tagging the live turn empties the request `contents`
+        ("No contents in messages"). Non-Gemini providers (inline cachePoint/ephemeral) keep
+        the incremental conversation breakpoint.
+        """
+        factory = GraphFactory(config=mock_config)
+
+        def _caching(stack):
+            return next(m for m in stack if isinstance(m, LiteLLMPromptCachingMiddleware))
+
+        gemini_stack = factory._create_middleware_stack(model=Mock(), is_gemini=True)
+        assert _caching(gemini_stack).cache_conversation is False
+
+        other_stack = factory._create_middleware_stack(model=Mock(), is_gemini=False)
+        assert _caching(other_stack).cache_conversation is True
+
+    @patch("app.core.graph_factory._has_aws_credentials", return_value=True)
+    @patch("langgraph.store.postgres.aio.AsyncPostgresStore")
     def test_middleware_stack_excludes_bedrock_caching_when_model_is_none(
         self, mock_pg_store, _mock_creds, mock_config
     ):

--- a/scripts/start-local.sh
+++ b/scripts/start-local.sh
@@ -729,7 +729,7 @@ export LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY:-sk-nannos-local}"
 export GATEWAY_INGEST_TOKEN="${GATEWAY_INGEST_TOKEN:-sk-nannos-local-ingest}"
 # Pinned to match the prod base image (packages/litellm-proxy/Dockerfile) so local
 # reproduces prod's Vertex region-resolution behavior. Override with LITELLM_IMAGE.
-_LITELLM_IMAGE="${LITELLM_IMAGE:-ghcr.io/berriai/litellm:v1.89.2@sha256:713e2a036aecc8f2cb24cdf0bdeffd893b4f37190d4b21eb9e26ac648939c67a}"
+_LITELLM_IMAGE="${LITELLM_IMAGE:-ghcr.io/berriai/litellm:v1.90.0-rc.1@sha256:7315a3a1573d9ff0ed78068b73260e960486ff62922ee6a78f1a2be0f1e5e249}"
 _GW_CONTAINER="nannos-litellm-proxy-local"
 
 log "Starting local Model Gateway (LiteLLM proxy) on :${LLM_GATEWAY_PORT}..."
@@ -758,6 +758,13 @@ litellm_settings:
   # client-side inter-chunk watchdog (Bedrock ignores stream_timeout).
   request_timeout: 600
   drop_params: true
+  # Let LiteLLM normalize provider-specific message sequencing. Bedrock's Converse API
+  # requires alternating user/assistant turns; agent loops with parallel tool calls produce
+  # consecutive user/tool blocks, which LiteLLM otherwise merges-and-warns about on every
+  # turn ("Potential consecutive user/tool blocks"). With this set it normalizes them
+  # cleanly (inserting a dummy assistant turn where needed) and stays quiet. Mirror in the
+  # k8s ConfigMap.
+  modify_params: true
   # Gateway-native retries on transient failures/timeouts, replacing the
   # per-call boto3 retries dropped in the migration. Matches the k8s ConfigMap.
   num_retries: 2


### PR DESCRIPTION
## Why

Registering `gemini-3.5-flash` (and other Vertex Gemini models) on the `eu` region worked, but **every invocation 404'd**:

```
litellm.NotFoundError: Vertex_aiException - 404
The requested URL /v1/projects/.../locations/eu/cachedContents was not found
```

Root cause is **upstream LiteLLM bug [#29571](https://github.com/BerriAI/litellm/issues/29571)**: the context-caching path hardcoded `https://{location}-aiplatform.googleapis.com`, which 404s for the `eu`/`us` multi-regions — only the *inference* path used the correct REP host `aiplatform.{geo}.rep.googleapis.com` ([#27293](https://github.com/BerriAI/litellm/pull/27293)). So plain completions worked but any `cache_control` (which the orchestrator sends on every turn) 404'd.

Fix [#29573](https://github.com/BerriAI/litellm/pull/29573) routes the caching call through `get_vertex_base_url()`. Verified by reading the source at each tag:

| Tag | `cachedContents` URL | Status |
|---|---|---|
| v1.89.2 (was pinned) | `{location}-aiplatform.googleapis.com` | broken |
| v1.89.4 (latest stable) | identical | **still broken** — never backported to 1.89.x |
| **v1.90.0-rc.1** | `get_vertex_base_url(...)` | **fixed** |

A plain stable bump wouldn't help; the RC is the earliest published tag with the fix.

## The second layer

With the 404 gone, Gemini then warned **"No contents in messages."** Vertex uses *extractive* context caching — LiteLLM physically **moves** `cache_control`-tagged messages out of the live request into a `CachedContent` ([`separate_cached_messages`](https://github.com/BerriAI/litellm/blob/v1.90.0-rc.1/litellm/llms/vertex_ai/context_caching/transformation.py)), unlike the inline Anthropic `ephemeral` / Bedrock `cachePoint` markers. The orchestrator's conversation breakpoint tags the **last** message, so on a single-message turn the live turn is pulled entirely into the cache, leaving `contents` empty.

Fix: disable the conversation breakpoint for Gemini (system-prefix caching only); keep it for the inline-breakpoint providers. Gated via `is_gemini_model`, which correctly excludes Vertex-Claude (inline caching).

## Changes

- **Dockerfile / start-local.sh** — pin `litellm:v1.90.0-rc.1@sha256:7315a3a1…` (multi-arch index verified)
- **graph_factory.py / graph_utils.py** — `cache_conversation = not is_gemini` in both middleware builders (orchestrator + sub-agent/task-scheduler)
- **start-local.sh** — `modify_params: true` so Bedrock's alternating-turn requirement is normalized (silences the recurring "consecutive user/tool blocks" warning); **mirror in the k8s ConfigMap when promoting**
- **README.md / model_factory.py / graph_factory.py** — refreshed version refs + caveats
- **test_graph_factory.py** — locks Gemini=off / others=on caching wiring

Tests: `test_graph_factory` 18/18, `test_prompt_caching_middleware` 11/11.

## Before promoting past dev — must verify
1. **Billing breakdown** (`custom_logger._billing_unit_breakdown`) parses version-specific usage shapes — run a known cache-read/cache-creation call and confirm bucketing didn't drift (see README caveat).
2. **Gemini caching runtime check** — confirm system-prefix caching on Gemini doesn't trip the separate `400 "Tool config, tools and system instruction should not be set when using cached content"`. If it does, the fallback is to drop `cache_control` for Gemini entirely (rely on implicit caching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)