### PR TITLE
fix(gateway): force additionalProperties:false on structured-output schemas

### DIFF
--- a/packages/litellm-proxy/README.md
+++ b/packages/litellm-proxy/README.md
@@ -6,9 +6,17 @@ model registration, and proxy-side cost capture. Apps talk to it via
 `LLM_GATEWAY_URL` and never construct provider clients directly.
 
 ## Contents (deployment-agnostic)
-- `custom_logger.py` — `NannosCostLogger`: maps native usage (incl. cache/reasoning
-  tokens) → Nannos billing units and POSTs to console-backend `/api/v1/usage/gateway-batch-log`
-  with the attribution the app forwarded as `spend_logs_metadata`.
+- `custom_logger.py` — `NannosCostLogger`, the in-process callback that owns two
+  provider-boundary jobs:
+  - **Cost capture** (`async_log_success_event`): maps native usage (incl. cache/reasoning
+    tokens) → Nannos billing units and POSTs to console-backend `/api/v1/usage/gateway-batch-log`
+    with the attribution the app forwarded as `spend_logs_metadata`.
+  - **Structured-output schema normalization** (`async_pre_call_hook`): forces
+    `additionalProperties: false` on every object node of a `response_format` json_schema.
+    Bedrock's Converse structured-output validator rejects schemas without it
+    ("`additionalProperties: object` is not supported. Please set to false"); LangChain's
+    native `ProviderStrategy`/`AutoStrategy` path emits non-strict schemas that omit it.
+    Fixing it here covers every structured-output path uniformly and is safe across providers.
 - `Dockerfile` — `FROM ghcr.io/berriai/litellm` + the callback only.
 
 The `config.yaml` (model_list, regions, `model_info` cost seeds, `store_model_in_db`)

--- a/packages/litellm-proxy/custom_logger.py
+++ b/packages/litellm-proxy/custom_logger.py
@@ -57,6 +57,94 @@ def _get_client() -> httpx.AsyncClient:
     return _client
 
 
+# --- Bedrock structured-output schema compatibility -------------------------------------
+# Bedrock's Converse structured-output validator (outputConfig.format.schema) requires EVERY
+# object node to carry an explicit `additionalProperties: false`. It rejects both the absent
+# default and an object-valued `additionalProperties` with:
+#   "output_config.format.schema: For 'object' type, 'additionalProperties: object' is not
+#    supported. Please set 'additionalProperties' to false"
+#
+# The app's strict tool path (convert_to_openai_tool(strict=True)) already emits
+# additionalProperties:false, so those calls succeed. But the native ProviderStrategy /
+# AutoStrategy path (LangChain `with_structured_output` / `AutoStrategy(schema=...)`) sends a
+# NON-strict `response_format` json_schema with no `additionalProperties` at all — which Bedrock
+# 400s on. We normalize it here, at the provider boundary, so every structured-output path is
+# fixed uniformly regardless of how the caller built the schema.
+#
+# Applied to ALL providers (not just Bedrock): the model alias hasn't been routed to a deployment
+# at pre-call time, and the change is safe everywhere — OpenAI strict mode REQUIRES
+# additionalProperties:false, OpenAI non-strict accepts it, and Gemini's responseSchema subset
+# ignores/strips it. Every structured-output schema in this product is a closed Pydantic model
+# (no open `dict[str, X]` maps), so forcing closed objects loses no expressible validation —
+# and Bedrock/OpenAI-strict can't express open maps anyway.
+_SCHEMA_CHILD_LISTS = ("anyOf", "allOf", "oneOf", "prefixItems")
+_SCHEMA_CHILD_TABLES = ("$defs", "definitions")
+
+
+def _force_additional_properties_false(node, _depth: int = 0) -> None:
+    """Recursively set ``additionalProperties: false`` on every object node, in place.
+
+    An "object node" is any schema dict declaring ``type: object`` or carrying
+    ``properties``. A pre-existing boolean ``additionalProperties`` is preserved (the caller
+    may have deliberately set ``true``); only a missing or object/non-bool value is forced to
+    ``false`` — that is exactly the shape Bedrock rejects. ``_depth`` guards against
+    pathologically deep / cyclic schemas.
+    """
+    if not isinstance(node, dict) or _depth > 64:
+        return
+
+    properties = node.get("properties")
+    is_object = node.get("type") == "object" or isinstance(properties, dict)
+    if is_object and not isinstance(node.get("additionalProperties"), bool):
+        node["additionalProperties"] = False
+
+    if isinstance(properties, dict):
+        for sub in properties.values():
+            _force_additional_properties_false(sub, _depth + 1)
+
+    items = node.get("items")
+    if isinstance(items, dict):
+        _force_additional_properties_false(items, _depth + 1)
+    elif isinstance(items, list):  # draft tuple-form items
+        for sub in items:
+            _force_additional_properties_false(sub, _depth + 1)
+
+    for key in _SCHEMA_CHILD_LISTS:
+        seq = node.get(key)
+        if isinstance(seq, list):
+            for sub in seq:
+                _force_additional_properties_false(sub, _depth + 1)
+
+    for key in _SCHEMA_CHILD_TABLES:
+        table = node.get(key)
+        if isinstance(table, dict):
+            for sub in table.values():
+                _force_additional_properties_false(sub, _depth + 1)
+
+
+def _sanitize_response_format(data: dict) -> None:
+    """Make a request's ``response_format`` json_schema Bedrock-safe, in place.
+
+    No-op unless ``data`` carries a ``response_format`` of type ``json_schema`` with a dict
+    schema. Tolerant of both shapes LiteLLM accepts: the schema under
+    ``response_format.json_schema.schema`` (OpenAI) or directly under ``response_format.schema``.
+    """
+    response_format = data.get("response_format")
+    if (
+        not isinstance(response_format, dict)
+        or response_format.get("type") != "json_schema"
+    ):
+        return
+    json_schema = response_format.get("json_schema")
+    schema = (
+        json_schema.get("schema")
+        if isinstance(json_schema, dict)
+        else response_format.get("schema")
+    )
+    if isinstance(schema, dict):
+        _force_additional_properties_false(schema)
+
+
 def _as_dict(obj) -> dict:
     if obj is None:
         return {}
@@ -69,7 +157,11 @@ def _as_dict(obj) -> dict:
                 pass
     if isinstance(obj, dict):
         return obj
-    return {k: v for k, v in vars(obj).items() if not k.startswith("_")} if hasattr(obj, "__dict__") else {}
+    return (
+        {k: v for k, v in vars(obj).items() if not k.startswith("_")}
+        if hasattr(obj, "__dict__")
+        else {}
+    )
 
 
 def _billing_unit_breakdown(usage: dict) -> dict[str, int]:
@@ -108,7 +200,9 @@ def _billing_unit_breakdown(usage: dict) -> dict[str, int]:
     inclusive_cache_read = prompt_details.get("cached_tokens") or 0
     inclusive_cache_creation = prompt_details.get("cache_creation_tokens") or 0
     cache_read = usage.get("cache_read_input_tokens") or inclusive_cache_read or 0
-    cache_creation = usage.get("cache_creation_input_tokens") or inclusive_cache_creation or 0
+    cache_creation = (
+        usage.get("cache_creation_input_tokens") or inclusive_cache_creation or 0
+    )
     reasoning = completion_details.get("reasoning_tokens") or 0
 
     # Base (full-price) input. Trust text_tokens when present — it is LiteLLM's authoritative
@@ -204,7 +298,9 @@ def _count_image_inputs(kwargs: dict) -> int:
         for part in parts:
             if isinstance(part, str) and part.startswith(("data:", "gs://")):
                 count += 1
-            elif isinstance(part, dict) and ("image" in part or part.get("type") == "image"):
+            elif isinstance(part, dict) and (
+                "image" in part or part.get("type") == "image"
+            ):
                 count += 1
     return count
 
@@ -229,13 +325,18 @@ def _build_record(kwargs: dict, response_obj) -> dict | None:
     # custom_llm_provider on passthrough/routed calls. Fall back to the provider prefix of the
     # resolved deployment id ("bedrock/anthropic.claude-..." → "bedrock") so the record stays
     # priceable instead of landing at $0 and silently under-counting budget spend.
-    provider = kwargs.get("custom_llm_provider") or litellm_params.get("custom_llm_provider")
+    provider = kwargs.get("custom_llm_provider") or litellm_params.get(
+        "custom_llm_provider"
+    )
     if not provider:
         deployment_id = kwargs.get("model") or ""
         if "/" in deployment_id:
             provider = deployment_id.split("/", 1)[0]
     if not provider:
-        logger.warning("[cost] could not resolve provider for model=%s; cost may not resolve", model_name)
+        logger.warning(
+            "[cost] could not resolve provider for model=%s; cost may not resolve",
+            model_name,
+        )
 
     usage = _as_dict(getattr(response_obj, "usage", None))
     breakdown = _billing_unit_breakdown(usage)
@@ -249,7 +350,9 @@ def _build_record(kwargs: dict, response_obj) -> dict | None:
     if kwargs.get("input") is not None and "base_input_tokens" not in breakdown:
         estimated = _estimate_text_token_units(kwargs)
         if estimated:
-            breakdown["input_text_tokens"] = breakdown.get("input_text_tokens", 0) + estimated
+            breakdown["input_text_tokens"] = (
+                breakdown.get("input_text_tokens", 0) + estimated
+            )
     if not breakdown:
         logger.warning("[cost] empty billing breakdown for model=%s", model_name)
         return None
@@ -267,7 +370,9 @@ def _build_record(kwargs: dict, response_obj) -> dict | None:
     }
 
 
-_RETRYABLE_STATUS = frozenset({408, 429})  # request-timeout / too-many-requests: transient
+_RETRYABLE_STATUS = frozenset(
+    {408, 429}
+)  # request-timeout / too-many-requests: transient
 
 
 def _is_retryable(exc: Exception) -> bool:
@@ -325,6 +430,25 @@ class NannosCostLogger(CustomLogger):
         if self._worker is None or self._worker.done():
             self._worker = asyncio.create_task(self._run())
 
+    async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
+        """Normalize structured-output schemas before the request leaves the gateway.
+
+        LiteLLM calls this on every proxied request and uses the returned ``data`` as the
+        (possibly mutated) request. We force ``additionalProperties: false`` on every object
+        node of a ``response_format`` json_schema so Bedrock's Converse structured-output
+        validator accepts it (see ``_force_additional_properties_false``). Never raise — a
+        sanitization bug must not block a request, so on any error we pass ``data`` through
+        unchanged.
+        """
+        try:
+            if isinstance(data, dict):
+                _sanitize_response_format(data)
+        except Exception as e:  # never break the call on a sanitization failure
+            logger.warning(
+                "[schema] response_format sanitization failed: %s", e, exc_info=True
+            )
+        return data
+
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         try:
             record = _build_record(kwargs, response_obj)
@@ -345,7 +469,10 @@ class NannosCostLogger(CustomLogger):
                 # console-backend unreachable long enough to fill the buffer; drop rather
                 # than grow memory, but dead-letter the payload so it stays recoverable. We
                 # never break the LLM call on a logging failure.
-                logger.error("[cost] ingest buffer full (%d); dead-lettering usage record", _MAX_BUFFER)
+                logger.error(
+                    "[cost] ingest buffer full (%d); dead-lettering usage record",
+                    _MAX_BUFFER,
+                )
                 self._dead_letter([record], None)
         except Exception as e:  # never break the LLM call on a logging failure
             logger.error("[cost] failed to enqueue usage: %s", e, exc_info=True)
@@ -388,7 +515,11 @@ class NannosCostLogger(CustomLogger):
                 backoff = _FLUSH_BACKOFF_BASE * (2**attempt)
                 logger.warning(
                     "[cost] flush attempt %d/%d for %d record(s) failed (%s); retrying in %.1fs",
-                    attempt + 1, _FLUSH_MAX_RETRIES + 1, len(batch), e, backoff,
+                    attempt + 1,
+                    _FLUSH_MAX_RETRIES + 1,
+                    len(batch),
+                    e,
+                    backoff,
                 )
                 await asyncio.sleep(backoff)
         # Retries exhausted (or a non-retryable error): dead-letter so the records survive

--- a/packages/litellm-proxy/tests/test_custom_logger.py
+++ b/packages/litellm-proxy/tests/test_custom_logger.py
@@ -49,7 +49,9 @@ class _StatusResponse:
 
     def raise_for_status(self) -> None:
         resp = httpx.Response(self.status_code, request=self._request)
-        raise httpx.HTTPStatusError(f"HTTP {self.status_code}", request=self._request, response=resp)
+        raise httpx.HTTPStatusError(
+            f"HTTP {self.status_code}", request=self._request, response=resp
+        )
 
 
 class _FakeClient:
@@ -149,7 +151,9 @@ def test_is_retryable_classification():
     req = httpx.Request("POST", "http://x")
 
     def status(code: int) -> httpx.HTTPStatusError:
-        return httpx.HTTPStatusError("", request=req, response=httpx.Response(code, request=req))
+        return httpx.HTTPStatusError(
+            "", request=req, response=httpx.Response(code, request=req)
+        )
 
     assert cl._is_retryable(status(503))
     assert cl._is_retryable(status(500))
@@ -189,7 +193,9 @@ async def test_retryable_failure_is_retried_then_succeeds(logger_env, monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_non_retryable_status_is_not_retried_and_dead_letters(logger_env, monkeypatch):
+async def test_non_retryable_status_is_not_retried_and_dead_letters(
+    logger_env, monkeypatch
+):
     """A 4xx won't fix itself, so it is dead-lettered immediately without retrying."""
     monkeypatch.setattr(cl, "_FLUSH_BACKOFF_BASE", 0)
     calls = {"n": 0}
@@ -268,7 +274,11 @@ def test_dead_letter_emits_parseable_redacted_line(caplog):
     with caplog.at_level(_logging.ERROR, logger="nannos.litellm.custom_logger"):
         logger._dead_letter([record], RuntimeError("boom"))
 
-    lines = [r.getMessage() for r in caplog.records if "[cost][dead-letter]" in r.getMessage()]
+    lines = [
+        r.getMessage()
+        for r in caplog.records
+        if "[cost][dead-letter]" in r.getMessage()
+    ]
     assert len(lines) == 1
     payload = _json.loads(lines[0].split("[cost][dead-letter]", 1)[1].strip())
     # PII is gone; safe operational context survives.
@@ -287,6 +297,7 @@ def test_dead_letter_emits_parseable_redacted_line(caplog):
 
 # --- Billing breakdown: embedding token-counting edge cases (#7) ---
 
+
 def test_total_tokens_only_billed_as_input():
     """An embedding provider that reports ONLY total_tokens bills real tokens, not $0/estimate."""
     bd = cl._billing_unit_breakdown({"total_tokens": 1234})
@@ -295,7 +306,9 @@ def test_total_tokens_only_billed_as_input():
 
 def test_chat_total_tokens_not_miscounted_as_input():
     """A chat call with a normal split is unaffected (total_tokens fallback must not trigger)."""
-    bd = cl._billing_unit_breakdown({"prompt_tokens": 100, "completion_tokens": 40, "total_tokens": 140})
+    bd = cl._billing_unit_breakdown(
+        {"prompt_tokens": 100, "completion_tokens": 40, "total_tokens": 140}
+    )
     assert bd["base_input_tokens"] == 100
     assert bd["base_output_tokens"] == 40
 
@@ -378,8 +391,145 @@ def test_estimate_short_text_bills_at_least_one_token():
 def test_non_image_data_uri_is_billed_as_binary_input():
     # data:application/pdf / data:text are excluded from the char estimate; they must be
     # counted as a binary (input_images) part rather than billed nothing by both paths.
-    assert cl._estimate_text_token_units({"input": ["data:application/pdf;base64,AAAA"]}) == 0
+    assert (
+        cl._estimate_text_token_units({"input": ["data:application/pdf;base64,AAAA"]})
+        == 0
+    )
     assert cl._count_image_inputs({"input": ["data:application/pdf;base64,AAAA"]}) == 1
     assert cl._count_image_inputs({"input": ["data:text/plain;base64,AAAA"]}) == 1
     # image data URIs and gs:// still count (unchanged behavior).
-    assert cl._count_image_inputs({"input": ["data:image/png;base64,AAAA", "gs://bucket/x"]}) == 2
+    assert (
+        cl._count_image_inputs(
+            {"input": ["data:image/png;base64,AAAA", "gs://bucket/x"]}
+        )
+        == 2
+    )
+
+
+# --- Bedrock structured-output schema sanitization ----------------------------------------
+
+
+def test_force_additional_properties_false_on_flat_object():
+    # The real-world failing case: a flat object (FinalResponseSchema shape) with no
+    # additionalProperties. Bedrock requires it set to false.
+    schema = {
+        "type": "object",
+        "properties": {"task_state": {"type": "string"}, "message": {"type": "string"}},
+        "required": ["task_state", "message"],
+    }
+    cl._force_additional_properties_false(schema)
+    assert schema["additionalProperties"] is False
+
+
+def test_force_additional_properties_overrides_object_value():
+    # Bedrock's exact complaint: additionalProperties is an object (e.g. an open map). Force false.
+    schema = {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": {"type": "string"},
+    }
+    cl._force_additional_properties_false(schema)
+    assert schema["additionalProperties"] is False
+
+
+def test_force_additional_properties_preserves_explicit_bool():
+    # A caller that deliberately set a boolean is left alone (both true and false).
+    open_schema = {"type": "object", "properties": {}, "additionalProperties": True}
+    cl._force_additional_properties_false(open_schema)
+    assert open_schema["additionalProperties"] is True
+
+
+def test_force_additional_properties_recurses_nested_and_defs():
+    schema = {
+        "type": "object",
+        "properties": {
+            "child": {"type": "object", "properties": {"x": {"type": "string"}}},
+            "items": {"type": "array", "items": {"type": "object", "properties": {}}},
+            "variant": {
+                "anyOf": [{"type": "object", "properties": {}}, {"type": "null"}]
+            },
+        },
+        "$defs": {
+            "Nested": {"type": "object", "properties": {"y": {"type": "integer"}}}
+        },
+    }
+    cl._force_additional_properties_false(schema)
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["child"]["additionalProperties"] is False
+    assert schema["properties"]["items"]["items"]["additionalProperties"] is False
+    assert schema["properties"]["variant"]["anyOf"][0]["additionalProperties"] is False
+    assert schema["$defs"]["Nested"]["additionalProperties"] is False
+    # the null branch and scalar leaves are untouched
+    assert "additionalProperties" not in schema["properties"]["variant"]["anyOf"][1]
+
+
+def test_force_additional_properties_object_detected_via_properties_without_type():
+    # Some generators omit "type": "object" but include properties — still an object node.
+    schema = {"properties": {"a": {"type": "string"}}}
+    cl._force_additional_properties_false(schema)
+    assert schema["additionalProperties"] is False
+
+
+def test_sanitize_response_format_openai_shape():
+    data = {
+        "model": "claude-sonnet-4.6",
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "FinalResponseSchema",
+                "schema": {"type": "object", "properties": {"m": {"type": "string"}}},
+            },
+        },
+    }
+    cl._sanitize_response_format(data)
+    assert (
+        data["response_format"]["json_schema"]["schema"]["additionalProperties"]
+        is False
+    )
+
+
+def test_sanitize_response_format_flat_schema_shape():
+    # Tolerate the variant where the schema sits directly under response_format.schema.
+    data = {
+        "response_format": {
+            "type": "json_schema",
+            "schema": {"type": "object", "properties": {}},
+        }
+    }
+    cl._sanitize_response_format(data)
+    assert data["response_format"]["schema"]["additionalProperties"] is False
+
+
+def test_sanitize_response_format_ignores_non_json_schema():
+    for rf in ({"type": "json_object"}, {"type": "text"}, None, "json"):
+        data = {"response_format": rf}
+        cl._sanitize_response_format(data)  # must not raise
+        assert data["response_format"] == rf
+
+
+def test_pre_call_hook_mutates_and_returns_data():
+    data = {
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "S",
+                "schema": {"type": "object", "properties": {}},
+            },
+        }
+    }
+    out = asyncio.run(
+        cl.proxy_handler_instance.async_pre_call_hook(None, None, data, "completion")
+    )
+    assert out is data
+    assert (
+        data["response_format"]["json_schema"]["schema"]["additionalProperties"]
+        is False
+    )
+
+
+def test_pre_call_hook_passthrough_without_response_format():
+    data = {"model": "claude-sonnet-4.6", "messages": []}
+    out = asyncio.run(
+        cl.proxy_handler_instance.async_pre_call_hook(None, None, data, "completion")
+    )
+    assert out == {"model": "claude-sonnet-4.6", "messages": []}


### PR DESCRIPTION
## Problem
LangChain's native `ProviderStrategy`/`AutoStrategy` path emits **non-strict** `response_format` json_schemas with no `additionalProperties`. Bedrock's Converse structured-output validator rejects those:

> `output_config.format.schema: For 'object' type, 'additionalProperties: object' is not supported. Please set 'additionalProperties' to false`

## Fix
Add an `async_pre_call_hook` to `NannosCostLogger` ([custom_logger.py](packages/litellm-proxy/custom_logger.py)) that recursively forces `additionalProperties: false` on every object node of a `response_format` json_schema (`_force_additional_properties_false` / `_sanitize_response_format`). Fixing it at the proxy boundary covers **every** structured-output path uniformly and is safe across providers — OpenAI non-strict accepts it, and Gemini's `responseSchema` subset ignores it. An explicit boolean `additionalProperties` already set is preserved.

## Tests
`test_custom_logger.py` — flat/nested/`$defs` object coverage, object-valued override, explicit-bool preservation, OpenAI + flat schema shapes, non-json-schema passthrough. **31 passed.**

> Follow-up to #96 (extended-thinking blocks). The branch `fix/bedrock-thinking-blocks-roundtrip` carried this alongside the thinking-blocks fix; that fix landed in #96, so this PR is rebased onto `main` with just the schema-normalization change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)