### PR TITLE
fix(console-backend): keep MCP /mcp connection alive on long tool calls

### DIFF
--- a/packages/console-backend/app.py
+++ b/packages/console-backend/app.py
@@ -39,6 +39,7 @@ from rcplus_alloy_common.logging import (
 )
 from sqlalchemy import text as sa_text
 from starlette.middleware.sessions import SessionMiddleware
+from starlette.types import Receive, Scope, Send
 
 from console_backend.config import config
 from console_backend.db import close_db, get_async_session_factory, init_db
@@ -92,6 +93,7 @@ from console_backend.services.socket_notification_manager import SocketNotificat
 from console_backend.utils.connection_pool import connection_pool
 from console_backend.utils.cookie_signer import verify_cookie
 from console_backend.utils.fastapi_mcp_patch import apply_patch
+from console_backend.utils.mcp_keepalive import with_progress_keepalive
 from console_backend.utils.socket_errors import (
     SocketError,
     create_error_response,
@@ -237,8 +239,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     # Start the MCP StreamableHTTP session manager (streaming SSE transport mounted
     # at /mcp). Its run() context owns the background task that services /mcp requests.
+    # A fresh instance is created here each startup because run() can only be entered
+    # once per instance; the /mcp mount delegate reads it back off app.state.
+    app.state.mcp_session_manager = StreamableHTTPSessionManager(
+        app=mcp.server,
+        json_response=False,  # SSE so intermediate keepalive notifications stream
+        stateless=False,  # keep optional session support, matching fastapi_mcp's mount_http
+    )
     app.state.mcp_sm_stack = AsyncExitStack()
-    await app.state.mcp_sm_stack.enter_async_context(mcp_session_manager.run())
+    await app.state.mcp_sm_stack.enter_async_context(app.state.mcp_session_manager.run())
     logger.info("MCP StreamableHTTP session manager started")
 
     logger.info("Application startup complete")
@@ -459,13 +468,19 @@ async def _handle_list_tools() -> list:
 # (e.g. console_web_search) don't trip the ALB idle timeout → 504 on the /mcp connection.
 # fastapi_mcp's handle_call_tool calls self._execute_api_tool; shadowing it on the instance
 # routes every tool call through the keepalive. See utils.mcp_keepalive for why progress
-# notifications (not streaming.py-style whitespace) are the signal that reaches the ALB here.
-from console_backend.utils.mcp_keepalive import with_progress_keepalive  # noqa: E402
-
+# notifications (rather than raw whitespace) are the signal that reaches the ALB here.
+#
+# The shadow targets a *private* fastapi_mcp attribute; if a future upgrade renames or
+# inlines it the keepalive would silently no-op and the /mcp 504s would return with no
+# error. Fail loudly at import instead so the regression is caught on upgrade.
+assert hasattr(mcp, "_execute_api_tool"), (
+    "fastapi_mcp no longer exposes `_execute_api_tool`; the MCP keepalive shadow is broken "
+    "and /mcp will 504 on long tool calls. Re-wire after the fastapi_mcp upgrade."
+)
 _original_execute_api_tool = mcp._execute_api_tool
 
 
-async def _execute_api_tool_with_keepalive(*args, **kwargs):
+async def _execute_api_tool_with_keepalive(*args: Any, **kwargs: Any) -> Any:
     return await with_progress_keepalive(_original_execute_api_tool(*args, **kwargs), mcp.server)
 
 
@@ -479,16 +494,16 @@ mcp._execute_api_tool = _execute_api_tool_with_keepalive
 # ALB still times out (→ 504 ExceptionGroup on /mcp). Mounting the SDK's session
 # manager as a native ASGI app with json_response=False instead lets each progress/
 # log notification flush as an SSE event as it is produced, keeping the connection
-# alive. The manager's lifecycle is started/stopped in the app lifespan above.
-mcp_session_manager = StreamableHTTPSessionManager(
-    app=mcp.server,
-    json_response=False,  # SSE so intermediate keepalive notifications stream
-    stateless=False,  # keep optional session support, matching fastapi_mcp's mount_http
-)
-
-
-async def _mcp_streamable_asgi(scope, receive, send):
-    await mcp_session_manager.handle_request(scope, receive, send)
+# alive.
+#
+# The StreamableHTTPSessionManager instance is created per-startup inside the lifespan
+# (its run() context can only be entered once per instance — a module-level singleton
+# would raise RuntimeError the second time the lifespan runs, e.g. every test after the
+# first, or under `uvicorn --reload`). The delegate resolves the live manager off the
+# app on each request via scope["app"], which Starlette sets to the root app.
+async def _mcp_streamable_asgi(scope: Scope, receive: Receive, send: Send) -> None:
+    session_manager: StreamableHTTPSessionManager = scope["app"].state.mcp_session_manager
+    await session_manager.handle_request(scope, receive, send)
 
 
 app.mount("/mcp", _mcp_streamable_asgi)

--- a/packages/console-backend/app.py
+++ b/packages/console-backend/app.py
@@ -4,7 +4,7 @@ import logging
 import os
 import socket
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from http.cookies import SimpleCookie
@@ -30,6 +30,7 @@ from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi_mcp import FastApiMCP
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from google.protobuf.json_format import MessageToDict, ParseDict
 from google.protobuf.struct_pb2 import Value
 from rcplus_alloy_common.logging import (
@@ -234,12 +235,21 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     connection_pool.start_cleanup_task()
     logger.info("Connection pool cleanup task started")
 
+    # Start the MCP StreamableHTTP session manager (streaming SSE transport mounted
+    # at /mcp). Its run() context owns the background task that services /mcp requests.
+    app.state.mcp_sm_stack = AsyncExitStack()
+    await app.state.mcp_sm_stack.enter_async_context(mcp_session_manager.run())
+    logger.info("MCP StreamableHTTP session manager started")
+
     logger.info("Application startup complete")
 
     yield
 
     # Shutdown - called automatically when Uvicorn receives SIGTERM/SIGINT
     logger.info("Application shutting down...")
+    if hasattr(app.state, "mcp_sm_stack"):
+        await app.state.mcp_sm_stack.aclose()
+        logger.info("MCP StreamableHTTP session manager stopped")
     if hasattr(app.state, "scheduler_engine"):
         await app.state.scheduler_engine.stop()
         logger.info("Scheduler engine stopped")
@@ -445,8 +455,43 @@ async def _handle_list_tools() -> list:
         return all_tools
 
 
-# Mount the MCP server directly to your FastAPI app using HTTP transport
-mcp.mount_http()
+# Wrap tool execution with a progress-notification keepalive so long-running tools
+# (e.g. console_web_search) don't trip the ALB idle timeout → 504 on the /mcp connection.
+# fastapi_mcp's handle_call_tool calls self._execute_api_tool; shadowing it on the instance
+# routes every tool call through the keepalive. See utils.mcp_keepalive for why progress
+# notifications (not streaming.py-style whitespace) are the signal that reaches the ALB here.
+from console_backend.utils.mcp_keepalive import with_progress_keepalive  # noqa: E402
+
+_original_execute_api_tool = mcp._execute_api_tool
+
+
+async def _execute_api_tool_with_keepalive(*args, **kwargs):
+    return await with_progress_keepalive(_original_execute_api_tool(*args, **kwargs), mcp.server)
+
+
+mcp._execute_api_tool = _execute_api_tool_with_keepalive
+
+# Mount the MCP server over a *streaming* StreamableHTTP transport.
+#
+# We deliberately do NOT use mcp.mount_http(): fastapi_mcp's handle_fastapi_request
+# buffers the whole ASGI response and returns it as one Response only after the tool
+# call finishes — so the keepalive notifications above never reach the wire and the
+# ALB still times out (→ 504 ExceptionGroup on /mcp). Mounting the SDK's session
+# manager as a native ASGI app with json_response=False instead lets each progress/
+# log notification flush as an SSE event as it is produced, keeping the connection
+# alive. The manager's lifecycle is started/stopped in the app lifespan above.
+mcp_session_manager = StreamableHTTPSessionManager(
+    app=mcp.server,
+    json_response=False,  # SSE so intermediate keepalive notifications stream
+    stateless=False,  # keep optional session support, matching fastapi_mcp's mount_http
+)
+
+
+async def _mcp_streamable_asgi(scope, receive, send):
+    await mcp_session_manager.handle_request(scope, receive, send)
+
+
+app.mount("/mcp", _mcp_streamable_asgi)
 # Initialize Socket.IO server with optimized settings
 sio = socketio.AsyncServer(
     async_mode="asgi",

--- a/packages/console-backend/console_backend/utils/mcp_keepalive.py
+++ b/packages/console-backend/console_backend/utils/mcp_keepalive.py
@@ -4,15 +4,16 @@ Prevents 504 Gateway Time-out errors from the ALB / reverse proxy in front of
 console-backend's ``/mcp`` endpoint when a tool runs longer than the proxy's
 idle timeout (e.g. ``console_web_search``, which makes a full grounded LLM call).
 
-This is the MCP-transport analog of ``utils/streaming.py``'s whitespace
-keepalive. We cannot reuse that approach here: fastapi_mcp invokes the tool's
-FastAPI route through an internal ``httpx.ASGITransport`` client and reads the
-whole body with ``response.json()``, so any bytes a route streams are consumed
-by that internal client and never reach the outer ``/mcp`` SSE connection the
-ALB sees. The connection-keeping signal that *does* reach the ALB is an MCP
-**progress notification**: the SDK writes it as an SSE event on the per-request
-stream, flushing bytes through the proxy and resetting its idle timer (and the
-client's ``sse_read_timeout`` — see ``ringier_a2a_sdk.utils.mcp_progress``).
+A raw whitespace/heartbeat keepalive on the tool's FastAPI route does not work
+here: fastapi_mcp invokes the route through an internal ``httpx.ASGITransport``
+client and reads the whole body with ``response.json()``, so any bytes a route
+streams are consumed by that internal client and never reach the outer ``/mcp``
+SSE connection the ALB sees. The connection-keeping signal that *does* reach the
+ALB is an MCP **progress/log notification**: the SDK writes it as an SSE event on
+the per-request stream, flushing bytes through the proxy and resetting its idle
+timer. (The orchestrator-side ``ringier_a2a_sdk.utils.mcp_progress`` consumes the
+matching ``on_progress`` callback; note the SDK's ``sse_read_timeout`` is now
+deprecated, so the keepalive's effect is on the proxy idle timer, not that param.)
 
 The orchestrator already injects a ``progressToken`` on every console tool call
 (it registers an ``on_progress`` callback). We still always send a log-level
@@ -26,6 +27,7 @@ Usage — wrap the coroutine that runs the tool, inside an MCP request context::
 """
 
 import asyncio
+import contextlib
 import logging
 import os
 from collections.abc import Coroutine
@@ -58,55 +60,65 @@ async def with_progress_keepalive(
     is awaited with no keepalive.
     """
     task = asyncio.ensure_future(coro)
-
-    progress_token = None
-    session = None
-    request_id = None
     try:
-        ctx = server.request_context
-        progress_token = ctx.meta.progressToken if ctx.meta else None
-        session = ctx.session
-        request_id = ctx.request_id
-    except LookupError:
-        # No active MCP request context — nothing to keep alive against.
-        pass
-    except AttributeError:
-        logger.debug("MCP keepalive: unexpected request context shape", exc_info=True)
-
-    if session is None:
-        return await task
-
-    total = 1.0
-    steps = 0
-    while True:
+        progress_token = None
+        session = None
+        request_id = None
         try:
-            # asyncio.shield so a per-interval timeout cancels only the wait, not
-            # the underlying tool call. Returns/raises exactly what the tool does.
-            return await asyncio.wait_for(asyncio.shield(task), timeout=interval)
-        except asyncio.TimeoutError:
-            steps += 1
-            # Asymptotic curve: approaches `total` but never reaches it.
-            current = total * (1 - 1 / (1 + steps * 0.15))
-            # Progress notification (skipped by the SDK if no progressToken).
-            if progress_token is not None:
+            ctx = server.request_context
+            progress_token = ctx.meta.progressToken if ctx.meta else None
+            session = ctx.session
+            request_id = ctx.request_id
+        except LookupError:
+            # No active MCP request context — nothing to keep alive against.
+            pass
+        except AttributeError:
+            logger.debug("MCP keepalive: unexpected request context shape", exc_info=True)
+
+        if session is None:
+            return await task
+
+        total = 1.0
+        steps = 0
+        while True:
+            try:
+                # asyncio.shield so a per-interval timeout cancels only the wait, not
+                # the underlying tool call. Returns/raises exactly what the tool does.
+                return await asyncio.wait_for(asyncio.shield(task), timeout=interval)
+            except asyncio.TimeoutError:
+                steps += 1
+                # Asymptotic curve: approaches `total` but never reaches it.
+                current = total * (1 - 1 / (1 + steps * 0.15))
+                # Progress notification (skipped by the SDK if no progressToken).
+                if progress_token is not None:
+                    try:
+                        await session.send_progress_notification(
+                            progress_token=progress_token,
+                            progress=current,
+                            total=total,
+                            message="Tool still running…",
+                            related_request_id=request_id,
+                        )
+                    except Exception:
+                        logger.debug("MCP keepalive: progress notification failed", exc_info=True)
+                # Log notification — token-independent, so this is the keepalive that
+                # always reaches the wire. A failed keepalive must never break the tool
+                # call; if the SSE stream is gone the awaited task surfaces the real error.
                 try:
-                    await session.send_progress_notification(
-                        progress_token=progress_token,
-                        progress=current,
-                        total=total,
-                        message="Tool still running…",
+                    await session.send_log_message(
+                        level="debug",
+                        data=f"Processing… {current / total:.0%}",
                         related_request_id=request_id,
                     )
                 except Exception:
-                    logger.debug("MCP keepalive: progress notification failed", exc_info=True)
-            # Log notification — token-independent, so this is the keepalive that
-            # always reaches the wire. A failed keepalive must never break the tool
-            # call; if the SSE stream is gone the awaited task surfaces the real error.
-            try:
-                await session.send_log_message(
-                    level="debug",
-                    data=f"Processing… {current / total:.0%}",
-                    related_request_id=request_id,
-                )
-            except Exception:
-                logger.debug("MCP keepalive: log notification failed", exc_info=True)
+                    logger.debug("MCP keepalive: log notification failed", exc_info=True)
+    finally:
+        # If we leave before the tool finished — the /mcp request handler was cancelled
+        # (client disconnect, server shutdown) — the shielded task is still running
+        # detached. Cancel it so we don't leak the underlying tool call (e.g. an upstream
+        # LLM request) and its connection. On the normal return/raise paths the task is
+        # already done, so this is a no-op.
+        if not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task

--- a/packages/console-backend/console_backend/utils/mcp_keepalive.py
+++ b/packages/console-backend/console_backend/utils/mcp_keepalive.py
@@ -1,0 +1,112 @@
+"""Progress-notification keepalive for long-running MCP tool calls.
+
+Prevents 504 Gateway Time-out errors from the ALB / reverse proxy in front of
+console-backend's ``/mcp`` endpoint when a tool runs longer than the proxy's
+idle timeout (e.g. ``console_web_search``, which makes a full grounded LLM call).
+
+This is the MCP-transport analog of ``utils/streaming.py``'s whitespace
+keepalive. We cannot reuse that approach here: fastapi_mcp invokes the tool's
+FastAPI route through an internal ``httpx.ASGITransport`` client and reads the
+whole body with ``response.json()``, so any bytes a route streams are consumed
+by that internal client and never reach the outer ``/mcp`` SSE connection the
+ALB sees. The connection-keeping signal that *does* reach the ALB is an MCP
+**progress notification**: the SDK writes it as an SSE event on the per-request
+stream, flushing bytes through the proxy and resetting its idle timer (and the
+client's ``sse_read_timeout`` — see ``ringier_a2a_sdk.utils.mcp_progress``).
+
+The orchestrator already injects a ``progressToken`` on every console tool call
+(it registers an ``on_progress`` callback). We still always send a log-level
+notification too: ``progress`` notifications are silently dropped by the SDK when
+the client supplied no ``progressToken``, whereas ``notifications/message`` are
+unconditional, so the log message is the keepalive that always reaches the wire.
+
+Usage — wrap the coroutine that runs the tool, inside an MCP request context::
+
+    result = await with_progress_keepalive(slow_tool_coro(), mcp.server)
+"""
+
+import asyncio
+import logging
+import os
+from collections.abc import Coroutine
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Seconds between keepalive progress notifications. Must be comfortably below the
+# proxy idle timeout (AWS ALB default 60s) so a notification always lands before
+# the connection is considered idle. Override via env for ops tuning.
+_KEEPALIVE_INTERVAL: float = float(os.environ.get("MCP_KEEPALIVE_INTERVAL_SECONDS", "15"))
+
+
+async def with_progress_keepalive(
+    coro: Coroutine[Any, Any, Any],
+    server: Any,
+    *,
+    interval: float = _KEEPALIVE_INTERVAL,
+) -> Any:
+    """Run *coro*, emitting periodic MCP progress notifications while it executes.
+
+    1. The coroutine is started immediately.
+    2. While it is running, a keepalive is sent every *interval* seconds to keep
+       the ``/mcp`` SSE connection alive through the ALB — always a log-level
+       notification, plus a progress notification when the client gave a token.
+    3. The coroutine's result is returned (or its exception re-raised) unchanged,
+       so fastapi_mcp's normal result/error handling is preserved.
+
+    If no MCP request context is active (no SSE stream to write to), the coroutine
+    is awaited with no keepalive.
+    """
+    task = asyncio.ensure_future(coro)
+
+    progress_token = None
+    session = None
+    request_id = None
+    try:
+        ctx = server.request_context
+        progress_token = ctx.meta.progressToken if ctx.meta else None
+        session = ctx.session
+        request_id = ctx.request_id
+    except LookupError:
+        # No active MCP request context — nothing to keep alive against.
+        pass
+    except AttributeError:
+        logger.debug("MCP keepalive: unexpected request context shape", exc_info=True)
+
+    if session is None:
+        return await task
+
+    total = 1.0
+    steps = 0
+    while True:
+        try:
+            # asyncio.shield so a per-interval timeout cancels only the wait, not
+            # the underlying tool call. Returns/raises exactly what the tool does.
+            return await asyncio.wait_for(asyncio.shield(task), timeout=interval)
+        except asyncio.TimeoutError:
+            steps += 1
+            # Asymptotic curve: approaches `total` but never reaches it.
+            current = total * (1 - 1 / (1 + steps * 0.15))
+            # Progress notification (skipped by the SDK if no progressToken).
+            if progress_token is not None:
+                try:
+                    await session.send_progress_notification(
+                        progress_token=progress_token,
+                        progress=current,
+                        total=total,
+                        message="Tool still running…",
+                        related_request_id=request_id,
+                    )
+                except Exception:
+                    logger.debug("MCP keepalive: progress notification failed", exc_info=True)
+            # Log notification — token-independent, so this is the keepalive that
+            # always reaches the wire. A failed keepalive must never break the tool
+            # call; if the SSE stream is gone the awaited task surfaces the real error.
+            try:
+                await session.send_log_message(
+                    level="debug",
+                    data=f"Processing… {current / total:.0%}",
+                    related_request_id=request_id,
+                )
+            except Exception:
+                logger.debug("MCP keepalive: log notification failed", exc_info=True)

--- a/packages/console-backend/tests/test_mcp_keepalive.py
+++ b/packages/console-backend/tests/test_mcp_keepalive.py
@@ -1,0 +1,116 @@
+"""Tests for the MCP progress-notification keepalive (utils/mcp_keepalive)."""
+
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+os.environ.setdefault("ECS_CONTAINER_METADATA_URI", "true")
+
+from console_backend.utils.mcp_keepalive import with_progress_keepalive
+
+
+def _make_server(*, progress_token, session):
+    ctx = SimpleNamespace(
+        meta=SimpleNamespace(progressToken=progress_token) if progress_token is not None else None,
+        session=session,
+        request_id="req-1",
+    )
+    return SimpleNamespace(request_context=ctx)
+
+
+@pytest.mark.asyncio
+async def test_keepalive_emits_notifications_during_slow_call_and_returns_result():
+    session = AsyncMock()
+
+    async def slow():
+        await asyncio.sleep(0.25)
+        return "done"
+
+    server = _make_server(progress_token="tok-123", session=session)
+    result = await with_progress_keepalive(slow(), server, interval=0.05)
+
+    assert result == "done"
+    # With token: both progress + log keepalives fire on each tick.
+    assert session.send_progress_notification.await_count >= 2
+    assert session.send_log_message.await_count >= 2
+    # Progress is monotonic and stays below total (asymptotic curve).
+    progresses = [c.kwargs["progress"] for c in session.send_progress_notification.await_args_list]
+    assert progresses == sorted(progresses)
+    assert all(p < 1.0 for p in progresses)
+
+
+@pytest.mark.asyncio
+async def test_keepalive_log_message_without_token():
+    session = AsyncMock()
+
+    async def slow():
+        await asyncio.sleep(0.15)
+        return 42
+
+    server = _make_server(progress_token=None, session=session)
+    result = await with_progress_keepalive(slow(), server, interval=0.05)
+
+    assert result == 42
+    # No token → no progress notifications, but log keepalives still fire.
+    session.send_progress_notification.assert_not_awaited()
+    assert session.send_log_message.await_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_fast_call_sends_no_keepalive():
+    session = AsyncMock()
+
+    async def fast():
+        return "quick"
+
+    server = _make_server(progress_token="tok", session=session)
+    result = await with_progress_keepalive(fast(), server, interval=0.05)
+
+    assert result == "quick"
+    session.send_progress_notification.assert_not_awaited()
+    session.send_log_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_exception_propagates_unchanged():
+    session = AsyncMock()
+
+    async def boom():
+        await asyncio.sleep(0.12)
+        raise ValueError("tool failed")
+
+    server = _make_server(progress_token="tok", session=session)
+    with pytest.raises(ValueError, match="tool failed"):
+        await with_progress_keepalive(boom(), server, interval=0.05)
+
+
+@pytest.mark.asyncio
+async def test_no_request_context_awaits_without_keepalive():
+    class _NoCtx:
+        @property
+        def request_context(self):
+            raise LookupError("no context")
+
+    async def work():
+        return "ok"
+
+    result = await with_progress_keepalive(work(), _NoCtx(), interval=0.05)
+    assert result == "ok"
+
+
+@pytest.mark.asyncio
+async def test_failed_keepalive_does_not_break_tool():
+    session = AsyncMock()
+    session.send_log_message.side_effect = RuntimeError("stream gone")
+    session.send_progress_notification.side_effect = RuntimeError("stream gone")
+
+    async def slow():
+        await asyncio.sleep(0.15)
+        return "survived"
+
+    server = _make_server(progress_token="tok", session=session)
+    result = await with_progress_keepalive(slow(), server, interval=0.05)
+    assert result == "survived"

--- a/packages/console-backend/tests/test_mcp_keepalive.py
+++ b/packages/console-backend/tests/test_mcp_keepalive.py
@@ -114,3 +114,29 @@ async def test_failed_keepalive_does_not_break_tool():
     server = _make_server(progress_token="tok", session=session)
     result = await with_progress_keepalive(slow(), server, interval=0.05)
     assert result == "survived"
+
+
+@pytest.mark.asyncio
+async def test_outer_cancellation_cancels_underlying_tool_task():
+    """If the /mcp handler is cancelled mid-call, the shielded tool task must not
+    be left running detached — the keepalive cancels it on the way out."""
+    session = AsyncMock()
+    cancelled = asyncio.Event()
+
+    async def slow():
+        try:
+            await asyncio.sleep(10)
+            return "should not finish"
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    server = _make_server(progress_token="tok", session=session)
+    outer = asyncio.ensure_future(with_progress_keepalive(slow(), server, interval=0.05))
+    # Let the keepalive loop tick at least once, then cancel the outer wrapper.
+    await asyncio.sleep(0.12)
+    outer.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await outer
+    # The underlying tool task must have received the cancellation (no orphan leak).
+    await asyncio.wait_for(cancelled.wait(), timeout=1.0)

--- a/packages/console-backend/tests/test_mcp_streaming_keepalive.py
+++ b/packages/console-backend/tests/test_mcp_streaming_keepalive.py
@@ -1,0 +1,120 @@
+"""HTTP-level regression test for the streaming MCP keepalive.
+
+Guards the two-part fix together:
+  1. utils.mcp_keepalive emits progress/log notifications during a slow tool call;
+  2. the /mcp transport is mounted as a *streaming* StreamableHTTPSessionManager
+     (json_response=False, native ASGI) so those notifications flush as SSE events
+     instead of being buffered until the tool returns.
+
+If someone reverts to fastapi_mcp's buffering mount_http(), this test fails because
+no notification arrives before the final result.
+"""
+
+import asyncio
+import os
+import socket
+import threading
+import time
+
+import pytest
+import uvicorn
+
+os.environ.setdefault("ECS_CONTAINER_METADATA_URI", "true")
+
+from contextlib import AsyncExitStack, asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi_mcp import FastApiMCP
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+
+from console_backend.utils.mcp_keepalive import with_progress_keepalive
+
+
+def _build_app(interval: float = 0.4) -> FastAPI:
+    """Build an app wired exactly like app.py: keepalive + streaming SSE mount."""
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        app.state.stack = AsyncExitStack()
+        await app.state.stack.enter_async_context(session_manager.run())
+        yield
+        await app.state.stack.aclose()
+
+    app = FastAPI(lifespan=lifespan)
+
+    @app.post("/api/v1/slow", tags=["MCP"], operation_id="slow_tool", response_model=str)
+    async def slow_tool(seconds: float = 2.0) -> str:
+        await asyncio.sleep(seconds)
+        return f"done after {seconds}s"
+
+    mcp = FastApiMCP(app, include_tags=["MCP"])
+
+    _orig = mcp._execute_api_tool
+
+    async def _with_keepalive(*args, **kwargs):
+        return await with_progress_keepalive(_orig(*args, **kwargs), mcp.server, interval=interval)
+
+    mcp._execute_api_tool = _with_keepalive
+
+    session_manager = StreamableHTTPSessionManager(app=mcp.server, json_response=False, stateless=False)
+
+    async def _mcp_asgi(scope, receive, send):
+        await session_manager.handle_request(scope, receive, send)
+
+    app.mount("/mcp", _mcp_asgi)
+    return app
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+@pytest.mark.asyncio
+async def test_keepalive_notifications_stream_before_result():
+    port = _free_port()
+    config = uvicorn.Config(_build_app(), host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    try:
+        # Wait for the server to accept connections.
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline and not server.started:
+            await asyncio.sleep(0.05)
+        assert server.started, "uvicorn did not start"
+
+        notifications: list[tuple[float, str]] = []
+        t0 = time.monotonic()
+
+        async def on_progress(progress, total, message):
+            notifications.append((time.monotonic() - t0, "progress"))
+
+        async def on_logging(params):
+            notifications.append((time.monotonic() - t0, "log"))
+
+        url = f"http://127.0.0.1:{port}/mcp"
+        async with streamablehttp_client(url) as (read, write, _):
+            async with ClientSession(read, write, logging_callback=on_logging) as session:
+                await session.initialize()
+                result = await session.call_tool("slow_tool", {"seconds": 2.0}, progress_callback=on_progress)
+                result_at = time.monotonic() - t0
+
+        text = result.content[0].text
+        assert "done after 2.0s" in text
+        assert not result.isError
+        # Keepalives must have arrived, and BEFORE the result (i.e. they streamed).
+        assert notifications, "no keepalive notifications received — transport is buffering"
+        assert any(t < result_at - 0.2 for t, _ in notifications), (
+            f"notifications did not stream before result: {notifications} vs result_at={result_at:.2f}"
+        )
+        assert any(kind == "progress" for _, kind in notifications)
+        assert any(kind == "log" for _, kind in notifications)
+    finally:
+        server.should_exit = True
+        thread.join(timeout=10)


### PR DESCRIPTION
## Problem

Long-running console MCP tools — notably `console_web_search`, which makes a full grounded LLM call — could exceed the ALB idle timeout and return a **504 Gateway Time-out** on the `/mcp` connection. The orchestrator surfaces this as:

```
ExceptionGroup: unhandled errors in a TaskGroup
  └─ httpx.HTTPStatusError: Server error '504 Gateway Time-out'
     for url 'https://console.s.nannos.ringier.ch/mcp'
```

## Root cause (two-fold)

1. While a tool runs, console-backend's `/mcp` connection emitted **no bytes**, so the ALB saw an idle connection and closed it.
2. fastapi_mcp's `mount_http()` (`handle_fastapi_request`) **buffers the entire ASGI response** and returns it only after the tool finishes — so even periodic notifications would never reach the wire.

Both had to be fixed; fixing only the keepalive (my first pass) does nothing because the transport still buffers.

## Fix (two parts)

- **`utils/mcp_keepalive.py`** — runs the tool while emitting a keepalive every 15s (`MCP_KEEPALIVE_INTERVAL_SECONDS`): always a token-independent **log** notification, plus a **progress** notification when the client supplied a `progressToken`. Notifications reset the proxy idle timer — the same mechanism [`ringier_a2a_sdk.utils.mcp_progress`](packages/ringier-a2a-sdk/ringier_a2a_sdk/utils/mcp_progress.py) documents for the Gatana gateway (which already does this; console didn't).
- **`app.py`** — replaces `mcp.mount_http()` with a streaming `StreamableHTTPSessionManager` (`json_response=False`) mounted as a native ASGI app, lifecycle managed in the app lifespan, so each notification **flushes as an SSE event as produced**.

This is the MCP-transport analog of [`utils/streaming.py`](packages/console-backend/console_backend/utils/streaming.py)'s whitespace keepalive (used in another project). `streaming.py` can't be reused here because fastapi_mcp consumes the tool route via an internal `httpx.ASGITransport` client and reads the full body — so route-level whitespace never reaches the outer `/mcp` connection.

## Validation

- **Unit tests** (`test_mcp_keepalive.py`): keepalive emission, asymptotic progress curve, log-only without token, fast-call no-op, exception propagation, failed-keepalive doesn't break the tool.
- **HTTP-level regression test** (`test_mcp_streaming_keepalive.py`): asserts notifications stream **before** the result — fails if anyone reverts to buffered `mount_http()`.
- **Live-browser QA** through an 8s-idle proxy standing in for the ALB:
  - **New wiring** → keepalives stream every 3s, tool completes ✅
  - **Old buffered wiring** → connection dies at t+8s, reproducing the exact `ExceptionGroup` ❌

## Deploy note

Ships a 15s keepalive interval against the ALB's ~60s idle timeout (comfortable margin). Worth confirming the actual ALB idle-timeout value for this environment before/after deploy.

## Follow-up (not in this PR)

Migrating console-backend off fastapi_mcp to native FastMCP would let `ctx.report_progress` replace this manual keepalive — but it's a real migration (24 tag-discovered tools, custom `list_tools` RBAC filtering, header forwarding), best done separately. Note even on FastMCP a token-independent log keepalive is still needed, since `report_progress` is dropped without a client `progressToken`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)