### PR TITLE
refactor(orchestrator-agent): centralize {{TOKEN}} system-prompt placeholder resolution

### DIFF
--- a/packages/orchestrator-agent/app/agents/task_scheduler.py
+++ b/packages/orchestrator-agent/app/agents/task_scheduler.py
@@ -38,6 +38,8 @@ from agent_common.models.base import ModelType
 from deepagents import CompiledSubAgent
 from ringier_a2a_sdk.cost_tracking import CostLogger
 
+from ..core.prompt_placeholders import resolve_prompt_placeholders
+
 logger = logging.getLogger(__name__)
 
 # Sub-agent configuration
@@ -66,9 +68,8 @@ TASK_SCHEDULER_DESCRIPTION = (
 # Default model for task scheduling (strategic planning)
 # Can be overridden via TASK_SCHEDULER_MODEL environment variable
 DEFAULT_TASK_SCHEDULER_MODEL: ModelType = os.getenv("TASK_SCHEDULER_MODEL", "claude-sonnet-4.6")  # type: ignore
-CONSOLE_FRONTEND_URL = os.getenv("CONSOLE_FRONTEND_URL", "http://localhost:5173")
 # System prompt for the task scheduler agent
-TASK_SCHEDULER_SYSTEM_PROMPT = """<role>
+TASK_SCHEDULER_SYSTEM_PROMPT = resolve_prompt_placeholders("""<role>
 You are a task scheduling specialist responsible for managing scheduled tasks and automated workflows.
 </role>
 
@@ -178,8 +179,8 @@ Poll interval: interval_seconds
 - Show job IDs and next run times
 - Explain what will happen when the job executes
 - Guide users on how to monitor or modify schedules
-- Provide a link to the newly created scheduled job in the UI: CONSOLE_FRONTEND_URL/app/scheduler/{scheduled_job_id}
-</response_format>""".replace("CONSOLE_FRONTEND_URL", CONSOLE_FRONTEND_URL)
+- Provide a link to the newly created scheduled job in the UI: {{CONSOLE_FRONTEND_URL}}/app/scheduler/{scheduled_job_id}
+</response_format>""")
 
 
 class TaskSchedulerRunnable(StructuredResponseMixin, LocalA2ARunnable):

--- a/packages/orchestrator-agent/app/core/prompt_placeholders.py
+++ b/packages/orchestrator-agent/app/core/prompt_placeholders.py
@@ -1,0 +1,23 @@
+"""Whitelisted ``{{TOKEN}}`` placeholder resolution for system prompts.
+
+Used for both DB-stored sub-agent prompts (resolved at materialization time) and
+static built-in prompts. Placeholders are resolved from the environment rather than
+baked in, so the same prompt stays portable across deployments. Each resolver must
+have a sensible dev fallback so prompts still work locally.
+"""
+
+import os
+from typing import Any
+
+_PROMPT_PLACEHOLDERS: dict[str, Any] = {
+    "CONSOLE_FRONTEND_URL": lambda: os.environ.get("CONSOLE_FRONTEND_URL", "http://localhost:5173").rstrip("/"),
+}
+
+
+def resolve_prompt_placeholders(prompt: str) -> str:
+    """Substitute whitelisted ``{{TOKEN}}`` placeholders in a system prompt."""
+    for token, resolver in _PROMPT_PLACEHOLDERS.items():
+        placeholder = "{{" + token + "}}"
+        if placeholder in prompt:
+            prompt = prompt.replace(placeholder, resolver())
+    return prompt

--- a/packages/orchestrator-agent/app/core/registry.py
+++ b/packages/orchestrator-agent/app/core/registry.py
@@ -11,6 +11,8 @@ from agent_common.a2a.models import LocalFoundrySubAgentConfig, LocalLangGraphSu
 from agent_common.models.base import ThinkingLevel
 from pydantic import BaseModel, Field
 
+from .prompt_placeholders import resolve_prompt_placeholders
+
 logger = logging.getLogger(__name__)
 
 # System prompt addendum for playground mode
@@ -399,7 +401,7 @@ class RegistryService:
                     }
             elif sa.type == "local":
                 # Local agents have system_prompt and mcp_tools at root level
-                system_prompt = cv.system_prompt or ""
+                system_prompt = resolve_prompt_placeholders(cv.system_prompt or "")
                 mcp_tools = cv.mcp_tools or []
 
                 if sa.name and system_prompt:

--- a/packages/orchestrator-agent/tests/test_prompt_placeholders.py
+++ b/packages/orchestrator-agent/tests/test_prompt_placeholders.py
@@ -1,0 +1,75 @@
+"""Tests for whitelisted ``{{TOKEN}}`` system-prompt placeholder resolution."""
+
+import pytest
+
+from app.core.prompt_placeholders import resolve_prompt_placeholders
+
+
+def test_resolves_console_frontend_url_from_env(monkeypatch):
+    """A ``{{CONSOLE_FRONTEND_URL}}`` placeholder is replaced with the env value."""
+    monkeypatch.setenv("CONSOLE_FRONTEND_URL", "https://console.example.com")
+
+    result = resolve_prompt_placeholders("Open {{CONSOLE_FRONTEND_URL}}/app/scheduler/{job_id}")
+
+    assert result == "Open https://console.example.com/app/scheduler/{job_id}"
+
+
+def test_strips_trailing_slashes_from_resolved_url(monkeypatch):
+    """Trailing slashes are stripped so prompts can append their own path."""
+    monkeypatch.setenv("CONSOLE_FRONTEND_URL", "https://console.example.com///")
+
+    result = resolve_prompt_placeholders("link {{CONSOLE_FRONTEND_URL}}/foo")
+
+    assert result == "link https://console.example.com/foo"
+
+
+def test_uses_dev_fallback_when_env_unset(monkeypatch):
+    """Without the env var, the dev fallback keeps local prompts working."""
+    monkeypatch.delenv("CONSOLE_FRONTEND_URL", raising=False)
+
+    result = resolve_prompt_placeholders("go to {{CONSOLE_FRONTEND_URL}}")
+
+    assert result == "go to http://localhost:5173"
+
+
+def test_replaces_all_occurrences(monkeypatch):
+    """Every occurrence of a placeholder is substituted, not just the first."""
+    monkeypatch.setenv("CONSOLE_FRONTEND_URL", "https://c.example.com")
+
+    result = resolve_prompt_placeholders("{{CONSOLE_FRONTEND_URL}} and {{CONSOLE_FRONTEND_URL}}")
+
+    assert result == "https://c.example.com and https://c.example.com"
+
+
+def test_resolved_at_call_time_not_import_time(monkeypatch):
+    """Resolution reads the environment on each call, keeping configs portable."""
+    monkeypatch.setenv("CONSOLE_FRONTEND_URL", "https://first.example.com")
+    assert resolve_prompt_placeholders("{{CONSOLE_FRONTEND_URL}}") == "https://first.example.com"
+
+    monkeypatch.setenv("CONSOLE_FRONTEND_URL", "https://second.example.com")
+    assert resolve_prompt_placeholders("{{CONSOLE_FRONTEND_URL}}") == "https://second.example.com"
+
+
+def test_single_brace_literals_left_untouched(monkeypatch):
+    """Single-brace prompt literals (e.g. ``{job_id}``) are not treated as placeholders."""
+    monkeypatch.setenv("CONSOLE_FRONTEND_URL", "https://c.example.com")
+
+    prompt = "fill {scheduled_job_id} then visit {CONSOLE_FRONTEND_URL}"
+    result = resolve_prompt_placeholders(prompt)
+
+    assert result == prompt
+
+
+def test_unknown_double_brace_token_left_intact(monkeypatch):
+    """Non-whitelisted ``{{TOKEN}}`` placeholders pass through unchanged."""
+    monkeypatch.setenv("CONSOLE_FRONTEND_URL", "https://c.example.com")
+
+    result = resolve_prompt_placeholders("{{SOME_OTHER_TOKEN}} stays")
+
+    assert result == "{{SOME_OTHER_TOKEN}} stays"
+
+
+@pytest.mark.parametrize("prompt", ["", "no placeholders here"])
+def test_passthrough_when_nothing_to_resolve(prompt):
+    """Empty or placeholder-free prompts are returned unchanged."""
+    assert resolve_prompt_placeholders(prompt) == prompt

--- a/packages/orchestrator-agent/tests/test_registry.py
+++ b/packages/orchestrator-agent/tests/test_registry.py
@@ -183,6 +183,58 @@ class TestRegistryService:
             assert local_agent.model_name == "gpt-4o"
 
     @pytest.mark.asyncio
+    async def test_local_agent_system_prompt_placeholders_resolved(self, mock_registry_service, monkeypatch):
+        """A stored local-agent prompt has its {{CONSOLE_FRONTEND_URL}} placeholder resolved."""
+        monkeypatch.setenv("CONSOLE_FRONTEND_URL", "https://console.example.com")
+        mock_sub_agents_response = {
+            "items": [
+                {
+                    "id": 2,
+                    "name": "data-analyst",
+                    "description": "Analyzes data",
+                    "owner_user_id": "test-user",
+                    "type": "local",
+                    "current_version": 1,
+                    "default_version": 1,
+                    "config_version": {
+                        "id": 2,
+                        "sub_agent_id": 2,
+                        "version": 1,
+                        "description": "Analyzes data",
+                        "model": "gpt-4o",
+                        "agent_url": None,
+                        "system_prompt": "Link users to {{CONSOLE_FRONTEND_URL}}/app for details.",
+                        "mcp_tools": [],
+                        "status": "approved",
+                        "created_at": "2024-01-01T00:00:00",
+                    },
+                    "created_at": "2024-01-01T00:00:00",
+                    "updated_at": "2024-01-01T00:00:00",
+                }
+            ],
+            "total": 1,
+        }
+        mock_settings_response = {
+            "data": {
+                "user_id": "test-user-id",
+                "sub": "test-user-sub",
+                "language": "en",
+                "custom_prompt": None,
+                "timezone": "Europe/Zurich",
+                "mcp_tools": [],
+                "created_at": "2026-01-01T00:00:00",
+                "updated_at": "2026-01-01T00:00:00",
+            }
+        }
+
+        with mock_registry_service(mock_sub_agents_response, mock_settings_response) as registry_service:
+            user = await registry_service.get_user(user_sub="test-user-sub", access_token="test-token")
+
+            assert user is not None
+            assert len(user.local_subagents) == 1
+            assert user.local_subagents[0].system_prompt == "Link users to https://console.example.com/app for details."
+
+    @pytest.mark.asyncio
     async def test_get_user_success_with_mixed_agents(self, mock_registry_service):
         """Test get_user successfully fetches both remote and local sub-agents."""
         mock_sub_agents_response = {


### PR DESCRIPTION
## Summary

Consolidates the whitelisted `{{TOKEN}}` system-prompt placeholder mechanism into one shared module and routes both call sites through it.

- **New** [`app/core/prompt_placeholders.py`](packages/orchestrator-agent/app/core/prompt_placeholders.py) — single home for `resolve_prompt_placeholders()` and the placeholder whitelist (and the `http://localhost:5173` dev default).
- [`registry.py`](packages/orchestrator-agent/app/core/registry.py) — materializes local sub-agent prompts via the shared helper instead of a private copy.
- [`task_scheduler.py`](packages/orchestrator-agent/app/agents/task_scheduler.py) — migrated off the fragile bare-substring `.replace("CONSOLE_FRONTEND_URL", ...)` onto the braced `{{CONSOLE_FRONTEND_URL}}` placeholder, and dropped its now-redundant module-level constant.

## Why

- Removes the duplicated `http://localhost:5173` dev-default literal (was in two places within the package).
- Gives the package **one** substitution convention: braced, resolved at call time from the environment, and whitelisted. The braced form also avoids accidentally rewriting prose that merely contains the token substring — a latent footgun in the old bare-substring approach.

## Tests

- New `tests/test_prompt_placeholders.py` (9 cases): env substitution, trailing-slash stripping, dev fallback, **call-time** resolution, single-brace literals (`{job_id}`) left untouched, unknown `{{TOKEN}}` passed through, empty/no-op passthrough.
- New end-to-end case in `tests/test_registry.py`: a stored local-agent prompt with `{{CONSOLE_FRONTEND_URL}}` is resolved through `get_user`.
- `test_task_scheduler_whitelist.py` regression check: passing.

All green: 35 passed locally.

## Out of scope

`packages/voice-agent` keeps its own `_CONSOLE_FRONTEND_URL` — separate package, and its usage is a plain f-string rather than prompt-token substitution, so the resolver doesn't fit. Cross-package consolidation would mean promoting the helper into `agent_common`; left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)