### PR TITLE
fix(agent-common): attribute in-process sub-agent LLM costs to the sub-agent

### DIFF
--- a/packages/agent-common/agent_common/a2a/base.py
+++ b/packages/agent-common/agent_common/a2a/base.py
@@ -937,6 +937,25 @@ class LocalA2ARunnable(CostTrackingMixin, BaseA2ARunnable):
         Raises:
             NotImplementedError: If subclass doesn't implement _astream_impl()
         """
+        # Gateway cost-attribution for in-process sub-agents.
+        # A local sub-agent's LLM calls reach the Model Gateway on the *caller's*
+        # attribution context (the orchestrator turn, where sub_agent_id is unset),
+        # so their litellm spend logs would be misattributed to the orchestrator.
+        # The app-side CostLogger already gets sub_agent_id from the ``sub_agent:``
+        # LangGraph tag (see _instrument), but the gateway's
+        # ``x-litellm-spend-logs-metadata`` header is stamped from the
+        # ``current_sub_agent_id`` ContextVar, which nothing updates when the
+        # orchestrator dispatches into a local sub-agent. Set it to this agent's own
+        # id for the duration of the run, then restore the caller's value so the
+        # orchestrator's subsequent calls are not mis-tagged with this sub-agent.
+        # Restore via set() (not token.reset()): this is an async generator, and a
+        # Token created in one context cannot be reset from another after a yield.
+        from ringier_a2a_sdk.cost_tracking.attribution import current_sub_agent_id as _attr_sub_agent_id
+
+        _sa_id = getattr(self, "sub_agent_id", None)
+        _attr_prev = _attr_sub_agent_id.get()
+        if isinstance(_sa_id, int):
+            _attr_sub_agent_id.set(_sa_id)
         try:
             # For HITL resume: pass Command directly to _astream_impl, skip validation
             from langgraph.types import Command as LGCommand
@@ -987,6 +1006,11 @@ class LocalA2ARunnable(CostTrackingMixin, BaseA2ARunnable):
             result = self._build_error_response(f"Internal error: {str(e)}")
             wrapped = self._wrap_message_with_metadata(result)
             yield ErrorEvent(error=str(e), data=wrapped)
+        finally:
+            # Restore the caller's attribution so the orchestrator's own model
+            # calls after this sub-agent returns aren't billed to the sub-agent.
+            if isinstance(_sa_id, int):
+                _attr_sub_agent_id.set(_attr_prev)
 
     async def _astream_impl(self, input_data: SubAgentInput, config: Dict[str, Any]) -> AsyncIterable[StreamEvent]:
         """Stream implementation to be provided by subclasses.

--- a/packages/agent-common/tests/test_local_a2a_runnable.py
+++ b/packages/agent-common/tests/test_local_a2a_runnable.py
@@ -307,3 +307,79 @@ class TestEnsureSupportedBlockTypes:
         blocks = [{"type": "audio", "url": "https://example.com/clip.mp3"}]
         result = StubLocalAgent._ensure_supported_block_types(blocks, supported_modes=None)
         assert result == blocks
+
+
+class _AttributionCapturingAgent(StubLocalAgent):
+    """Records the gateway attribution sub_agent_id seen during execution."""
+
+    def __init__(self, sub_agent_id):
+        super().__init__()
+        self.sub_agent_id = sub_agent_id
+        self.seen_sub_agent_id = "unset"
+
+    async def _process(self, input_data, config):
+        from ringier_a2a_sdk.cost_tracking.attribution import current_sub_agent_id
+
+        self.seen_sub_agent_id = current_sub_agent_id.get()
+        return self._build_success_response("ok")
+
+
+class TestGatewayAttributionScope:
+    """astream() must stamp the gateway attribution ContextVar with the sub-agent's
+    own id for the duration of the run, then restore the caller's value — otherwise
+    in-process sub-agent LLM calls are billed to the orchestrator in litellm spend
+    logs (the app-side tag path is separate and already correct)."""
+
+    async def test_sets_sub_agent_id_during_run_and_restores_after(self):
+        from ringier_a2a_sdk.cost_tracking.attribution import current_sub_agent_id
+
+        agent = _AttributionCapturingAgent(sub_agent_id=42)
+        token = current_sub_agent_id.set(None)  # caller (orchestrator) has none
+        try:
+            _input = SubAgentInput(
+                messages=[HumanMessage(content="hello")], orchestrator_conversation_id="ctx-123"
+            )
+            async for _ in agent.astream(_input, _base_config()):
+                pass
+            # Seen during _process == this agent's id
+            assert agent.seen_sub_agent_id == 42
+            # Restored to the caller's value after the sub-agent returns
+            assert current_sub_agent_id.get() is None
+        finally:
+            current_sub_agent_id.reset(token)
+
+    async def test_restores_caller_value_for_nested_dispatch(self):
+        """A sub-agent invoked while another sub-agent's id is active must restore
+        that outer id, not blanket-clear it."""
+        from ringier_a2a_sdk.cost_tracking.attribution import current_sub_agent_id
+
+        agent = _AttributionCapturingAgent(sub_agent_id=7)
+        token = current_sub_agent_id.set(99)  # outer sub-agent active
+        try:
+            _input = SubAgentInput(
+                messages=[HumanMessage(content="hello")], orchestrator_conversation_id="ctx-123"
+            )
+            async for _ in agent.astream(_input, _base_config()):
+                pass
+            assert agent.seen_sub_agent_id == 7
+            assert current_sub_agent_id.get() == 99
+        finally:
+            current_sub_agent_id.reset(token)
+
+    async def test_no_sub_agent_id_leaves_caller_attribution_untouched(self):
+        """A built-in agent without an int sub_agent_id (e.g. file-analyzer) must
+        not clobber the caller's attribution."""
+        from ringier_a2a_sdk.cost_tracking.attribution import current_sub_agent_id
+
+        agent = _AttributionCapturingAgent(sub_agent_id=None)
+        token = current_sub_agent_id.set(99)
+        try:
+            _input = SubAgentInput(
+                messages=[HumanMessage(content="hello")], orchestrator_conversation_id="ctx-123"
+            )
+            async for _ in agent.astream(_input, _base_config()):
+                pass
+            assert agent.seen_sub_agent_id == 99  # inherits caller's
+            assert current_sub_agent_id.get() == 99
+        finally:
+            current_sub_agent_id.reset(token)


### PR DESCRIPTION
## Problem

Local (in-process) sub-agents' gateway spend logs are **misattributed to the orchestrator** — `sub_agent_id` is missing in the litellm `LiteLLM_SpendLogs` metadata for any interactive orchestrator→sub-agent turn. Reproduced with task-scheduler and confirmed generic across agents (general-purpose, agent-creator, etc.).

## Root cause

There are two cost-attribution sinks:

1. **App-side `CostLogger`** — reads `sub_agent_id` from the `sub_agent:{id}` **LangGraph tag** added by `LocalA2ARunnable._instrument()`. ✅ Works.
2. **LiteLLM gateway spend logs** — the proxy reads `sub_agent_id` from the `x-litellm-spend-logs-metadata` header, which the shared httpx hook stamps from the `current_sub_agent_id` **ContextVar** (`ringier_a2a_sdk.cost_tracking.attribution`). ❌ Broken.

The executor sets the attribution ContextVars once per orchestrator turn, with `sub_agent_id` left unset (the orchestrator has none). When the orchestrator dispatches into a **local** sub-agent, the sub-agent's LLM calls run in-process on that same context and nobody ever updates `current_sub_agent_id` — so those tokens reach the gateway tagged as the orchestrator. (The scheduled-job path was fine because it sets attribution explicitly before invoking.)

## Fix

`LocalA2ARunnable.astream()` — the single chokepoint all local sub-agents (and `ainvoke`, which delegates to it) flow through — now sets `current_sub_agent_id` to the agent's own `sub_agent_id` for the duration of the run and restores the caller's value in `finally`.

- Restore uses `set()` rather than `token.reset()`: `astream()` is an async generator and a `Token` created in one context can't be reset from another after a `yield`.
- Built-in agents with no integer `sub_agent_id` (e.g. file-analyzer) leave the caller's attribution untouched.
- Leak-safe and nests correctly (a sub-agent invoked while another's id is active restores that outer id, not blanket-clears it).

Confirmed end-to-end that the proxy reads `sub_agent_id` from this header (`packages/litellm-proxy/custom_logger.py`).

## Tests

Adds 3 regression tests in `test_local_a2a_runnable.py`: sets-during-run/restores-after, nested-dispatch restore, and no-int-id no-op. Full agent-common suite passes (653).

🤖 Generated with [Claude Code](https://claude.com/claude-code)