### PR TITLE
fix(orchestrator-agent): fast-retry budget guard on transient lock, stop mislabeling it as overspend

### DIFF
--- a/packages/orchestrator-agent/app/core/budget_guard.py
+++ b/packages/orchestrator-agent/app/core/budget_guard.py
@@ -83,6 +83,10 @@ class BudgetStatus:
     is_locked: bool
     last_refresh: Optional[datetime]
     warnings: list[float]
+    lock_reason: Optional[str] = None
+    # True when the lock is a fail-closed "couldn't verify spend" state (transient) rather
+    # than a real budget breach. Lets callers show an honest message and expect fast recovery.
+    locked_by_error: bool = False
 
 
 @dataclass
@@ -94,22 +98,32 @@ class BudgetGuard:
     authenticate (no OIDC client — local dev), which `enabled` reports as a capability.
 
     Fail-closed: when polling fails the guard locks until a healthy status is seen again.
+    Such error-locks (transient IdP/network/backend failures — distinct from a real budget
+    breach) retry on a short, backing-off cadence so a brief blip doesn't keep the
+    orchestrator locked for a full poll interval.
 
     Attributes:
         base_url: console-backend base URL.
         oauth2_client: OIDC client-credentials client (None keeps the guard inert).
         audience: console-backend client id used as the token audience.
-        check_interval_seconds: Poll interval (default 300 = 5 minutes).
+        check_interval_seconds: Poll interval when healthy or on a real breach (default 300 = 5 min).
+        error_retry_interval_seconds: Base retry delay while locked by a transient error; backs off
+            exponentially toward check_interval_seconds until a healthy status is seen (default 15s).
     """
 
     base_url: str
     oauth2_client: "OidcOAuth2Client | None" = None
     audience: str = "agent-console"
     check_interval_seconds: int = 300
+    error_retry_interval_seconds: int = 15
 
     # Internal state
     _is_locked: bool = field(default=False, init=False)
     _lock_reason: Optional[str] = field(default=None, init=False)
+    # True when the current lock is a fail-closed error state, not a real breach.
+    _locked_by_error: bool = field(default=False, init=False)
+    # Consecutive error-locks; drives the retry backoff, reset on any healthy poll.
+    _error_streak: int = field(default=0, init=False)
     _spend_usd: Decimal = field(default_factory=lambda: Decimal("0"), init=False)
     _limit_usd: Decimal = field(default_factory=lambda: Decimal("0"), init=False)
     _usage_percentage: float = field(default=0.0, init=False)
@@ -140,6 +154,11 @@ class BudgetGuard:
         """True if budget is locked (exceeded or status unavailable) and the guard can operate."""
         return self._is_locked and self.enabled
 
+    @property
+    def locked_by_error(self) -> bool:
+        """True when locked because spend couldn't be verified (transient), not a real breach."""
+        return self.is_locked and self._locked_by_error
+
     def get_status(self) -> BudgetStatus:
         """Get the last-polled budget status snapshot."""
         return BudgetStatus(
@@ -149,6 +168,8 @@ class BudgetGuard:
             is_locked=self._is_locked,
             last_refresh=self._last_refresh,
             warnings=list(self._warnings),
+            lock_reason=self._lock_reason,
+            locked_by_error=self._locked_by_error,
         )
 
     def _get_client(self) -> httpx.AsyncClient:
@@ -156,17 +177,28 @@ class BudgetGuard:
             self._client = httpx.AsyncClient(base_url=self.base_url, timeout=_HTTP_TIMEOUT)
         return self._client
 
-    def _lock(self, reason: str) -> None:
+    def _lock(self, reason: str, *, by_error: bool) -> None:
+        """Lock the guard.
+
+        by_error distinguishes a fail-closed "couldn't verify spend" lock (transient — token,
+        network, or backend failure) from a real budget breach. Error-locks drive the fast-retry
+        backoff so a brief blip recovers in seconds rather than a full poll interval; a genuine
+        breach clears the streak and uses the normal cadence.
+        """
         if not self._is_locked:
             logger.warning("BudgetGuard LOCKED: %s", reason)
         self._is_locked = True
         self._lock_reason = reason
+        self._locked_by_error = by_error
+        self._error_streak = self._error_streak + 1 if by_error else 0
 
     def _unlock(self) -> None:
         if self._is_locked:
             logger.info("BudgetGuard unlocked")
         self._is_locked = False
         self._lock_reason = None
+        self._locked_by_error = False
+        self._error_streak = 0
 
     async def refresh(self) -> None:
         """Poll console-backend for the budget status and update the cached lock decision.
@@ -180,7 +212,7 @@ class BudgetGuard:
         try:
             token = await self.oauth2_client.get_token(self.audience)  # type: ignore[union-attr]
         except Exception as e:
-            self._lock(f"Could not obtain service token: {e}")
+            self._lock(f"Could not obtain service token: {e}", by_error=True)
             return
 
         try:
@@ -188,7 +220,7 @@ class BudgetGuard:
                 _STATUS_PATH, headers={"Authorization": f"Bearer {token}"}
             )
             if resp.status_code != 200:
-                self._lock(f"Budget status endpoint returned {resp.status_code}")
+                self._lock(f"Budget status endpoint returned {resp.status_code}", by_error=True)
                 return
 
             data = resp.json()
@@ -199,7 +231,7 @@ class BudgetGuard:
             self._last_refresh = datetime.now(timezone.utc)
 
             if data.get("is_locked"):
-                self._lock("Monthly spending budget exceeded")
+                self._lock("Monthly spending budget exceeded", by_error=False)
             else:
                 self._unlock()
 
@@ -209,7 +241,7 @@ class BudgetGuard:
             )
         except Exception as e:
             # FAIL-CLOSED: lock on any error.
-            self._lock(f"Budget status poll failed: {e}")
+            self._lock(f"Budget status poll failed: {e}", by_error=True)
 
     async def start_polling(self) -> None:
         """Start the background polling task."""
@@ -235,6 +267,19 @@ class BudgetGuard:
         if self._client is not None and not self._client.is_closed:
             await self._client.aclose()
 
+    def _next_poll_delay(self) -> float:
+        """Seconds to wait before the next poll.
+
+        While locked by a transient error, retry fast and back off exponentially from
+        error_retry_interval_seconds toward check_interval_seconds — so a brief IdP/network/backend
+        blip recovers in seconds instead of leaving the orchestrator locked for a full interval. A
+        healthy status or a real breach uses the normal cadence.
+        """
+        if self._locked_by_error:
+            backoff = self.error_retry_interval_seconds * (2 ** max(0, self._error_streak - 1))
+            return float(min(backoff, self.check_interval_seconds))
+        return float(self.check_interval_seconds)
+
     async def _polling_loop(self) -> None:
         """Background loop that periodically refreshes the budget status."""
         # Initial refresh immediately.
@@ -242,7 +287,7 @@ class BudgetGuard:
 
         while True:
             try:
-                await asyncio.sleep(self.check_interval_seconds)
+                await asyncio.sleep(self._next_poll_delay())
                 await self.refresh()
             except asyncio.CancelledError:
                 logger.debug("Polling loop cancelled")

--- a/packages/orchestrator-agent/app/core/executor.py
+++ b/packages/orchestrator-agent/app/core/executor.py
@@ -543,14 +543,30 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
         budget_guard = get_budget_guard()
         if budget_guard and budget_guard.enabled and budget_guard.is_locked:
             status = budget_guard.get_status()
-            logger.warning(
-                f"Request rejected due to budget lock. "
-                f"Spend: ${status.spend_usd}/${status.limit_usd} ({status.usage_percentage:.1f}%)."
-            )
+            if status.locked_by_error:
+                # Fail-closed because spend couldn't be verified (transient IdP/network/backend
+                # blip), NOT a real overspend. Don't misdirect the user to an administrator — the
+                # guard fast-retries and typically clears within seconds.
+                logger.warning(
+                    f"Request rejected: budget status could not be verified ({status.lock_reason}). "
+                    f"Fail-closed until the next successful poll."
+                )
+                budget_message = (
+                    "Service temporarily unavailable: I couldn't verify the spending budget just "
+                    "now. This is usually a brief hiccup — please try again in a moment."
+                )
+            else:
+                logger.warning(
+                    f"Request rejected due to budget lock. "
+                    f"Spend: ${status.spend_usd}/${status.limit_usd} ({status.usage_percentage:.1f}%)."
+                )
+                budget_message = (
+                    "Service temporarily unavailable: the monthly spending budget has been exceeded. "
+                    "Please contact an administrator to increase the budget or wait until next month."
+                )
             await updater.update_status(
                 TaskState.TASK_STATE_FAILED,
-                new_text_message("Service temporarily unavailable: the monthly spending budget has been exceeded. "
-                    "Please contact an administrator to increase the budget or wait until next month.", context_id=task.context_id, task_id=task.id),
+                new_text_message(budget_message, context_id=task.context_id, task_id=task.id),
             )
             return
 

--- a/packages/orchestrator-agent/tests/test_budget_guard.py
+++ b/packages/orchestrator-agent/tests/test_budget_guard.py
@@ -84,12 +84,76 @@ class TestInitialization:
 class TestLocking:
     def test_lock_unlock(self):
         guard = BudgetGuard(base_url="http://c", oauth2_client=_oauth())
-        guard._lock("boom")
+        guard._lock("boom", by_error=True)
         assert guard.is_locked is True
         assert guard._lock_reason == "boom"
         guard._unlock()
         assert guard.is_locked is False
         assert guard._lock_reason is None
+
+    def test_error_lock_flags_locked_by_error(self):
+        guard = BudgetGuard(base_url="http://c", oauth2_client=_oauth())
+        guard._lock("transient blip", by_error=True)
+        assert guard.locked_by_error is True
+        assert guard.get_status().locked_by_error is True
+        assert guard.get_status().lock_reason == "transient blip"
+
+    def test_breach_lock_is_not_locked_by_error(self):
+        guard = BudgetGuard(base_url="http://c", oauth2_client=_oauth())
+        guard._lock("over budget", by_error=False)
+        assert guard.is_locked is True
+        assert guard.locked_by_error is False
+        assert guard.get_status().locked_by_error is False
+
+    def test_locked_by_error_false_when_inert(self):
+        """An inert guard (no OIDC) never enforces, so locked_by_error stays False too."""
+        guard = BudgetGuard(base_url="http://c", oauth2_client=None)
+        guard._lock("transient blip", by_error=True)
+        assert guard.locked_by_error is False
+
+    def test_breach_lock_clears_error_streak(self):
+        guard = BudgetGuard(base_url="http://c", oauth2_client=_oauth())
+        guard._lock("blip", by_error=True)
+        guard._lock("blip", by_error=True)
+        assert guard._error_streak == 2
+        guard._lock("over budget", by_error=False)
+        assert guard._error_streak == 0
+
+
+class TestRetryBackoff:
+    def test_normal_cadence_when_healthy(self):
+        guard = BudgetGuard(base_url="http://c", oauth2_client=_oauth(), check_interval_seconds=300)
+        assert guard._next_poll_delay() == 300.0
+
+    def test_normal_cadence_on_real_breach(self):
+        guard = BudgetGuard(base_url="http://c", oauth2_client=_oauth(), check_interval_seconds=300)
+        guard._lock("over budget", by_error=False)
+        assert guard._next_poll_delay() == 300.0
+
+    def test_fast_retry_backs_off_toward_interval(self):
+        guard = BudgetGuard(
+            base_url="http://c",
+            oauth2_client=_oauth(),
+            check_interval_seconds=300,
+            error_retry_interval_seconds=15,
+        )
+        guard._lock("blip", by_error=True)  # streak 1
+        assert guard._next_poll_delay() == 15.0
+        guard._lock("blip", by_error=True)  # streak 2
+        assert guard._next_poll_delay() == 30.0
+        guard._lock("blip", by_error=True)  # streak 3
+        assert guard._next_poll_delay() == 60.0
+
+    def test_backoff_capped_at_interval(self):
+        guard = BudgetGuard(
+            base_url="http://c",
+            oauth2_client=_oauth(),
+            check_interval_seconds=300,
+            error_retry_interval_seconds=15,
+        )
+        for _ in range(20):
+            guard._lock("blip", by_error=True)
+        assert guard._next_poll_delay() == 300.0
 
 
 class TestRefresh:
@@ -140,7 +204,15 @@ class TestRefresh:
         guard.oauth2_client.get_token = AsyncMock(side_effect=Exception("no idp"))
         await guard.refresh()
         assert guard.is_locked is True
+        assert guard.locked_by_error is True
         assert "service token" in guard._lock_reason
+
+    @pytest.mark.asyncio
+    async def test_real_breach_not_flagged_as_error(self):
+        guard = _guard_with_http(_status_payload(is_locked=True))
+        await guard.refresh()
+        assert guard.is_locked is True
+        assert guard.locked_by_error is False
 
     @pytest.mark.asyncio
     async def test_fail_closed_on_non_200(self):


### PR DESCRIPTION
## Problem

The orchestrator's `BudgetGuard` is fail-closed: any failed poll of the budget-status endpoint locks the orchestrator and rejects all requests. This surfaced when Keycloak briefly returned **502 during a redeploy**:

```
BudgetGuard LOCKED: Could not obtain service token: Failed to fetch OIDC metadata ... 502 Bad Gateway
```

Two distinct problems followed:

1. **Slow recovery.** The lock is only re-evaluated on the flat 300s poll cadence, so a few-second IdP blip kept the orchestrator locked for **up to 5 minutes** after Keycloak was already healthy again.
2. **Misleading message.** Every lock — transient infra failure or real overspend — reported *"the monthly spending budget has been exceeded. Please contact an administrator..."* Users saw this on the **1st of the month with \$0 spend**, pointing them at the wrong problem.

The `$0/$0` in the reject log was the tell: the guard had never had a single successful poll (a healthy poll would show the \$300 limit), so it was fail-closed from startup with default values.

## Fix

- **Distinguish error-locks from real breaches.** `_lock(reason, by_error=...)` now records whether a lock is a fail-closed "couldn't verify spend" state or a genuine budget breach; exposed via `locked_by_error` / `lock_reason` on the status snapshot.
- **Fast retry with backoff.** While locked by a transient error, the poll loop retries starting at `error_retry_interval_seconds` (default 15s) and backs off exponentially (15→30→60→120→240→300) toward the normal interval, resetting on any healthy poll or real breach. A Keycloak-redeploy blip now recovers in ~15s instead of up to 5 minutes.
- **Honest user message.** The executor shows *"I couldn't verify the spending budget just now — usually a brief hiccup, try again in a moment"* for error-locks, and keeps the overspend message for genuine breaches.

## Tests

`tests/test_budget_guard.py` — added coverage for the error-vs-breach flag, streak reset, the backoff schedule and cap, and the `refresh()` paths; fixed the one existing test that called `_lock()` without the new kwarg. **26/26 passing.**

## Not included

A separate month-transition edge case in console-backend's `_month_start` (period_start == now at exactly 00:00:00 on the 1st → empty spend window → briefly *unlocks*) — different bug, left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)