### PR TITLE
feat(chat): resilient web chat — conversation-keyed turns with resume-on-subscribe

### DIFF
--- a/packages/console-backend/app.py
+++ b/packages/console-backend/app.py
@@ -38,6 +38,7 @@ from rcplus_alloy_common.logging import (
     configure_logger,
 )
 from sqlalchemy import text as sa_text
+from sqlalchemy.exc import IntegrityError
 from starlette.middleware.sessions import SessionMiddleware
 from starlette.types import Receive, Scope, Send
 
@@ -611,7 +612,7 @@ def _accumulate_reply_buffer(context_id: str, response_data: dict[str, Any]) -> 
     return len(_streaming_buffers[context_id])
 
 
-def _clear_turn_state(context_id: str) -> None:
+def _clear_turn_state(context_id: str, *, preserve_pending_interaction: bool = False) -> None:
     """Drop all in-memory turn state for a conversation.
 
     Called from the single turn exit point (handle_send_message's finally) so the state
@@ -619,13 +620,35 @@ def _clear_turn_state(context_id: str) -> None:
     the turn-ending event inside _process_a2a_response. Without this, a cancelled or
     errored turn leaves residue in these dicts and _has_active_turn reports the
     conversation as permanently in-flight (stale snapshot / stuck spinner on reload).
+
+    preserve_pending_interaction: keep the pending HITL prompt. A turn that ends in
+    input-required closes the A2A stream (LangGraph interrupt), so this teardown runs
+    right after the prompt was captured — wiping it here would make the pendingHitl
+    snapshot-restore impossible. The prompt is instead cleared when the user's answer
+    starts the next turn (handle_send_message) or when a later turn ends without asking.
     """
     _streaming_buffers.pop(context_id, None)
-    _pending_interactions.pop(context_id, None)
+    if not preserve_pending_interaction:
+        _pending_interactions.pop(context_id, None)
     prefix = f"{context_id}:"
     for key in [k for k in _intermediate_buffers if k.startswith(prefix)]:
         _intermediate_buffers.pop(key, None)
         _intermediate_buffer_ts.pop(key, None)
+
+
+def _pending_input_required(context_id: str) -> bool:
+    """Whether the stored pending interaction is an input-required (HITL) prompt.
+
+    Feedback-requests are mid-stream events whose turn keeps running; only an
+    input-required prompt legitimately outlives its turn's stream (the interrupt
+    closes the stream while the conversation waits on the user's answer).
+    """
+    pending = _pending_interactions.get(context_id)
+    if not pending:
+        return False
+    status = pending.get("status", {})
+    state = _short_state_name(status.get("state")) if isinstance(status, dict) else None
+    return state == "input-required"
 
 
 # ==============================================================================
@@ -852,20 +875,11 @@ async def _process_a2a_response(
             # (user_id, conversation_id) at Turn start, NOT to the ephemeral socket
             # session — which is destroyed on disconnect. This lets a Turn that
             # outlives its originating connection still persist its reply.
+            # Ownership was verified once at Turn start (handle_send_message's
+            # get_or_create gate) and cannot change mid-turn, so no per-event
+            # re-check here — this runs on EVERY streamed chunk and a DB round-trip
+            # per chunk would delay the forwarding pipeline.
             if user_id:
-                # Verify conversation exists and belongs to user
-                conversation_service = sio.app_instance.state.conversation_service  # type: ignore[attr-defined]
-
-                conversation = await conversation_service.get_conversation(
-                    conversation_id=effective_context_id,
-                    user_id=user_id,
-                )
-
-                if not conversation:
-                    raise ConversationOwnershipError(
-                        f"Conversation {effective_context_id} does not exist or does not belong to user {user_id}"
-                    )
-
                 messages_service = sio.app_instance.state.messages_service  # type: ignore[attr-defined]
 
                 # Detect work-plan events via extensions on the status message
@@ -1024,11 +1038,6 @@ async def _process_a2a_response(
                         conversation_id=effective_context_id,
                         user_id=user_id,
                     )
-        except ConversationOwnershipError as ownership_error:
-            logger.error(
-                f"Conversation ownership violation in agent response: sid={sid}, response_id={response_id}, "
-                f"context_id={effective_context_id}, error={ownership_error!s}"
-            )
         except Exception as db_error:
             # Log but don't fail the response if DB write fails
             logger.error(f"Failed to save agent response to DynamoDB: {db_error}", exc_info=True)
@@ -1445,7 +1454,6 @@ async def handle_initialize_client(sid: str, data: dict[str, Any]) -> dict[str, 
 
 
 async def _save_user_message_to_db(
-    conversation_service: ConversationService,
     messages_service: MessagesService,
     context_id: str,
     socket_session: SocketSession | None,
@@ -1457,8 +1465,10 @@ async def _save_user_message_to_db(
 ) -> None:
     """Save user message to DynamoDB with conversation tracking.
 
+    The conversation row must already exist: the caller (handle_send_message) creates
+    and ownership-verifies it via its get_or_create gate before this runs.
+
     Args:
-        conversation_service: ConversationService instance
         messages_service: MessagesService instance
         context_id: Conversation context ID
         socket_session: Socket session with user_id (guaranteed non-None after validation)
@@ -1471,9 +1481,6 @@ async def _save_user_message_to_db(
     try:
         if not socket_session or not socket_session.user_id:
             raise ValueError("Socket session or user ID is missing")
-
-        # The conversation is already created/ownership-verified by the caller's ownership
-        # gate (handle_send_message) before this runs, so we don't get_or_create again here.
 
         # Build parts array: text part (if non-empty) + file parts (if any)
         parts = []
@@ -1783,10 +1790,13 @@ async def handle_send_message(sid: str, json_data: dict[str, Any]) -> dict[str, 
 
         # Enforce conversation ownership BEFORE joining its stream room or forwarding to the
         # orchestrator. The sender must own the conversation, or it must be new (created here
-        # under the sender). get_or_create raises for a conversation_id owned by another user
-        # (PK conflict on insert), so we fail closed — otherwise a caller could join a victim's
-        # room and eavesdrop the stream, or run a turn on the victim's orchestrator thread.
-        # (_save_user_message_to_db calls get_or_create again idempotently.)
+        # under the sender). A conversation_id owned by another user surfaces as an
+        # IntegrityError (PK conflict on insert — get_conversation filters by user, so the
+        # foreign row is invisible and the create path collides) or a ConversationOwnershipError,
+        # and we fail closed — otherwise a caller could join a victim's room and eavesdrop the
+        # stream, or run a turn on the victim's orchestrator thread. Other exceptions (DB
+        # outage, timeouts) are NOT ownership violations and propagate to the generic error
+        # handler below so they surface as retryable server errors, not "Conversation not found".
         sub_agent_config_hash = metadata.get("subAgentConfigHash") if isinstance(metadata, dict) else None
         try:
             await conversation_service.get_or_create_conversation(
@@ -1796,7 +1806,7 @@ async def handle_send_message(sid: str, json_data: dict[str, Any]) -> dict[str, 
                 message=message_text,
                 sub_agent_config_hash=sub_agent_config_hash,
             )
-        except Exception:
+        except (ConversationOwnershipError, IntegrityError):
             logger.warning(
                 f"send_message rejected: conversation {context_id} is not owned by user "
                 f"{socket_session.user_id} (sid={sid})"
@@ -1815,7 +1825,6 @@ async def handle_send_message(sid: str, json_data: dict[str, Any]) -> dict[str, 
 
         # Save message to database
         await _save_user_message_to_db(
-            conversation_service,
             messages_service,
             context_id,
             socket_session,
@@ -1848,19 +1857,27 @@ async def handle_send_message(sid: str, json_data: dict[str, Any]) -> dict[str, 
             logger.info(f"[STEERING] Active turn detected for conversation {task_key}, routing as steering message")
             return await _send_steering_message_to_agent(a2a_client, message, sid, message_id, sio)
 
+        # This send is the user's response to any prompt the previous turn left pending
+        # (input-required prompts survive their turn's teardown, see _clear_turn_state),
+        # so drop it now — otherwise a mid-turn (re)subscribe would replay it.
+        _pending_interactions.pop(context_id, None)
+
         send_task = asyncio.create_task(
             _send_message_to_agent(
                 a2a_client, message, sid, message_id, sio, task_key=task_key, user_id=socket_session.user_id
             )
         )
-        active_tasks[task_key] = ActiveTaskInfo(
+        turn_info = ActiveTaskInfo(
             asyncio_task=send_task,
             a2a_client=a2a_client,
             origin_sid=sid,
         )
+        active_tasks[task_key] = turn_info
+        turn_cancelled = False
         try:
             return await send_task
         except asyncio.CancelledError:
+            turn_cancelled = True
             logger.info(f"Send message task cancelled: context_id={context_id}")
             cancelled_response = {
                 "id": message_id,
@@ -1873,8 +1890,19 @@ async def handle_send_message(sid: str, json_data: dict[str, Any]) -> dict[str, 
             # Single teardown point for the turn: clear task tracking AND all in-memory
             # turn state on every exit (completion, cancel, error) so the conversation
             # doesn't stay falsely "in-flight" (stale resume snapshot / stuck spinner).
-            active_tasks.pop(task_key, None)
-            _clear_turn_state(context_id)
+            # Identity-checked: if another send already superseded this turn (our task was
+            # done but this finally hadn't run yet), the state now belongs to the new turn
+            # and must not be torn down by this stale handler. A missing entry (popped by
+            # handle_cancel_task) still means the state is ours to clear.
+            current = active_tasks.get(task_key)
+            if current is turn_info or current is None:
+                active_tasks.pop(task_key, None)
+                # A turn that ended BY asking for input (LangGraph interrupt closes the
+                # stream) must keep its prompt so a (re)subscribing client can restore it.
+                _clear_turn_state(
+                    context_id,
+                    preserve_pending_interaction=not turn_cancelled and _pending_input_required(context_id),
+                )
 
     except ValueError as e:
         # Validation errors - send specific error details

--- a/packages/console-backend/app.py
+++ b/packages/console-backend/app.py
@@ -554,6 +554,48 @@ _intermediate_buffers: dict[str, str] = {}
 # reload ordering aligned with how the thoughts streamed live.
 _intermediate_buffer_ts: dict[str, datetime] = {}
 
+# Pending interactive prompt (HITL / feedback-request) per conversation, keyed by
+# context_id. Captured when the orchestrator asks for input and cleared when the turn
+# ends, so a client that (re)subscribes mid-turn can restore a prompt that arrived
+# while it was disconnected — otherwise the turn would hang waiting on input the user
+# never saw. Value is the raw agent_response payload of the prompt event.
+_pending_interactions: dict[str, dict[str, Any]] = {}
+
+
+def _conversation_room(conversation_id: str) -> str:
+    """Socket.IO room name carrying a conversation's live stream.
+
+    Delivery is keyed by conversation_id (not the ephemeral connection), so a client
+    that reconnects/reloads (new sid) resumes the stream by rejoining this room, and
+    multiple tabs on the same conversation all receive it.
+    """
+    return f"conversation:{conversation_id}"
+
+
+def _accumulate_reply_buffer(context_id: str, response_data: dict[str, Any]) -> int | None:
+    """Append an orchestrator-reply artifact chunk to the resumable buffer; return the new length.
+
+    Runs BEFORE the chunk is emitted so a client subscribing mid-stream gets a snapshot
+    consistent with the live chunks: the returned offset (cumulative reply length) is
+    attached to the emitted chunk as ``turnOffset``, and the client drops any chunk whose
+    ``turnOffset`` is already covered by its snapshot. Only orchestrator content is
+    buffered — intermediate (sub-agent) output is handled separately and is best-effort
+    on resume. Returns None when the event is not a resumable reply chunk.
+    """
+    if not context_id or response_data.get("kind") != "artifact-update":
+        return None
+    artifact = response_data.get("artifact", {})
+    if not isinstance(artifact, dict):
+        return None
+    if "urn:nannos:a2a:intermediate-output:1.0" in artifact.get("extensions", []):
+        return None
+    parts = artifact.get("parts", [])
+    chunk_text = "".join(p.get("text", "") for p in parts if isinstance(p, dict) and p.get("text"))
+    # Always update on an artifact chunk (even empty, e.g. the final last_chunk) so the
+    # offset is defined for every emitted reply chunk.
+    _streaming_buffers[context_id] = _streaming_buffers.get(context_id, "") + chunk_text
+    return len(_streaming_buffers[context_id])
+
 
 # ==============================================================================
 # Active Task Helpers
@@ -750,16 +792,27 @@ async def _process_a2a_response(
         logger.info("Agent response (sid=%s) id=%s", sid, response_id)
 
     effective_context_id = context_id or response_data.get("contextId")
+    # Deliver to the conversation room (keyed by conversation_id) so a reconnected or
+    # multi-tab client receives the stream; fall back to the originating socket only when
+    # there is no conversation context to route by.
+    emit_target = _conversation_room(effective_context_id) if effective_context_id else sid
+
+    # Accumulate the resumable reply buffer BEFORE emitting and tag the chunk with its
+    # cumulative offset, so a client subscribing mid-stream dedupes live chunks against its
+    # snapshot (accumulate-then-emit ⇒ every emitted chunk is already in the buffer).
+    turn_offset = _accumulate_reply_buffer(effective_context_id, response_data) if effective_context_id else None
+    if turn_offset is not None:
+        response_data["turnOffset"] = turn_offset
 
     # EMIT IMMEDIATELY for real-time streaming - do this BEFORE database access
     # Artifact chunks with append=true need to appear on the client immediately
     is_streaming_chunk = response_data.get("kind") == "artifact-update" and response_data.get("append")
     if is_streaming_chunk:
         logger.info(
-            f"[STREAMING] Emitting artifact chunk immediately: sid={sid}, "
+            f"[STREAMING] Emitting artifact chunk immediately: target={emit_target}, "
             f"append={response_data.get('append')}, last_chunk={response_data.get('lastChunk')}, context={effective_context_id}"
         )
-        await sio.emit(SocketEvents.AGENT_RESPONSE, response_data, to=sid)
+        await sio.emit(SocketEvents.AGENT_RESPONSE, response_data, to=emit_target)
         await _emit_debug_log(sid, response_id, "artifact_chunk", response_data)
         # Don't return yet - we still need to accumulate for persistence below
 
@@ -803,15 +856,19 @@ async def _process_a2a_response(
                 status_obj = response_data.get("status", {})
                 status_state = _short_state_name(status_obj.get("state")) if isinstance(status_obj, dict) else None
 
-                # Accumulate streaming artifact text for persistence.
-                # Individual chunks are transient (not saved to DB); the assembled
-                # content is persisted when last_chunk arrives.
-                # Use is_artifact_update (not is_artifact_append): the FIRST chunk of an
-                # artifact is append=False (it creates the artifact). It must be
-                # accumulated with the rest — otherwise it falls through to
-                # save_agent_response as its own standalone message and the content is
-                # split into two messages, which reload renders as two fragments
-                # (e.g. an orchestrator thought split mid-sentence).
+                # Capture a pending interactive prompt (HITL / feedback-request) so a client
+                # that (re)subscribes mid-turn can restore a prompt that arrived while it was
+                # disconnected — otherwise the turn hangs on input the user never saw. Kept in
+                # memory keyed by conversation; cleared when the turn ends without asking.
+                if is_feedback_request or status_state == "input-required":
+                    _pending_interactions[effective_context_id] = response_data
+
+                # Orchestrator reply chunks are accumulated into _streaming_buffers earlier
+                # (see _accumulate_reply_buffer, before the emit) so the resumable snapshot
+                # and the live chunk offsets stay consistent. Here we only accumulate
+                # intermediate output (sub-agent thoughts), which is persisted at turn end
+                # so reasoning blocks survive page reload. The FIRST artifact chunk has
+                # append=False (it creates the artifact); it is buffered the same way.
                 if is_artifact_update:
                     artifact = response_data.get("artifact", {})
                     artifact_metadata = artifact.get("metadata", {}) if isinstance(artifact, dict) else {}
@@ -819,26 +876,7 @@ async def _process_a2a_response(
                     artifact_extensions = artifact.get("extensions", []) if isinstance(artifact, dict) else []
                     is_intermediate_output = "urn:nannos:a2a:intermediate-output:1.0" in artifact_extensions
 
-                    if not is_intermediate_output:
-                        # Only accumulate orchestrator content, not intermediate output
-                        parts = artifact.get("parts", []) if isinstance(artifact, dict) else []
-                        chunk_text = "".join(p.get("text", "") for p in parts if isinstance(p, dict) and p.get("text"))
-
-                        # Always update buffer on artifact-append, even if chunk is empty (for last_chunk handling)
-                        current_buffer = _streaming_buffers.get(effective_context_id, "")
-                        _streaming_buffers[effective_context_id] = current_buffer + chunk_text
-                        if chunk_text:  # Only log if there's actual content
-                            logger.info(
-                                f"[STREAMING] Accumulated chunk ({len(chunk_text)} chars) for context {effective_context_id}. "
-                                f"Total buffer: {len(_streaming_buffers[effective_context_id])} chars. last_chunk={is_last_chunk}. "
-                                f"chunk_preview: {chunk_text[:50]}..."
-                            )
-                        elif is_last_chunk:
-                            logger.info(
-                                f"[STREAMING] Received final empty chunk for context {effective_context_id}. "
-                                f"Buffer size: {len(_streaming_buffers[effective_context_id])} chars"
-                            )
-                    else:
+                    if is_intermediate_output:
                         # Accumulate intermediate output for persistence at turn end
                         parts = artifact.get("parts", []) if isinstance(artifact, dict) else []
                         chunk_text = "".join(p.get("text", "") for p in parts if isinstance(p, dict) and p.get("text"))
@@ -928,6 +966,12 @@ async def _process_a2a_response(
                             f"kind={response_data.get('kind')}, append={response_data.get('append')}"
                         )
 
+                    # The turn ended: clear any pending interactive prompt unless it ended
+                    # BY asking for input (input-required), in which case the prompt must
+                    # persist for a mid-turn (re)subscribe to restore.
+                    if status_state != "input-required" and not is_feedback_request:
+                        _pending_interactions.pop(effective_context_id, None)
+
                 # ── Persist non-streaming responses ──
                 # Skip: work-plan (transient), artifact chunks (accumulated above),
                 # bare completion signals (no content to save), safety-net (already saved).
@@ -967,8 +1011,8 @@ async def _process_a2a_response(
 
     # Emit the response to the client (skip if already emitted as streaming chunk)
     if not is_streaming_chunk:
-        logger.info(f"[BACKEND_RESPONSE] Emitting response: sid={sid}, kind={response_data.get('kind')}")
-        await sio.emit(SocketEvents.AGENT_RESPONSE, response_data, to=sid)
+        logger.info(f"[BACKEND_RESPONSE] Emitting response: target={emit_target}, kind={response_data.get('kind')}")
+        await sio.emit(SocketEvents.AGENT_RESPONSE, response_data, to=emit_target)
     else:
         logger.debug(
             f"[BACKEND_RESPONSE] Skipping double-emit for streaming chunk: sid={sid}, kind={response_data.get('kind')}, append={response_data.get('append')}"
@@ -1601,7 +1645,7 @@ async def _send_steering_message_to_agent(
                 "steering": True,
                 "status": {"state": "accepted"},
             },
-            to=sid,
+            to=_conversation_room(message.context_id) if message.context_id else sid,
         )
         return create_success_response({"id": message_id, "steering": True})
 
@@ -1679,6 +1723,11 @@ async def handle_send_message(sid: str, json_data: dict[str, Any]) -> dict[str, 
             error_response["id"] = message_id
             await sio.emit(SocketEvents.AGENT_RESPONSE, error_response, to=sid)
             return error_response
+
+        # Join the conversation room so this connection receives the turn's stream by
+        # conversation (not by sid). Keeps delivery working for the sending client even
+        # before it issues an explicit subscribe, and lets the stream survive reconnects.
+        await sio.enter_room(sid, _conversation_room(context_id))
 
         metadata = json_data.get("metadata", {})
         if not isinstance(metadata, dict):
@@ -1856,6 +1905,72 @@ async def handle_cancel_task(sid: str, json_data: dict[str, Any]) -> dict[str, A
         logger.info(f"No active task to cancel for sid={sid}, conversationId={conversation_id}")
 
     return create_success_response({"cancelled": task_info is not None})
+
+
+def _has_active_turn(conversation_id: str) -> bool:
+    """Whether a turn is currently streaming for this conversation on this pod."""
+    if conversation_id in _streaming_buffers or conversation_id in _pending_interactions:
+        return True
+    suffix = f":{conversation_id}"
+    return any(key.endswith(suffix) for key in active_tasks)
+
+
+@sio.on(SocketEvents.SUBSCRIBE_CONVERSATION)  # type: ignore
+@require_socket_auth(sio)
+async def handle_subscribe_conversation(sid: str, json_data: dict[str, Any]) -> dict[str, Any] | None:
+    """Join the conversation's stream room and return a snapshot of any in-flight turn.
+
+    Lets a client resume after a reconnect or page reload (new sid): it rejoins the room
+    to receive live chunks, and the snapshot backfills the reply produced while it was
+    away plus any pending interactive (HITL) prompt. Membership is gated on the same
+    conversation-ownership check used on the persistence path.
+    """
+    conversation_id = json_data.get("conversationId")
+    if not conversation_id:
+        return create_error_response(SocketError.MSG_SEND_FAILED, details={"reason": "conversationId is required"})
+
+    socket_session = await sio.app_instance.state.socket_session_service.get_session(sid)  # type: ignore[attr-defined]
+    if not socket_session or not socket_session.user_id:
+        return create_error_response(SocketError.SESSION_NOT_FOUND, details={"reason": "Client session not found."})
+
+    # Authorize: the subscriber must own the conversation.
+    conversation_service = sio.app_instance.state.conversation_service  # type: ignore[attr-defined]
+    conversation = await conversation_service.get_conversation(
+        conversation_id=conversation_id,
+        user_id=socket_session.user_id,
+    )
+    if not conversation:
+        logger.warning(
+            f"Subscribe rejected: conversation {conversation_id} not owned by user {socket_session.user_id} (sid={sid})"
+        )
+        return create_error_response(SocketError.MSG_SEND_FAILED, details={"reason": "Conversation not found"})
+
+    # Enter the room BEFORE reading the snapshot: any reply chunk emitted after this point
+    # is delivered live, and any chunk already accounted for is reflected in the snapshot
+    # offset — so the client dedupes cleanly with no gap and no double-count.
+    await sio.enter_room(sid, _conversation_room(conversation_id))
+
+    reply = _streaming_buffers.get(conversation_id)
+    pending = _pending_interactions.get(conversation_id)
+    snapshot = {
+        "conversationId": conversation_id,
+        "inFlight": _has_active_turn(conversation_id),
+        "offset": len(reply) if reply is not None else 0,
+        "replyText": reply or "",
+        "pendingHitl": pending,
+    }
+    await sio.emit(SocketEvents.CONVERSATION_SNAPSHOT, snapshot, to=sid)
+    return create_success_response({"subscribed": True, "inFlight": snapshot["inFlight"]})
+
+
+@sio.on(SocketEvents.UNSUBSCRIBE_CONVERSATION)  # type: ignore
+@require_socket_auth(sio)
+async def handle_unsubscribe_conversation(sid: str, json_data: dict[str, Any]) -> dict[str, Any] | None:
+    """Leave a conversation's stream room (e.g. the user switched conversations)."""
+    conversation_id = json_data.get("conversationId")
+    if conversation_id:
+        await sio.leave_room(sid, _conversation_room(conversation_id))
+    return create_success_response({"unsubscribed": True})
 
 
 # ==============================================================================

--- a/packages/console-backend/app.py
+++ b/packages/console-backend/app.py
@@ -535,8 +535,16 @@ class ActiveTaskInfo:
     asyncio_task: asyncio.Task[Any]
     a2a_client: Client | None = None
     a2a_task_id: str | None = None
+    # The connection that started the turn. The turn is keyed by conversation (so it
+    # survives that connection dropping and can be steered/cancelled from any later
+    # connection), but its httpx/A2A client belongs to origin_sid's connection-pool
+    # entry — so deferred cleanup must keep that entry alive until the task finishes.
+    origin_sid: str | None = None
 
 
+# Active turns keyed by conversation_id (== A2A context_id): a turn is owned by the
+# conversation, not the connection, so a reconnected client can steer/cancel it and
+# at most one turn runs per conversation (a concurrent send becomes steering).
 active_tasks: dict[str, ActiveTaskInfo] = {}
 
 # Buffer for accumulating streaming artifact chunks per conversation.
@@ -661,13 +669,12 @@ async def _cancel_active_task(task_info: ActiveTaskInfo, key: str, reason: str) 
 
 
 async def _deferred_connection_cleanup(sid: str) -> None:
-    """Wait for all tasks of a disconnected socket to finish, then clean up the connection pool."""
-    prefix = f"{sid}:"
+    """Wait for all tasks started by a disconnected socket to finish, then clean up its connection."""
     while True:
         running = [
             info.asyncio_task
-            for key, info in active_tasks.items()
-            if key.startswith(prefix) and not info.asyncio_task.done()
+            for info in active_tasks.values()
+            if info.origin_sid == sid and not info.asyncio_task.done()
         ]
         if not running:
             break
@@ -1245,11 +1252,10 @@ async def handle_disconnect(sid: str, reason: str | None = None) -> None:
     # the httpx client backs the SSE stream the task is consuming.  We schedule
     # deferred cleanup so the connection is removed once all tasks finish.
     has_running_tasks = False
-    prefix = f"{sid}:"
     for key in list(active_tasks.keys()):
-        if key.startswith(prefix):
-            task_info = active_tasks.get(key)
-            if task_info and not task_info.asyncio_task.done():
+        task_info = active_tasks.get(key)
+        if task_info and task_info.origin_sid == sid:
+            if not task_info.asyncio_task.done():
                 has_running_tasks = True
             else:
                 active_tasks.pop(key, None)
@@ -1817,14 +1823,16 @@ async def handle_send_message(sid: str, json_data: dict[str, Any]) -> dict[str, 
             metadata=metadata,
         )
 
-        task_key = f"{sid}:{context_id}"
+        # Turns are keyed by conversation, not connection, so a turn started on one
+        # socket can be steered/cancelled after a reconnect (new sid).
+        task_key = context_id
 
-        # Steering: if there's already an active task for this context_id,
-        # send as a steering message (continuous interaction turn) instead
-        # of starting a new full stream.
+        # Steering: if there's already an active turn for this conversation (from this
+        # or a previous connection), send as a steering message (continuous interaction
+        # turn) instead of starting a second full stream.
         existing_task = active_tasks.get(task_key)
         if existing_task is not None and not existing_task.asyncio_task.done():
-            logger.info(f"[STEERING] Active task detected for {task_key}, routing as steering message")
+            logger.info(f"[STEERING] Active turn detected for conversation {task_key}, routing as steering message")
             return await _send_steering_message_to_agent(a2a_client, message, sid, message_id, sio)
 
         send_task = asyncio.create_task(
@@ -1835,17 +1843,18 @@ async def handle_send_message(sid: str, json_data: dict[str, Any]) -> dict[str, 
         active_tasks[task_key] = ActiveTaskInfo(
             asyncio_task=send_task,
             a2a_client=a2a_client,
+            origin_sid=sid,
         )
         try:
             return await send_task
         except asyncio.CancelledError:
-            logger.info(f"Send message task cancelled: sid={sid}, context_id={context_id}")
+            logger.info(f"Send message task cancelled: context_id={context_id}")
             cancelled_response = {
                 "id": message_id,
                 "contextId": context_id,
                 "status": {"state": "cancelled"},
             }
-            await sio.emit(SocketEvents.AGENT_RESPONSE, cancelled_response, to=sid)
+            await sio.emit(SocketEvents.AGENT_RESPONSE, cancelled_response, to=_conversation_room(context_id))
             return cancelled_response
         finally:
             active_tasks.pop(task_key, None)
@@ -1915,31 +1924,45 @@ async def handle_send_message(sid: str, json_data: dict[str, Any]) -> dict[str, 
 async def handle_cancel_task(sid: str, json_data: dict[str, Any]) -> dict[str, Any] | None:
     """Handle the 'cancel_task' socket.io event.
 
-    Cancels an active send_message task for the given conversation.
+    Cancels the active turn for the given conversation. The turn is keyed by
+    conversation (not the connection), so a reconnected client can cancel a turn it
+    started earlier — but only for a conversation it owns.
     """
     conversation_id = json_data.get("conversationId")
     if not conversation_id:
         return create_error_response(SocketError.MSG_SEND_FAILED, details={"reason": "Missing conversationId"})
 
-    # Look up the task by sid + conversationId (the same value used as
-    # context_id when the task was created in handle_send_message).
-    task_key = f"{sid}:{conversation_id}"
-    task_info = active_tasks.pop(task_key, None)
-    if task_info:
-        await _cancel_active_task(task_info, task_key, reason="user requested")
+    # Ownership check: cancel is keyed by conversation_id alone, so verify the caller
+    # owns it — otherwise any authenticated user could cancel another user's turn.
+    socket_session = await sio.app_instance.state.socket_session_service.get_session(sid)  # type: ignore[attr-defined]
+    if not socket_session or not socket_session.user_id:
+        return create_error_response(SocketError.SESSION_NOT_FOUND, details={"reason": "Client session not found."})
+    conversation = await sio.app_instance.state.conversation_service.get_conversation(  # type: ignore[attr-defined]
+        conversation_id=conversation_id,
+        user_id=socket_session.user_id,
+    )
+    if not conversation:
+        logger.warning(
+            f"Cancel rejected: conversation {conversation_id} not owned by user {socket_session.user_id} (sid={sid})"
+        )
+        return create_error_response(SocketError.MSG_SEND_FAILED, details={"reason": "Conversation not found"})
 
-    if not task_info:
-        logger.info(f"No active task to cancel for sid={sid}, conversationId={conversation_id}")
+    task_info = active_tasks.pop(conversation_id, None)
+    if task_info:
+        await _cancel_active_task(task_info, conversation_id, reason="user requested")
+    else:
+        logger.info(f"No active turn to cancel for conversation {conversation_id}")
 
     return create_success_response({"cancelled": task_info is not None})
 
 
 def _has_active_turn(conversation_id: str) -> bool:
     """Whether a turn is currently streaming for this conversation on this pod."""
-    if conversation_id in _streaming_buffers or conversation_id in _pending_interactions:
-        return True
-    suffix = f":{conversation_id}"
-    return any(key.endswith(suffix) for key in active_tasks)
+    return (
+        conversation_id in active_tasks
+        or conversation_id in _streaming_buffers
+        or conversation_id in _pending_interactions
+    )
 
 
 @sio.on(SocketEvents.SUBSCRIBE_CONVERSATION)  # type: ignore

--- a/packages/console-backend/app.py
+++ b/packages/console-backend/app.py
@@ -1724,11 +1724,6 @@ async def handle_send_message(sid: str, json_data: dict[str, Any]) -> dict[str, 
             await sio.emit(SocketEvents.AGENT_RESPONSE, error_response, to=sid)
             return error_response
 
-        # Join the conversation room so this connection receives the turn's stream by
-        # conversation (not by sid). Keeps delivery working for the sending client even
-        # before it issues an explicit subscribe, and lets the stream survive reconnects.
-        await sio.enter_room(sid, _conversation_room(context_id))
-
         metadata = json_data.get("metadata", {})
         if not isinstance(metadata, dict):
             metadata = {}
@@ -1766,6 +1761,38 @@ async def handle_send_message(sid: str, json_data: dict[str, Any]) -> dict[str, 
         # Get services
         conversation_service: ConversationService = sio.app_instance.state.conversation_service  # type: ignore[attr-defined]
         messages_service: MessagesService = sio.app_instance.state.messages_service  # type: ignore[attr-defined]
+
+        # Enforce conversation ownership BEFORE joining its stream room or forwarding to the
+        # orchestrator. The sender must own the conversation, or it must be new (created here
+        # under the sender). get_or_create raises for a conversation_id owned by another user
+        # (PK conflict on insert), so we fail closed — otherwise a caller could join a victim's
+        # room and eavesdrop the stream, or run a turn on the victim's orchestrator thread.
+        # (_save_user_message_to_db calls get_or_create again idempotently.)
+        sub_agent_config_hash = metadata.get("subAgentConfigHash") if isinstance(metadata, dict) else None
+        try:
+            await conversation_service.get_or_create_conversation(
+                conversation_id=context_id,
+                user_id=socket_session.user_id,
+                agent_url=socket_session.agent_url or "",
+                message=message_text,
+                sub_agent_config_hash=sub_agent_config_hash,
+            )
+        except Exception:
+            logger.warning(
+                f"send_message rejected: conversation {context_id} is not owned by user "
+                f"{socket_session.user_id} (sid={sid})"
+            )
+            error_response = create_error_response(
+                SocketError.MSG_SEND_FAILED, details={"reason": "Conversation not found"}
+            )
+            error_response["id"] = message_id
+            await sio.emit(SocketEvents.AGENT_RESPONSE, error_response, to=sid)
+            return error_response
+
+        # Ownership confirmed — safe to join the conversation's stream room. Keeps delivery
+        # working for this connection before it issues an explicit subscribe, and lets the
+        # stream survive reconnects.
+        await sio.enter_room(sid, _conversation_room(context_id))
 
         # Save message to database
         await _save_user_message_to_db(

--- a/packages/console-backend/app.py
+++ b/packages/console-backend/app.py
@@ -702,6 +702,7 @@ async def _process_a2a_response(
     sid: str,
     request_id: str,
     context_id: str | None = None,
+    user_id: str | None = None,
 ) -> None:
     """Processes a response from the A2A client, validates it, and emits events.
 
@@ -713,6 +714,8 @@ async def _process_a2a_response(
     sid: The session ID associated with the original request.
     request_id: The unique ID of the original request.
     context_id: The context ID (conversation ID) from the original message request.
+    user_id: The owning user's id, captured at Turn start. Used for persistence so
+        the Turn's reply is saved even after the originating socket session is gone.
     """
     # The response payload 'event' (Task, Message, etc.) may have its own 'id',
     # which can differ from the JSON-RPC request/response 'id'. We prioritize
@@ -762,19 +765,22 @@ async def _process_a2a_response(
 
     if effective_context_id:
         try:
-            socket_session = await sio.app_instance.state.socket_session_service.get_session(sid)  # type: ignore[attr-defined]
-            if socket_session:
+            # Persist under the Turn's captured user_id: identity is bound to
+            # (user_id, conversation_id) at Turn start, NOT to the ephemeral socket
+            # session — which is destroyed on disconnect. This lets a Turn that
+            # outlives its originating connection still persist its reply.
+            if user_id:
                 # Verify conversation exists and belongs to user
                 conversation_service = sio.app_instance.state.conversation_service  # type: ignore[attr-defined]
 
                 conversation = await conversation_service.get_conversation(
                     conversation_id=effective_context_id,
-                    user_id=socket_session.user_id,
+                    user_id=user_id,
                 )
 
                 if not conversation:
                     raise ConversationOwnershipError(
-                        f"Conversation {effective_context_id} does not exist or does not belong to user {socket_session.user_id}"
+                        f"Conversation {effective_context_id} does not exist or does not belong to user {user_id}"
                     )
 
                 messages_service = sio.app_instance.state.messages_service  # type: ignore[attr-defined]
@@ -864,7 +870,7 @@ async def _process_a2a_response(
                     await _flush_intermediate_buffers(
                         effective_context_id,
                         messages_service,
-                        socket_session.user_id,
+                        user_id,
                         task_id=task_id,
                     )
 
@@ -880,7 +886,7 @@ async def _process_a2a_response(
                                 )
                                 saved_msg = await messages_service.insert_message(
                                     conversation_id=effective_context_id,
-                                    user_id=socket_session.user_id,
+                                    user_id=user_id,
                                     role="assistant",
                                     parts=[{"kind": "text", "text": accumulated}],
                                     task_id=task_id,
@@ -899,7 +905,7 @@ async def _process_a2a_response(
                                 )
                                 saved_msg = await messages_service.insert_message(
                                     conversation_id=effective_context_id,
-                                    user_id=socket_session.user_id,
+                                    user_id=user_id,
                                     role="assistant",
                                     parts=[{"kind": "text", "text": accumulated}],
                                     task_id=task_id,
@@ -942,7 +948,7 @@ async def _process_a2a_response(
                     await messages_service.save_agent_response(
                         response_data=response_data,
                         conversation_id=effective_context_id,
-                        user_id=socket_session.user_id,
+                        user_id=user_id,
                     )
         except ConversationOwnershipError as ownership_error:
             logger.error(
@@ -1488,6 +1494,7 @@ async def _send_message_to_agent(
     message_id: str,
     sio: socketio.AsyncServer,
     task_key: str | None = None,
+    user_id: str | None = None,
 ) -> dict[str, Any] | None:
     """Send message to agent via A2A client and process stream response.
 
@@ -1498,6 +1505,8 @@ async def _send_message_to_agent(
         message_id: Message ID
         sio: Socket.IO server
         task_key: Key in active_tasks to update with A2A task_id from stream
+        user_id: Owning user's id, captured at Turn start; threaded to persistence
+            so the reply is saved even if the originating socket session is gone.
 
     Returns:
         Success response or error response if HTTP error occurs
@@ -1531,7 +1540,7 @@ async def _send_message_to_agent(
                 if artifact.HasField("metadata"):
                     logger.info(f"[BACKEND_STREAM] artifact-update metadata: {MessageToDict(artifact.metadata)}")
 
-            await _process_a2a_response(stream_result, sid, message_id, message.context_id)
+            await _process_a2a_response(stream_result, sid, message_id, message.context_id, user_id=user_id)
 
         logger.info(f"[BACKEND_STREAM] Stream complete - received {stream_item_count} total items")
         return create_success_response({"id": message_id})
@@ -1743,7 +1752,9 @@ async def handle_send_message(sid: str, json_data: dict[str, Any]) -> dict[str, 
             return await _send_steering_message_to_agent(a2a_client, message, sid, message_id, sio)
 
         send_task = asyncio.create_task(
-            _send_message_to_agent(a2a_client, message, sid, message_id, sio, task_key=task_key)
+            _send_message_to_agent(
+                a2a_client, message, sid, message_id, sio, task_key=task_key, user_id=socket_session.user_id
+            )
         )
         active_tasks[task_key] = ActiveTaskInfo(
             asyncio_task=send_task,

--- a/packages/console-backend/app.py
+++ b/packages/console-backend/app.py
@@ -507,7 +507,13 @@ async def _mcp_streamable_asgi(scope: Scope, receive: Receive, send: Send) -> No
 
 
 app.mount("/mcp", _mcp_streamable_asgi)
-# Initialize Socket.IO server with optimized settings
+# Initialize Socket.IO server with optimized settings.
+# NOTE: no cross-node client_manager (Redis/pub-sub) — conversation rooms, active_tasks,
+# and the in-memory turn buffers are per-process. Stream resume and the one-turn-per-
+# conversation guard therefore assume a client's reconnect lands on the SAME pod (session
+# affinity). Scaling to multiple replicas without affinity + a cross-pod adapter would make
+# a reconnect that lands elsewhere see an empty snapshot and could start a second turn on
+# the same orchestrator thread. Cross-pod coordination is planned (Postgres lease-lock).
 sio = socketio.AsyncServer(
     async_mode="asgi",
     cors_allowed_origins=cors_origins,
@@ -603,6 +609,23 @@ def _accumulate_reply_buffer(context_id: str, response_data: dict[str, Any]) -> 
     # offset is defined for every emitted reply chunk.
     _streaming_buffers[context_id] = _streaming_buffers.get(context_id, "") + chunk_text
     return len(_streaming_buffers[context_id])
+
+
+def _clear_turn_state(context_id: str) -> None:
+    """Drop all in-memory turn state for a conversation.
+
+    Called from the single turn exit point (handle_send_message's finally) so the state
+    is cleared on EVERY termination path — normal completion, cancel, and error — not only
+    the turn-ending event inside _process_a2a_response. Without this, a cancelled or
+    errored turn leaves residue in these dicts and _has_active_turn reports the
+    conversation as permanently in-flight (stale snapshot / stuck spinner on reload).
+    """
+    _streaming_buffers.pop(context_id, None)
+    _pending_interactions.pop(context_id, None)
+    prefix = f"{context_id}:"
+    for key in [k for k in _intermediate_buffers if k.startswith(prefix)]:
+        _intermediate_buffers.pop(key, None)
+        _intermediate_buffer_ts.pop(key, None)
 
 
 # ==============================================================================
@@ -1449,18 +1472,8 @@ async def _save_user_message_to_db(
         if not socket_session or not socket_session.user_id:
             raise ValueError("Socket session or user ID is missing")
 
-        sub_agent_config_hash = metadata.get("subAgentConfigHash") if isinstance(metadata, dict) else None
-        logger.info(
-            f"Creating/getting conversation {context_id} with sub_agent_config_hash={sub_agent_config_hash}, metadata={metadata}"
-        )
-
-        await conversation_service.get_or_create_conversation(
-            conversation_id=context_id,
-            user_id=socket_session.user_id,
-            agent_url=socket_session.agent_url or "",
-            message=message_text,
-            sub_agent_config_hash=sub_agent_config_hash,
-        )
+        # The conversation is already created/ownership-verified by the caller's ownership
+        # gate (handle_send_message) before this runs, so we don't get_or_create again here.
 
         # Build parts array: text part (if non-empty) + file parts (if any)
         parts = []
@@ -1857,7 +1870,11 @@ async def handle_send_message(sid: str, json_data: dict[str, Any]) -> dict[str, 
             await sio.emit(SocketEvents.AGENT_RESPONSE, cancelled_response, to=_conversation_room(context_id))
             return cancelled_response
         finally:
+            # Single teardown point for the turn: clear task tracking AND all in-memory
+            # turn state on every exit (completion, cancel, error) so the conversation
+            # doesn't stay falsely "in-flight" (stale resume snapshot / stuck spinner).
             active_tasks.pop(task_key, None)
+            _clear_turn_state(context_id)
 
     except ValueError as e:
         # Validation errors - send specific error details
@@ -1919,6 +1936,22 @@ async def handle_send_message(sid: str, json_data: dict[str, Any]) -> dict[str, 
         return error_response
 
 
+async def _authorized_conversation(sid: str, conversation_id: str) -> Any | None:
+    """Return the conversation iff the socket's authenticated user owns it, else None.
+
+    Shared read-only ownership gate for handlers acting on an EXISTING conversation
+    (subscribe, cancel). The send path uses get_or_create instead, since it may
+    legitimately create a brand-new conversation under the sender.
+    """
+    socket_session = await sio.app_instance.state.socket_session_service.get_session(sid)  # type: ignore[attr-defined]
+    if not socket_session or not socket_session.user_id:
+        return None
+    return await sio.app_instance.state.conversation_service.get_conversation(  # type: ignore[attr-defined]
+        conversation_id=conversation_id,
+        user_id=socket_session.user_id,
+    )
+
+
 @sio.on(SocketEvents.CANCEL_TASK)  # type: ignore
 @require_socket_auth(sio)
 async def handle_cancel_task(sid: str, json_data: dict[str, Any]) -> dict[str, Any] | None:
@@ -1934,17 +1967,8 @@ async def handle_cancel_task(sid: str, json_data: dict[str, Any]) -> dict[str, A
 
     # Ownership check: cancel is keyed by conversation_id alone, so verify the caller
     # owns it — otherwise any authenticated user could cancel another user's turn.
-    socket_session = await sio.app_instance.state.socket_session_service.get_session(sid)  # type: ignore[attr-defined]
-    if not socket_session or not socket_session.user_id:
-        return create_error_response(SocketError.SESSION_NOT_FOUND, details={"reason": "Client session not found."})
-    conversation = await sio.app_instance.state.conversation_service.get_conversation(  # type: ignore[attr-defined]
-        conversation_id=conversation_id,
-        user_id=socket_session.user_id,
-    )
-    if not conversation:
-        logger.warning(
-            f"Cancel rejected: conversation {conversation_id} not owned by user {socket_session.user_id} (sid={sid})"
-        )
+    if not await _authorized_conversation(sid, conversation_id):
+        logger.warning(f"Cancel rejected: conversation {conversation_id} not owned (sid={sid})")
         return create_error_response(SocketError.MSG_SEND_FAILED, details={"reason": "Conversation not found"})
 
     task_info = active_tasks.pop(conversation_id, None)
@@ -1979,20 +2003,9 @@ async def handle_subscribe_conversation(sid: str, json_data: dict[str, Any]) -> 
     if not conversation_id:
         return create_error_response(SocketError.MSG_SEND_FAILED, details={"reason": "conversationId is required"})
 
-    socket_session = await sio.app_instance.state.socket_session_service.get_session(sid)  # type: ignore[attr-defined]
-    if not socket_session or not socket_session.user_id:
-        return create_error_response(SocketError.SESSION_NOT_FOUND, details={"reason": "Client session not found."})
-
     # Authorize: the subscriber must own the conversation.
-    conversation_service = sio.app_instance.state.conversation_service  # type: ignore[attr-defined]
-    conversation = await conversation_service.get_conversation(
-        conversation_id=conversation_id,
-        user_id=socket_session.user_id,
-    )
-    if not conversation:
-        logger.warning(
-            f"Subscribe rejected: conversation {conversation_id} not owned by user {socket_session.user_id} (sid={sid})"
-        )
+    if not await _authorized_conversation(sid, conversation_id):
+        logger.warning(f"Subscribe rejected: conversation {conversation_id} not owned (sid={sid})")
         return create_error_response(SocketError.MSG_SEND_FAILED, details={"reason": "Conversation not found"})
 
     # Enter the room BEFORE reading the snapshot: any reply chunk emitted after this point

--- a/packages/console-backend/console_backend/services/in_memory_conversation_service.py
+++ b/packages/console-backend/console_backend/services/in_memory_conversation_service.py
@@ -8,6 +8,7 @@ import logging
 import uuid
 from datetime import datetime, timezone
 
+from ..exceptions import ConversationOwnershipError
 from ..models.conversation import Conversation
 
 logger = logging.getLogger(__name__)
@@ -68,6 +69,13 @@ class InMemoryConversationService:
     ) -> Conversation:
         now = datetime.now(timezone.utc)
         cid = conversation_id or _uuid7_str()
+
+        # Mirror the PostgreSQL PK constraint: creating a conversation_id that already
+        # exists (necessarily under another user — get_conversation filters by owner)
+        # must fail closed, not silently rebind the conversation to the new user.
+        existing = self._conversations.get(cid)
+        if existing and existing.user_id != user_id:
+            raise ConversationOwnershipError(f"Conversation {cid} is owned by another user")
 
         conv = Conversation(
             conversation_id=cid,

--- a/packages/console-backend/console_backend/utils/socket_events.py
+++ b/packages/console-backend/console_backend/utils/socket_events.py
@@ -17,6 +17,14 @@ class SocketEvents:
     AGENT_RESPONSE = "agent_response"
     CANCEL_TASK = "cancel_task"
 
+    # Conversation stream subscription (resume after reconnect / reload; multi-tab)
+    # A client joins the room for the conversation it is viewing; the backend delivers
+    # a conversation's live stream to that room (keyed by conversation_id) rather than
+    # to a single ephemeral connection, and replies with a snapshot of any in-flight turn.
+    SUBSCRIBE_CONVERSATION = "subscribe_conversation"
+    UNSUBSCRIBE_CONVERSATION = "unsubscribe_conversation"
+    CONVERSATION_SNAPSHOT = "conversation_snapshot"
+
     # Debugging
     DEBUG_LOG = "debug_log"
 

--- a/packages/console-backend/tests/test_socket_message_handling.py
+++ b/packages/console-backend/tests/test_socket_message_handling.py
@@ -105,7 +105,11 @@ async def test_process_a2a_response_receives_context_id():
 
         # Call _process_a2a_response with context_id
         await _process_a2a_response(
-            client_event=StreamResponse(message=message), sid="test-sid", request_id="req-1", context_id="conv-context-123"
+            client_event=StreamResponse(message=message),
+            sid="test-sid",
+            request_id="req-1",
+            context_id="conv-context-123",
+            user_id="user-1",
         )
 
         # Verify conversation service was called to check ownership
@@ -155,6 +159,7 @@ async def test_process_a2a_response_uses_fallback_context_id():
             sid="test-sid",
             request_id="req-2",
             context_id=None,  # No context_id passed
+            user_id="user-1",
         )
 
         # Should use contextId from the message's model_dump and verify ownership
@@ -162,6 +167,56 @@ async def test_process_a2a_response_uses_fallback_context_id():
         call_kwargs = mock_sio.app_instance.state.conversation_service.get_conversation.call_args.kwargs
         assert call_kwargs["conversation_id"] == "conv-from-response-456"
         assert call_kwargs["user_id"] == "user-1"
+
+
+@pytest.mark.asyncio
+async def test_process_a2a_response_persists_when_socket_session_is_gone():
+    """A Turn must persist under its captured user_id even after the socket session is destroyed.
+
+    Regression for the disconnect data-loss bug: the orchestrator Turn keeps
+    running after the client disconnects, but the socket session is destroyed on disconnect.
+    Persistence must use the user_id captured at Turn start, NOT get_session(sid) — otherwise
+    a disconnect that outlives the Turn silently loses the reply.
+    """
+    from a2a.types import Message, Part, Role, StreamResponse
+
+    from app import _process_a2a_response
+
+    mock_sio = MagicMock()
+    mock_sio.emit = AsyncMock()
+    mock_sio.app_instance = MagicMock()
+
+    # Socket session is GONE (client disconnected; destroy_session already ran).
+    mock_sio.app_instance.state.socket_session_service.get_session = AsyncMock(return_value=None)
+    # Conversation still exists and belongs to the captured user.
+    mock_conversation = MagicMock(conversation_id="conv-disconnected", user_id="user-1")
+    mock_sio.app_instance.state.conversation_service.get_conversation = AsyncMock(return_value=mock_conversation)
+    mock_sio.app_instance.state.messages_service.save_history_messages = AsyncMock(return_value=0)
+    mock_sio.app_instance.state.messages_service.save_agent_response = AsyncMock()
+
+    with patch("app.sio", mock_sio):
+        message = Message(
+            role=Role.ROLE_AGENT,
+            parts=[Part(text="Reply produced after the client dropped")],
+            message_id="msg-after-disconnect",
+            context_id="conv-disconnected",
+        )
+
+        await _process_a2a_response(
+            client_event=StreamResponse(message=message),
+            sid="dead-sid",
+            request_id="req-dc",
+            context_id="conv-disconnected",
+            user_id="user-1",  # captured at Turn start, survives the disconnect
+        )
+
+    # Ownership checked and the reply persisted — under the captured user_id, despite no session.
+    mock_sio.app_instance.state.conversation_service.get_conversation.assert_called_once()
+    assert mock_sio.app_instance.state.conversation_service.get_conversation.call_args.kwargs["user_id"] == "user-1"
+    mock_sio.app_instance.state.messages_service.save_agent_response.assert_called_once()
+    save_kwargs = mock_sio.app_instance.state.messages_service.save_agent_response.call_args.kwargs
+    assert save_kwargs["conversation_id"] == "conv-disconnected"
+    assert save_kwargs["user_id"] == "user-1"
 
 
 @pytest.mark.asyncio
@@ -203,6 +258,7 @@ async def test_first_artifact_chunk_is_accumulated_not_persisted_standalone():
             sid="sid",
             request_id="req-fc",
             context_id="conv-firstchunk",
+            user_id="user-1",
         )
         # First chunk is accumulated for later assembly, never persisted on its own.
         mock_sio.app_instance.state.messages_service.save_agent_response.assert_not_called()

--- a/packages/console-backend/tests/test_socket_message_handling.py
+++ b/packages/console-backend/tests/test_socket_message_handling.py
@@ -112,16 +112,15 @@ async def test_process_a2a_response_receives_context_id():
             user_id="user-1",
         )
 
-        # Verify conversation service was called to check ownership
-        mock_sio.app_instance.state.conversation_service.get_conversation.assert_called_once()
-        call_kwargs = mock_sio.app_instance.state.conversation_service.get_conversation.call_args.kwargs
-        assert call_kwargs["conversation_id"] == "conv-context-123"
-        assert call_kwargs["user_id"] == "user-1"
+        # Ownership is verified once at Turn start (handle_send_message's gate), NOT
+        # re-fetched per streamed event — that would add a DB round-trip per chunk.
+        mock_sio.app_instance.state.conversation_service.get_conversation.assert_not_called()
 
-        # Verify message was saved with context_id
+        # Verify message was saved with context_id under the captured user_id
         mock_sio.app_instance.state.messages_service.save_agent_response.assert_called_once()
         save_call_kwargs = mock_sio.app_instance.state.messages_service.save_agent_response.call_args.kwargs
         assert save_call_kwargs["conversation_id"] == "conv-context-123"
+        assert save_call_kwargs["user_id"] == "user-1"
 
 
 @pytest.mark.asyncio
@@ -162,11 +161,11 @@ async def test_process_a2a_response_uses_fallback_context_id():
             user_id="user-1",
         )
 
-        # Should use contextId from the message's model_dump and verify ownership
-        mock_sio.app_instance.state.conversation_service.get_conversation.assert_called_once()
-        call_kwargs = mock_sio.app_instance.state.conversation_service.get_conversation.call_args.kwargs
-        assert call_kwargs["conversation_id"] == "conv-from-response-456"
-        assert call_kwargs["user_id"] == "user-1"
+        # Should use contextId from the message's model_dump for persistence
+        mock_sio.app_instance.state.messages_service.save_agent_response.assert_called_once()
+        save_call_kwargs = mock_sio.app_instance.state.messages_service.save_agent_response.call_args.kwargs
+        assert save_call_kwargs["conversation_id"] == "conv-from-response-456"
+        assert save_call_kwargs["user_id"] == "user-1"
 
 
 @pytest.mark.asyncio
@@ -210,9 +209,7 @@ async def test_process_a2a_response_persists_when_socket_session_is_gone():
             user_id="user-1",  # captured at Turn start, survives the disconnect
         )
 
-    # Ownership checked and the reply persisted — under the captured user_id, despite no session.
-    mock_sio.app_instance.state.conversation_service.get_conversation.assert_called_once()
-    assert mock_sio.app_instance.state.conversation_service.get_conversation.call_args.kwargs["user_id"] == "user-1"
+    # The reply persisted — under the captured user_id, despite no session.
     mock_sio.app_instance.state.messages_service.save_agent_response.assert_called_once()
     save_kwargs = mock_sio.app_instance.state.messages_service.save_agent_response.call_args.kwargs
     assert save_kwargs["conversation_id"] == "conv-disconnected"
@@ -461,6 +458,8 @@ async def test_send_message_rejects_conversation_not_owned():
     """A caller cannot send to (or join the room of, or run an orchestrator turn on) a
     conversation owned by another user. get_or_create raises on the foreign conversation_id
     and the handler fails closed — no room join, no forward to the orchestrator."""
+    from sqlalchemy.exc import IntegrityError
+
     from app import handle_send_message
 
     mock_sio = MagicMock()
@@ -471,8 +470,12 @@ async def test_send_message_rejects_conversation_not_owned():
         return_value=MagicMock(user_id="attacker", agent_url="http://agent")
     )
     # Victim owns the conversation → get_or_create raises (PK conflict on insert).
+    # Only ownership-shaped failures (IntegrityError / ConversationOwnershipError) are
+    # treated as rejections; other exceptions surface as server errors.
     mock_sio.app_instance.state.conversation_service.get_or_create_conversation = AsyncMock(
-        side_effect=Exception("duplicate key value violates unique constraint")
+        side_effect=IntegrityError(
+            "INSERT INTO conversations ...", {}, Exception("duplicate key value violates unique constraint")
+        )
     )
 
     mock_a2a_client = MagicMock()
@@ -591,3 +594,81 @@ def test_clear_turn_state_resets_in_flight_after_cancel_or_error():
         app._pending_interactions.pop("c-leak", None)
         app._intermediate_buffers.pop("c-leak:general-purpose", None)
         app._intermediate_buffer_ts.pop("c-leak:general-purpose", None)
+
+
+def test_clear_turn_state_can_preserve_pending_input_required_prompt():
+    """A turn that ends BY asking for input closes its stream (LangGraph interrupt), so
+    the teardown runs right after the prompt was captured. The teardown must be able to
+    keep the prompt — otherwise a reconnecting client's snapshot can never restore it
+    and the conversation hangs on input the user never saw."""
+    import app
+
+    app._streaming_buffers["c-hitl"] = "partial reply"
+    app._pending_interactions["c-hitl"] = {"kind": "status-update", "status": {"state": "input-required"}}
+    try:
+        assert app._pending_input_required("c-hitl") is True
+
+        app._clear_turn_state("c-hitl", preserve_pending_interaction=True)
+
+        # Buffers cleared, but the prompt survives for a mid-HITL (re)subscribe —
+        # and it alone keeps the conversation visible as in-flight for the snapshot.
+        assert "c-hitl" not in app._streaming_buffers
+        assert "c-hitl" in app._pending_interactions
+        assert app._has_active_turn("c-hitl") is True
+    finally:
+        app._streaming_buffers.pop("c-hitl", None)
+        app._pending_interactions.pop("c-hitl", None)
+
+
+def test_pending_input_required_is_false_for_feedback_requests():
+    """Only input-required prompts outlive their turn's stream; a feedback-request is a
+    mid-stream WORKING event whose turn keeps running, so it must not be preserved
+    past teardown (a stale one would be replayed on every resubscribe)."""
+    import app
+
+    app._pending_interactions["c-fb"] = {"kind": "status-update", "status": {"state": "working"}}
+    try:
+        assert app._pending_input_required("c-fb") is False
+    finally:
+        app._pending_interactions.pop("c-fb", None)
+    assert app._pending_input_required("c-missing") is False
+
+
+@pytest.mark.asyncio
+async def test_send_message_surfaces_db_errors_instead_of_conversation_not_found():
+    """A transient DB failure in the ownership gate is NOT an ownership violation: it
+    must surface as a generic send failure (retryable server error), not reject the
+    owner's send with a misleading 'Conversation not found'."""
+    from sqlalchemy.exc import OperationalError
+
+    from app import handle_send_message
+
+    mock_sio = MagicMock()
+    mock_sio.emit = AsyncMock()
+    mock_sio.enter_room = AsyncMock()
+    mock_sio.app_instance = MagicMock()
+    mock_sio.app_instance.state.socket_session_service.get_session = AsyncMock(
+        return_value=MagicMock(user_id="owner", agent_url="http://agent")
+    )
+    # Postgres blip: the pool cannot connect — nothing to do with ownership.
+    mock_sio.app_instance.state.conversation_service.get_or_create_conversation = AsyncMock(
+        side_effect=OperationalError("SELECT 1", {}, Exception("connection refused"))
+    )
+
+    mock_a2a_client = MagicMock()
+    mock_a2a_client.send_message = MagicMock()
+    mock_pool = MagicMock()
+    mock_pool.get_or_create_a2a_client = AsyncMock(return_value=mock_a2a_client)
+
+    with patch("app.sio", mock_sio), patch("app.connection_pool", mock_pool):
+        result = await handle_send_message.__wrapped__(
+            "owner-sid",
+            {"message": "hello", "conversationId": "my-conv"},
+        )
+
+    # Still fails closed (no room join, no orchestrator forward), but as a server
+    # error — not the ownership rejection.
+    mock_sio.enter_room.assert_not_called()
+    mock_a2a_client.send_message.assert_not_called()
+    assert result is not None
+    assert result.get("details", {}).get("reason") != "Conversation not found"

--- a/packages/console-backend/tests/test_socket_message_handling.py
+++ b/packages/console-backend/tests/test_socket_message_handling.py
@@ -461,7 +461,6 @@ async def test_send_message_rejects_conversation_not_owned():
     """A caller cannot send to (or join the room of, or run an orchestrator turn on) a
     conversation owned by another user. get_or_create raises on the foreign conversation_id
     and the handler fails closed — no room join, no forward to the orchestrator."""
-    import app
     from app import handle_send_message
 
     mock_sio = MagicMock()
@@ -491,3 +490,77 @@ async def test_send_message_rejects_conversation_not_owned():
     mock_sio.enter_room.assert_not_called()
     mock_a2a_client.send_message.assert_not_called()
     assert result is not None  # an error response was returned to the caller
+
+
+# ── W4: conversation-keyed cancel (survives reconnect; ownership-guarded) ─────
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_rejected_when_not_owner():
+    """Cancel is keyed by conversation_id alone, so it must verify ownership — a user
+    cannot cancel another user's turn by supplying its conversation id."""
+    import asyncio as aio
+
+    import app
+    from app import handle_cancel_task
+
+    mock_sio = MagicMock()
+    mock_sio.emit = AsyncMock()
+    mock_sio.app_instance = MagicMock()
+    mock_sio.app_instance.state.socket_session_service.get_session = AsyncMock(
+        return_value=MagicMock(user_id="attacker")
+    )
+    mock_sio.app_instance.state.conversation_service.get_conversation = AsyncMock(return_value=None)  # not owned
+
+    async def _never():
+        await aio.sleep(3600)
+
+    victim_task = aio.create_task(_never())
+    app.active_tasks["victim-conv"] = app.ActiveTaskInfo(asyncio_task=victim_task, origin_sid="victim-sid")
+    try:
+        with patch("app.sio", mock_sio):
+            await handle_cancel_task.__wrapped__("attacker-sid", {"conversationId": "victim-conv"})
+        # The victim's turn is untouched.
+        assert "victim-conv" in app.active_tasks
+        assert not victim_task.cancelled() and not victim_task.done()
+    finally:
+        victim_task.cancel()
+        app.active_tasks.pop("victim-conv", None)
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_cancels_owned_turn_from_a_different_connection():
+    """A turn is keyed by conversation, so a reconnected client (new sid) can cancel a
+    turn started by an earlier, now-dead connection."""
+    import asyncio as aio
+
+    import app
+    from app import handle_cancel_task
+
+    mock_sio = MagicMock()
+    mock_sio.emit = AsyncMock()
+    mock_sio.app_instance = MagicMock()
+    mock_sio.app_instance.state.socket_session_service.get_session = AsyncMock(
+        return_value=MagicMock(user_id="owner")
+    )
+    mock_sio.app_instance.state.conversation_service.get_conversation = AsyncMock(
+        return_value=MagicMock(user_id="owner")
+    )
+
+    async def _never():
+        await aio.sleep(3600)
+
+    task = aio.create_task(_never())
+    # Turn started by an earlier connection that has since dropped.
+    app.active_tasks["conv-x"] = app.ActiveTaskInfo(asyncio_task=task, origin_sid="old-dead-sid")
+    try:
+        with patch("app.sio", mock_sio):
+            result = await handle_cancel_task.__wrapped__("new-sid", {"conversationId": "conv-x"})
+        await aio.sleep(0)  # let the cancellation propagate
+        assert result is not None
+        assert "conv-x" not in app.active_tasks
+        assert task.cancelled() or task.done()
+    finally:
+        if not task.done():
+            task.cancel()
+        app.active_tasks.pop("conv-x", None)

--- a/packages/console-backend/tests/test_socket_message_handling.py
+++ b/packages/console-backend/tests/test_socket_message_handling.py
@@ -454,3 +454,40 @@ async def test_pending_hitl_is_captured_on_input_required_and_cleared_on_complet
             assert "conv-hitl" not in app._pending_interactions
     finally:
         app._pending_interactions.pop("conv-hitl", None)
+
+
+@pytest.mark.asyncio
+async def test_send_message_rejects_conversation_not_owned():
+    """A caller cannot send to (or join the room of, or run an orchestrator turn on) a
+    conversation owned by another user. get_or_create raises on the foreign conversation_id
+    and the handler fails closed — no room join, no forward to the orchestrator."""
+    import app
+    from app import handle_send_message
+
+    mock_sio = MagicMock()
+    mock_sio.emit = AsyncMock()
+    mock_sio.enter_room = AsyncMock()
+    mock_sio.app_instance = MagicMock()
+    mock_sio.app_instance.state.socket_session_service.get_session = AsyncMock(
+        return_value=MagicMock(user_id="attacker", agent_url="http://agent")
+    )
+    # Victim owns the conversation → get_or_create raises (PK conflict on insert).
+    mock_sio.app_instance.state.conversation_service.get_or_create_conversation = AsyncMock(
+        side_effect=Exception("duplicate key value violates unique constraint")
+    )
+
+    mock_a2a_client = MagicMock()
+    mock_a2a_client.send_message = MagicMock()  # must never be called
+    mock_pool = MagicMock()
+    mock_pool.get_or_create_a2a_client = AsyncMock(return_value=mock_a2a_client)
+
+    with patch("app.sio", mock_sio), patch("app.connection_pool", mock_pool):
+        result = await handle_send_message.__wrapped__(
+            "attacker-sid",
+            {"message": "show me the victim's context", "conversationId": "victim-conv"},
+        )
+
+    # Failed closed: not joined to the victim's room, nothing forwarded to the orchestrator.
+    mock_sio.enter_room.assert_not_called()
+    mock_a2a_client.send_message.assert_not_called()
+    assert result is not None  # an error response was returned to the caller

--- a/packages/console-backend/tests/test_socket_message_handling.py
+++ b/packages/console-backend/tests/test_socket_message_handling.py
@@ -564,3 +564,30 @@ async def test_cancel_task_cancels_owned_turn_from_a_different_connection():
         if not task.done():
             task.cancel()
         app.active_tasks.pop("conv-x", None)
+
+
+def test_clear_turn_state_resets_in_flight_after_cancel_or_error():
+    """Turn state (reply buffer, pending HITL, intermediate buffers) must be cleared on
+    every termination path — regression for cancel/error leaving a conversation falsely
+    'in-flight' forever (stale resume snapshot / stuck spinner)."""
+    import app
+
+    app._streaming_buffers["c-leak"] = "partial reply"
+    app._pending_interactions["c-leak"] = {"kind": "status-update", "status": {"state": "input-required"}}
+    app._intermediate_buffers["c-leak:general-purpose"] = "sub-agent thoughts"
+    app._intermediate_buffer_ts["c-leak:general-purpose"] = "ts"
+    try:
+        assert app._has_active_turn("c-leak") is True
+
+        app._clear_turn_state("c-leak")
+
+        assert "c-leak" not in app._streaming_buffers
+        assert "c-leak" not in app._pending_interactions
+        assert "c-leak:general-purpose" not in app._intermediate_buffers
+        assert "c-leak:general-purpose" not in app._intermediate_buffer_ts
+        assert app._has_active_turn("c-leak") is False
+    finally:
+        app._streaming_buffers.pop("c-leak", None)
+        app._pending_interactions.pop("c-leak", None)
+        app._intermediate_buffers.pop("c-leak:general-purpose", None)
+        app._intermediate_buffer_ts.pop("c-leak:general-purpose", None)

--- a/packages/console-backend/tests/test_socket_message_handling.py
+++ b/packages/console-backend/tests/test_socket_message_handling.py
@@ -307,3 +307,150 @@ def test_short_state_name_normalizes_v1_states():
     # Already-short values and non-strings pass through untouched.
     assert _short_state_name("completed") == "completed"
     assert _short_state_name(None) is None
+
+
+# ── W3: room delivery + subscribe/snapshot resume ────────────────────────────
+
+
+def test_accumulate_reply_buffer_tracks_offsets_and_skips_intermediate():
+    """The resumable buffer accumulates only orchestrator reply text and returns the
+    cumulative offset used to dedupe live chunks against a snapshot."""
+    import app
+
+    app._streaming_buffers.pop("conv-acc", None)
+
+    def artifact_event(text, intermediate=False):
+        exts = ["urn:nannos:a2a:intermediate-output:1.0"] if intermediate else []
+        return {"kind": "artifact-update", "artifact": {"parts": [{"text": text}], "extensions": exts}}
+
+    try:
+        assert app._accumulate_reply_buffer("conv-acc", artifact_event("Hello")) == 5
+        assert app._accumulate_reply_buffer("conv-acc", artifact_event(" world")) == 11
+        assert app._streaming_buffers["conv-acc"] == "Hello world"
+        # intermediate (sub-agent) output is not part of the resumable reply
+        assert app._accumulate_reply_buffer("conv-acc", artifact_event("thinking", intermediate=True)) is None
+        # non-artifact events don't contribute
+        assert app._accumulate_reply_buffer("conv-acc", {"kind": "message"}) is None
+        assert app._streaming_buffers["conv-acc"] == "Hello world"
+    finally:
+        app._streaming_buffers.pop("conv-acc", None)
+
+
+@pytest.mark.asyncio
+async def test_subscribe_conversation_returns_snapshot_and_joins_room():
+    """Subscribing to an in-flight conversation joins its room and returns a snapshot
+    of the reply-so-far plus any pending HITL prompt (resume after reconnect/reload)."""
+    import app
+    from app import handle_subscribe_conversation
+
+    mock_sio = MagicMock()
+    mock_sio.emit = AsyncMock()
+    mock_sio.enter_room = AsyncMock()
+    mock_sio.app_instance = MagicMock()
+    mock_sio.app_instance.state.socket_session_service.get_session = AsyncMock(
+        return_value=MagicMock(user_id="user-1")
+    )
+    mock_sio.app_instance.state.conversation_service.get_conversation = AsyncMock(
+        return_value=MagicMock(conversation_id="conv-sub", user_id="user-1")
+    )
+
+    app._streaming_buffers["conv-sub"] = "partial reply"
+    app._pending_interactions["conv-sub"] = {"kind": "status-update", "status": {"state": "input-required"}}
+    try:
+        with patch("app.sio", mock_sio):
+            result = await handle_subscribe_conversation.__wrapped__("sid-1", {"conversationId": "conv-sub"})
+
+        mock_sio.enter_room.assert_awaited_once_with("sid-1", "conversation:conv-sub")
+        snap_call = mock_sio.emit.call_args
+        assert snap_call.args[0] == app.SocketEvents.CONVERSATION_SNAPSHOT
+        snapshot = snap_call.args[1]
+        assert snapshot["replyText"] == "partial reply"
+        assert snapshot["offset"] == len("partial reply")
+        assert snapshot["inFlight"] is True
+        assert snapshot["pendingHitl"]["status"]["state"] == "input-required"
+        assert result is not None
+    finally:
+        app._streaming_buffers.pop("conv-sub", None)
+        app._pending_interactions.pop("conv-sub", None)
+
+
+@pytest.mark.asyncio
+async def test_subscribe_conversation_rejected_when_not_owner():
+    """A socket cannot join a conversation room it does not own — no room join, no snapshot."""
+    import app
+    from app import handle_subscribe_conversation
+
+    mock_sio = MagicMock()
+    mock_sio.emit = AsyncMock()
+    mock_sio.enter_room = AsyncMock()
+    mock_sio.app_instance = MagicMock()
+    mock_sio.app_instance.state.socket_session_service.get_session = AsyncMock(
+        return_value=MagicMock(user_id="user-1")
+    )
+    # Ownership check fails.
+    mock_sio.app_instance.state.conversation_service.get_conversation = AsyncMock(return_value=None)
+
+    with patch("app.sio", mock_sio):
+        await handle_subscribe_conversation.__wrapped__("sid-x", {"conversationId": "conv-not-mine"})
+
+    mock_sio.enter_room.assert_not_called()
+    assert all(c.args[0] != app.SocketEvents.CONVERSATION_SNAPSHOT for c in mock_sio.emit.call_args_list)
+
+
+@pytest.mark.asyncio
+async def test_pending_hitl_is_captured_on_input_required_and_cleared_on_completion():
+    """A HITL prompt (input-required) is retained for mid-turn resume, then cleared once
+    the turn completes without asking — so a stale prompt isn't replayed forever."""
+    from a2a.types import StreamResponse, TaskStatus, TaskState, TaskStatusUpdateEvent
+
+    import app
+    from app import _process_a2a_response
+
+    mock_sio = MagicMock()
+    mock_sio.emit = AsyncMock()
+    mock_sio.app_instance = MagicMock()
+    mock_sio.app_instance.state.socket_session_service.get_session = AsyncMock(
+        return_value=MagicMock(user_id="user-1")
+    )
+    mock_sio.app_instance.state.conversation_service.get_conversation = AsyncMock(
+        return_value=MagicMock(conversation_id="conv-hitl", user_id="user-1")
+    )
+    mock_sio.app_instance.state.messages_service.save_agent_response = AsyncMock()
+    mock_sio.app_instance.state.messages_service.insert_message = AsyncMock()
+
+    app._pending_interactions.pop("conv-hitl", None)
+    try:
+        with patch("app.sio", mock_sio):
+            # Orchestrator asks for input → prompt retained for resume.
+            await _process_a2a_response(
+                client_event=StreamResponse(
+                    status_update=TaskStatusUpdateEvent(
+                        task_id="t1",
+                        context_id="conv-hitl",
+                        status=TaskStatus(state=TaskState.TASK_STATE_INPUT_REQUIRED),
+                    )
+                ),
+                sid="sid",
+                request_id="req-hitl-1",
+                context_id="conv-hitl",
+                user_id="user-1",
+            )
+            assert "conv-hitl" in app._pending_interactions
+
+            # Turn later completes without asking → prompt cleared.
+            await _process_a2a_response(
+                client_event=StreamResponse(
+                    status_update=TaskStatusUpdateEvent(
+                        task_id="t1",
+                        context_id="conv-hitl",
+                        status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
+                    )
+                ),
+                sid="sid",
+                request_id="req-hitl-2",
+                context_id="conv-hitl",
+                user_id="user-1",
+            )
+            assert "conv-hitl" not in app._pending_interactions
+    finally:
+        app._pending_interactions.pop("conv-hitl", None)

--- a/packages/console-frontend/src/components/chat/contexts/ChatContext.tsx
+++ b/packages/console-frontend/src/components/chat/contexts/ChatContext.tsx
@@ -213,7 +213,17 @@ export function ChatProvider({ children, playgroundMode }: ChatProviderProps) {
   const locationRef = useRef(location);
   const navigate = useNavigate();
   const navigateRef = useRef(navigate);
-  const { isConnected, isSocketReady, initializeClient, sendMessage: socketSendMessage, cancelTask, onAgentResponse } = useSocket();
+  const {
+    isConnected,
+    isSocketReady,
+    initializeClient,
+    sendMessage: socketSendMessage,
+    cancelTask,
+    subscribeConversation,
+    unsubscribeConversation,
+    onAgentResponse,
+    onConversationSnapshot,
+  } = useSocket();
 
   // Keep refs in sync for use inside event handler closures
   useEffect(() => {
@@ -245,6 +255,9 @@ export function ChatProvider({ children, playgroundMode }: ChatProviderProps) {
   const [pendingFeedbackRequest, setPendingFeedbackRequest] = useState<{ conversationId: string; subAgents: string[] } | null>(null);
   const workingStepsMapRef = useRef<Map<string, TodoItem[]>>(new Map());
   const streamingMapRef = useRef<Map<string, string>>(new Map());
+  // Highest reply offset (cumulative char length) applied per conversation. Used to dedupe
+  // streamed chunks against a resume snapshot so reconnect/reload doesn't double-count text.
+  const lastOffsetMapRef = useRef<Map<string, number>>(new Map());
   const subagentThoughtsMapRef = useRef<Map<string, Array<{agent_name: string; content: string; complete: boolean; startedAt?: Date}>>>(new Map());
   const statusHistoryMapRef = useRef<Map<string, Array<{timestamp: Date; message: string; source?: string}>>>(new Map());
   const [isLoadingConversations, setIsLoadingConversations] = useState(false);
@@ -453,6 +466,17 @@ export function ChatProvider({ children, playgroundMode }: ChatProviderProps) {
                 thoughts.forEach(t => { t.complete = true; });
                 setSubagentThoughtsMap(new Map(subagentThoughtsMapRef.current));
               }
+              // Dedupe against a resume snapshot: turnOffset is the cumulative reply
+              // length after this chunk. Skip chunks already covered by the snapshot (or an
+              // earlier chunk) so a reconnect/reload doesn't double-append.
+              const chunkOffset = data.turnOffset;
+              const lastOffset = lastOffsetMapRef.current.get(resolvedConversationId) ?? -1;
+              if (typeof chunkOffset === 'number' && chunkOffset <= lastOffset) {
+                return;
+              }
+              if (typeof chunkOffset === 'number') {
+                lastOffsetMapRef.current.set(resolvedConversationId, chunkOffset);
+              }
               const existing = streamingMapRef.current.get(resolvedConversationId) || '';
               streamingMapRef.current.set(resolvedConversationId, existing + text);
               setStreamingMap(new Map(streamingMapRef.current));
@@ -520,6 +544,7 @@ export function ChatProvider({ children, playgroundMode }: ChatProviderProps) {
           streamingMapRef.current.delete(resolvedConversationId);
           setStreamingMap(new Map(streamingMapRef.current));
         }
+        lastOffsetMapRef.current.delete(resolvedConversationId);
       }
 
       // Handle error
@@ -638,6 +663,7 @@ export function ChatProvider({ children, playgroundMode }: ChatProviderProps) {
           // Always clear streaming buffer and waiting indicator on completion
           streamingMapRef.current.delete(resolvedConversationId);
           setStreamingMap(new Map(streamingMapRef.current));
+          lastOffsetMapRef.current.delete(resolvedConversationId);
           setWaitingMap((prev) => {
             const m = new Map(prev);
             m.delete(resolvedConversationId);
@@ -867,6 +893,35 @@ export function ChatProvider({ children, playgroundMode }: ChatProviderProps) {
 
     return unsubscribe;
   }, [onAgentResponse, addMessage, addOrUpdateTask, updateConversation, tasksMap]);
+
+  // Apply the snapshot of an in-flight turn returned when (re)subscribing to a conversation.
+  // Seeds the streaming buffer with the reply produced while the client was away and records
+  // the offset so subsequent live chunks dedupe against it. A pending HITL prompt (if any) is
+  // restored separately via the normal agent_response path (see SocketContext).
+  useEffect(() => {
+    const unsubscribe = onConversationSnapshot((snap) => {
+      if (!snap?.conversationId || !snap.inFlight) return;
+      if (typeof snap.offset === 'number') {
+        streamingMapRef.current.set(snap.conversationId, snap.replyText || '');
+        setStreamingMap(new Map(streamingMapRef.current));
+        lastOffsetMapRef.current.set(snap.conversationId, snap.offset);
+        setWaitingMap((prev) => {
+          const m = new Map(prev);
+          m.set(snap.conversationId, true);
+          return m;
+        });
+      }
+    });
+    return unsubscribe;
+  }, [onConversationSnapshot]);
+
+  // Subscribe to the active conversation's stream room, and re-subscribe on reconnect
+  // (isSocketReady flips) so an in-flight turn resumes after a drop or page reload.
+  useEffect(() => {
+    if (!isSocketReady || !activeConversationId) return;
+    subscribeConversation(activeConversationId);
+    return () => unsubscribeConversation(activeConversationId);
+  }, [isSocketReady, activeConversationId, subscribeConversation, unsubscribeConversation]);
 
   // Load conversations from backend
   const loadConversations = useCallback(async (search?: string) => {

--- a/packages/console-frontend/src/components/chat/contexts/ChatContext.tsx
+++ b/packages/console-frontend/src/components/chat/contexts/ChatContext.tsx
@@ -255,9 +255,6 @@ export function ChatProvider({ children, playgroundMode }: ChatProviderProps) {
   const [pendingFeedbackRequest, setPendingFeedbackRequest] = useState<{ conversationId: string; subAgents: string[] } | null>(null);
   const workingStepsMapRef = useRef<Map<string, TodoItem[]>>(new Map());
   const streamingMapRef = useRef<Map<string, string>>(new Map());
-  // Highest reply offset (cumulative char length) applied per conversation. Used to dedupe
-  // streamed chunks against a resume snapshot so reconnect/reload doesn't double-count text.
-  const lastOffsetMapRef = useRef<Map<string, number>>(new Map());
   const subagentThoughtsMapRef = useRef<Map<string, Array<{agent_name: string; content: string; complete: boolean; startedAt?: Date}>>>(new Map());
   const statusHistoryMapRef = useRef<Map<string, Array<{timestamp: Date; message: string; source?: string}>>>(new Map());
   const [isLoadingConversations, setIsLoadingConversations] = useState(false);
@@ -467,17 +464,15 @@ export function ChatProvider({ children, playgroundMode }: ChatProviderProps) {
                 setSubagentThoughtsMap(new Map(subagentThoughtsMapRef.current));
               }
               // Dedupe against a resume snapshot: turnOffset is the cumulative reply
-              // length after this chunk. Skip chunks already covered by the snapshot (or an
-              // earlier chunk) so a reconnect/reload doesn't double-append.
+              // length after this chunk. The client's applied offset IS the current buffer
+              // length, so we derive it rather than tracking a parallel ref (which could go
+              // stale across turns and blank the next reply). Skip any chunk already covered
+              // (turnOffset <= what we already hold) so reconnect/reload never double-appends.
+              const existing = streamingMapRef.current.get(resolvedConversationId) || '';
               const chunkOffset = data.turnOffset;
-              const lastOffset = lastOffsetMapRef.current.get(resolvedConversationId) ?? -1;
-              if (typeof chunkOffset === 'number' && chunkOffset <= lastOffset) {
+              if (typeof chunkOffset === 'number' && chunkOffset <= existing.length) {
                 return;
               }
-              if (typeof chunkOffset === 'number') {
-                lastOffsetMapRef.current.set(resolvedConversationId, chunkOffset);
-              }
-              const existing = streamingMapRef.current.get(resolvedConversationId) || '';
               streamingMapRef.current.set(resolvedConversationId, existing + text);
               setStreamingMap(new Map(streamingMapRef.current));
             }
@@ -544,7 +539,6 @@ export function ChatProvider({ children, playgroundMode }: ChatProviderProps) {
           streamingMapRef.current.delete(resolvedConversationId);
           setStreamingMap(new Map(streamingMapRef.current));
         }
-        lastOffsetMapRef.current.delete(resolvedConversationId);
       }
 
       // Handle error
@@ -663,7 +657,6 @@ export function ChatProvider({ children, playgroundMode }: ChatProviderProps) {
           // Always clear streaming buffer and waiting indicator on completion
           streamingMapRef.current.delete(resolvedConversationId);
           setStreamingMap(new Map(streamingMapRef.current));
-          lastOffsetMapRef.current.delete(resolvedConversationId);
           setWaitingMap((prev) => {
             const m = new Map(prev);
             m.delete(resolvedConversationId);
@@ -895,16 +888,20 @@ export function ChatProvider({ children, playgroundMode }: ChatProviderProps) {
   }, [onAgentResponse, addMessage, addOrUpdateTask, updateConversation, tasksMap]);
 
   // Apply the snapshot of an in-flight turn returned when (re)subscribing to a conversation.
-  // Seeds the streaming buffer with the reply produced while the client was away and records
-  // the offset so subsequent live chunks dedupe against it. A pending HITL prompt (if any) is
-  // restored separately via the normal agent_response path (see SocketContext).
+  // Seeds the streaming buffer with the reply produced while the client was away. A pending
+  // HITL prompt (if any) is restored separately via the normal agent_response path (see
+  // SocketContext). Only overwrite when the snapshot is AHEAD of what we already hold: a live
+  // chunk can race ahead of the snapshot (server enters the room, then reads the buffer), and
+  // rewinding to the shorter snapshot would drop that segment.
   useEffect(() => {
     const unsubscribe = onConversationSnapshot((snap) => {
       if (!snap?.conversationId || !snap.inFlight) return;
       if (typeof snap.offset === 'number') {
-        streamingMapRef.current.set(snap.conversationId, snap.replyText || '');
-        setStreamingMap(new Map(streamingMapRef.current));
-        lastOffsetMapRef.current.set(snap.conversationId, snap.offset);
+        const existing = streamingMapRef.current.get(snap.conversationId) || '';
+        if (snap.offset > existing.length) {
+          streamingMapRef.current.set(snap.conversationId, snap.replyText || '');
+          setStreamingMap(new Map(streamingMapRef.current));
+        }
         setWaitingMap((prev) => {
           const m = new Map(prev);
           m.set(snap.conversationId, true);

--- a/packages/console-frontend/src/components/chat/contexts/ChatContext.tsx
+++ b/packages/console-frontend/src/components/chat/contexts/ChatContext.tsx
@@ -255,6 +255,18 @@ export function ChatProvider({ children, playgroundMode }: ChatProviderProps) {
   const [pendingFeedbackRequest, setPendingFeedbackRequest] = useState<{ conversationId: string; subAgents: string[] } | null>(null);
   const workingStepsMapRef = useRef<Map<string, TodoItem[]>>(new Map());
   const streamingMapRef = useRef<Map<string, string>>(new Map());
+  // Server-side offset (Unicode code points, from the backend's turnOffset/snapshot
+  // offset) that streamingMapRef's buffer corresponds to. Kept as its own ref because
+  // JS string.length counts UTF-16 units — deriving the offset from the buffer length
+  // would disagree with the backend as soon as the reply contains an astral-plane
+  // character (emoji) and silently drop chunks. Must be cleared wherever the streaming
+  // buffer is cleared.
+  const streamingOffsetMapRef = useRef<Map<string, number>>(new Map());
+  // Mirror of waitingMap for synchronous reads inside socket-event handlers.
+  const waitingMapRef = useRef<Map<string, boolean>>(new Map());
+  useEffect(() => {
+    waitingMapRef.current = waitingMap;
+  }, [waitingMap]);
   const subagentThoughtsMapRef = useRef<Map<string, Array<{agent_name: string; content: string; complete: boolean; startedAt?: Date}>>>(new Map());
   const statusHistoryMapRef = useRef<Map<string, Array<{timestamp: Date; message: string; source?: string}>>>(new Map());
   const [isLoadingConversations, setIsLoadingConversations] = useState(false);
@@ -464,16 +476,21 @@ export function ChatProvider({ children, playgroundMode }: ChatProviderProps) {
                 setSubagentThoughtsMap(new Map(subagentThoughtsMapRef.current));
               }
               // Dedupe against a resume snapshot: turnOffset is the cumulative reply
-              // length after this chunk. The client's applied offset IS the current buffer
-              // length, so we derive it rather than tracking a parallel ref (which could go
-              // stale across turns and blank the next reply). Skip any chunk already covered
-              // (turnOffset <= what we already hold) so reconnect/reload never double-appends.
+              // length (in code points, per the backend) after this chunk. Compare it to
+              // the applied offset we track alongside the buffer — NOT to the buffer's
+              // .length, which counts UTF-16 units and runs ahead of the backend offset
+              // whenever the reply contains emoji, wrongly discarding chunks. Skip any
+              // chunk already covered so reconnect/reload never double-appends.
               const existing = streamingMapRef.current.get(resolvedConversationId) || '';
+              const applied = streamingOffsetMapRef.current.get(resolvedConversationId) ?? 0;
               const chunkOffset = data.turnOffset;
-              if (typeof chunkOffset === 'number' && chunkOffset <= existing.length) {
+              if (typeof chunkOffset === 'number' && chunkOffset <= applied) {
                 return;
               }
               streamingMapRef.current.set(resolvedConversationId, existing + text);
+              if (typeof chunkOffset === 'number') {
+                streamingOffsetMapRef.current.set(resolvedConversationId, chunkOffset);
+              }
               setStreamingMap(new Map(streamingMapRef.current));
             }
           }
@@ -537,6 +554,7 @@ export function ChatProvider({ children, playgroundMode }: ChatProviderProps) {
       if (data.role === 'agent' && Array.isArray(data.parts) && shouldDisplayMessageParts(data.parts)) {
         if (streamingMapRef.current.has(resolvedConversationId)) {
           streamingMapRef.current.delete(resolvedConversationId);
+          streamingOffsetMapRef.current.delete(resolvedConversationId);
           setStreamingMap(new Map(streamingMapRef.current));
         }
       }
@@ -656,6 +674,7 @@ export function ChatProvider({ children, playgroundMode }: ChatProviderProps) {
 
           // Always clear streaming buffer and waiting indicator on completion
           streamingMapRef.current.delete(resolvedConversationId);
+          streamingOffsetMapRef.current.delete(resolvedConversationId);
           setStreamingMap(new Map(streamingMapRef.current));
           setWaitingMap((prev) => {
             const m = new Map(prev);
@@ -886,31 +905,6 @@ export function ChatProvider({ children, playgroundMode }: ChatProviderProps) {
 
     return unsubscribe;
   }, [onAgentResponse, addMessage, addOrUpdateTask, updateConversation, tasksMap]);
-
-  // Apply the snapshot of an in-flight turn returned when (re)subscribing to a conversation.
-  // Seeds the streaming buffer with the reply produced while the client was away. A pending
-  // HITL prompt (if any) is restored separately via the normal agent_response path (see
-  // SocketContext). Only overwrite when the snapshot is AHEAD of what we already hold: a live
-  // chunk can race ahead of the snapshot (server enters the room, then reads the buffer), and
-  // rewinding to the shorter snapshot would drop that segment.
-  useEffect(() => {
-    const unsubscribe = onConversationSnapshot((snap) => {
-      if (!snap?.conversationId || !snap.inFlight) return;
-      if (typeof snap.offset === 'number') {
-        const existing = streamingMapRef.current.get(snap.conversationId) || '';
-        if (snap.offset > existing.length) {
-          streamingMapRef.current.set(snap.conversationId, snap.replyText || '');
-          setStreamingMap(new Map(streamingMapRef.current));
-        }
-        setWaitingMap((prev) => {
-          const m = new Map(prev);
-          m.set(snap.conversationId, true);
-          return m;
-        });
-      }
-    });
-    return unsubscribe;
-  }, [onConversationSnapshot]);
 
   // Subscribe to the active conversation's stream room, and re-subscribe on reconnect
   // (isSocketReady flips) so an in-flight turn resumes after a drop or page reload.
@@ -1217,6 +1211,81 @@ export function ChatProvider({ children, playgroundMode }: ChatProviderProps) {
       setIsLoadingMessages(false);
     }
   }, []);
+
+  // Apply the snapshot returned when (re)subscribing to a conversation.
+  //
+  // inFlight: seeds the streaming buffer with the reply produced while the client was
+  // away. A pending HITL prompt (if any) is restored separately via the normal
+  // agent_response path (see SocketContext). Only overwrite when the snapshot is AHEAD
+  // of what we already hold: a live chunk can race ahead of the snapshot (server enters
+  // the room, then reads the buffer), and rewinding to the shorter snapshot would drop
+  // that segment.
+  //
+  // Not inFlight: the turn (if any) ended while we were out of the room — its terminal
+  // events went to a room we had left, so nothing cleared our in-flight UI state.
+  // Reconcile: drop the stale spinner/stream state and refetch the persisted messages,
+  // which include the reply we missed. Without this the spinner never clears and the
+  // stale buffer makes the next turn's turnOffset dedup drop its chunks.
+  useEffect(() => {
+    const unsubscribe = onConversationSnapshot((snap) => {
+      if (!snap?.conversationId) return;
+      const conversationId = snap.conversationId;
+
+      if (!snap.inFlight) {
+        const hadStaleStream = streamingMapRef.current.has(conversationId);
+        const hadWaiting = !!waitingMapRef.current.get(conversationId);
+        if (!hadStaleStream && !hadWaiting) return;
+        if (hadStaleStream) {
+          streamingMapRef.current.delete(conversationId);
+          streamingOffsetMapRef.current.delete(conversationId);
+          setStreamingMap(new Map(streamingMapRef.current));
+        }
+        if (hadWaiting) {
+          setWaitingMap((prev) => {
+            const m = new Map(prev);
+            m.delete(conversationId);
+            return m;
+          });
+        }
+        // Match the live finalize path: thoughts/history were attached to the persisted
+        // messages at turn end server-side, so drop the in-progress copies.
+        subagentThoughtsMapRef.current.delete(conversationId);
+        setSubagentThoughtsMap(new Map(subagentThoughtsMapRef.current));
+        statusHistoryMapRef.current.delete(conversationId);
+        setStatusHistoryMap(new Map(statusHistoryMapRef.current));
+        loadMessages(conversationId);
+        return;
+      }
+
+      if (typeof snap.offset === 'number') {
+        const applied = streamingOffsetMapRef.current.get(conversationId) ?? 0;
+        if (snap.offset > applied) {
+          streamingMapRef.current.set(conversationId, snap.replyText || '');
+          streamingOffsetMapRef.current.set(conversationId, snap.offset);
+          setStreamingMap(new Map(streamingMapRef.current));
+        }
+        // A pending HITL prompt means the turn is waiting on the USER, not the agent.
+        // The prompt was just replayed through the agent_response path (SocketContext),
+        // which rendered it and cleared the waiting spinner — don't re-set the spinner
+        // on top of it; nothing would ever clear it until the user answers.
+        if (snap.pendingHitl) {
+          setWaitingMap((prev) => {
+            if (!prev.has(conversationId)) return prev;
+            const m = new Map(prev);
+            m.delete(conversationId);
+            return m;
+          });
+        } else {
+          setWaitingMap((prev) => {
+            const m = new Map(prev);
+            m.set(conversationId, true);
+            return m;
+          });
+        }
+      }
+    });
+    return unsubscribe;
+  }, [onConversationSnapshot, loadMessages]);
 
   // Create a new conversation
   const createConversation = useCallback(() => {

--- a/packages/console-frontend/src/components/chat/contexts/SocketContext.tsx
+++ b/packages/console-frontend/src/components/chat/contexts/SocketContext.tsx
@@ -31,6 +31,17 @@ export interface CatalogSyncProgressData {
   [key: string]: unknown;
 }
 
+// Snapshot of an in-flight turn, returned when (re)subscribing to a conversation.
+// Lets a client that reconnected or reloaded resume the reply produced while it was
+// away (replyText up to `offset`) and restore any pending interactive prompt.
+export interface ConversationSnapshotData {
+  conversationId: string;
+  inFlight: boolean;
+  offset: number;
+  replyText: string;
+  pendingHitl?: AgentResponseData | null;
+}
+
 interface SocketContextType {
   socket: Socket | null;
   isConnected: boolean;
@@ -39,7 +50,10 @@ interface SocketContextType {
   initializeClient: (settings: Settings, sessionId: string) => Promise<boolean>;
   sendMessage: (payload: SendMessagePayload) => void;
   cancelTask: (conversationId: string) => void;
+  subscribeConversation: (conversationId: string) => void;
+  unsubscribeConversation: (conversationId: string) => void;
   onAgentResponse: (callback: (data: AgentResponseData) => void) => () => void;
+  onConversationSnapshot: (callback: (data: ConversationSnapshotData) => void) => () => void;
   onSchedulerNotification: (callback: (data: SchedulerNotification) => void) => () => void;
   onCallCompleted: (callback: (data: CallCompletedData) => void) => () => void;
   onCatalogReindexProgress: (callback: (data: CatalogReindexProgressData) => void) => () => void;
@@ -60,6 +74,7 @@ export function SocketProvider({ children, socketPath = '/api/v1/socket.io', cus
   const [isSocketReady, setIsSocketReady] = useState(false);
   const [agentInfo, setAgentInfo] = useState<AgentInfo | null>(null);
   const responseCallbacksRef = useRef<Set<(data: AgentResponseData) => void>>(new Set());
+  const conversationSnapshotCallbacksRef = useRef<Set<(data: ConversationSnapshotData) => void>>(new Set());
   const schedulerCallbacksRef = useRef<Set<(data: SchedulerNotification) => void>>(new Set());
   const callCompletedCallbacksRef = useRef<Set<(data: CallCompletedData) => void>>(new Set());
   const catalogReindexCallbacksRef = useRef<Set<(data: CatalogReindexProgressData) => void>>(new Set());
@@ -99,6 +114,15 @@ export function SocketProvider({ children, socketPath = '/api/v1/socket.io', cus
 
     newSocket.on('agent_response', (data: AgentResponseData) => {
       responseCallbacksRef.current.forEach((callback) => callback(data));
+    });
+
+    newSocket.on('conversation_snapshot', (data: ConversationSnapshotData) => {
+      // Restore any pending interactive prompt through the normal agent_response path so
+      // the existing HITL rendering handles it (a prompt that arrived while disconnected).
+      if (data?.pendingHitl) {
+        responseCallbacksRef.current.forEach((callback) => callback(data.pendingHitl as AgentResponseData));
+      }
+      conversationSnapshotCallbacksRef.current.forEach((callback) => callback(data));
     });
 
     newSocket.on('scheduler_notification', (data: SchedulerNotification) => {
@@ -183,10 +207,33 @@ export function SocketProvider({ children, socketPath = '/api/v1/socket.io', cus
     [socket]
   );
 
+  const subscribeConversation = useCallback(
+    (conversationId: string) => {
+      if (!socket?.connected || !conversationId) return;
+      socket.emit('subscribe_conversation', { conversationId });
+    },
+    [socket]
+  );
+
+  const unsubscribeConversation = useCallback(
+    (conversationId: string) => {
+      if (!socket?.connected || !conversationId) return;
+      socket.emit('unsubscribe_conversation', { conversationId });
+    },
+    [socket]
+  );
+
   const onAgentResponse = useCallback((callback: (data: AgentResponseData) => void) => {
     responseCallbacksRef.current.add(callback);
     return () => {
       responseCallbacksRef.current.delete(callback);
+    };
+  }, []);
+
+  const onConversationSnapshot = useCallback((callback: (data: ConversationSnapshotData) => void) => {
+    conversationSnapshotCallbacksRef.current.add(callback);
+    return () => {
+      conversationSnapshotCallbacksRef.current.delete(callback);
     };
   }, []);
 
@@ -228,7 +275,10 @@ export function SocketProvider({ children, socketPath = '/api/v1/socket.io', cus
         initializeClient,
         sendMessage,
         cancelTask,
+        subscribeConversation,
+        unsubscribeConversation,
         onAgentResponse,
+        onConversationSnapshot,
         onSchedulerNotification,
         onCallCompleted,
         onCatalogReindexProgress,

--- a/packages/console-frontend/src/components/chat/types.ts
+++ b/packages/console-frontend/src/components/chat/types.ts
@@ -154,6 +154,9 @@ export interface AgentResponseData {
   role?: string;
   messageId?: string;
   persistedMessageId?: string;
+  // Cumulative reply length after this streamed chunk; used to dedupe live chunks
+  // against a resume snapshot after reconnect/reload.
+  turnOffset?: number;
   parts?: Array<{ text?: string; kind?: string }>;
   status?: TaskStatusDetails;
   metadata?: Record<string, unknown>;

--- a/packages/orchestrator-agent/app/core/executor.py
+++ b/packages/orchestrator-agent/app/core/executor.py
@@ -29,8 +29,7 @@ from ringier_a2a_sdk.server.executor import (
     MAX_STEERING_QUEUE_DEPTH,
     MAX_STEERING_REINVOCATIONS,
     ActiveStreamInfo,
-    _active_streams,
-    _active_streams_lock,
+    get_stream_coordinator,
 )
 
 from app.models.responses import AgentStreamResponse
@@ -394,65 +393,68 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
                 "googleChatSpaceId"
             )
 
-        # --- Continuous Interaction Turn: route to active stream if one exists ---
-        async with _active_streams_lock:
-            active = _active_streams.get(context_id)
-            if active is not None:
-                # Verify the caller belongs to this conversation.
-                # Channel (Slack): check caller's channel matches the stream's assistant_id.
-                # Personal: check caller's user_sub matches the stream owner.
-                # If scope is not yet set (race: stream just registered), allow through.
-                if active.scope == "channel":
-                    if active.assistant_id and caller_channel_id != active.assistant_id:
-                        logger.warning(
-                            f"[STEERING] Rejected steering for context_id={context_id}: "
-                            f"caller channel_id does not match stream assistant_id"
-                        )
-                        raise InvalidParamsError()
-                elif active.scope == "personal":
-                    if active.owner_sub and caller_sub != active.owner_sub:
-                        logger.warning(
-                            f"[STEERING] Rejected steering for context_id={context_id}: "
-                            f"caller_sub={caller_sub} does not match stream owner"
-                        )
-                        raise InvalidParamsError()
-                if active.message_queue.qsize() >= MAX_STEERING_QUEUE_DEPTH:
+        # --- Continuous Interaction Turn: register this turn, or route to the active one ---
+        # try_register atomically claims the turn for this context_id, or returns the
+        # already-active stream so we steer into it instead of starting a second execution.
+        # Going through the StreamCoordinator (not the registry dict directly) keeps this
+        # executor covered when a cross-replica coordinator is installed via
+        # set_stream_coordinator, and closes the old check-then-register gap between two
+        # separate lock acquisitions.
+        stream_info = ActiveStreamInfo(context_id=context_id, task_id=task.id, owner_sub=caller_sub)
+        active = await get_stream_coordinator().try_register(stream_info)
+        if active is not None:
+            # Verify the caller belongs to this conversation.
+            # Channel (Slack): check caller's channel matches the stream's assistant_id.
+            # Personal: check caller's user_sub matches the stream owner.
+            # If scope is not yet set (race: stream just registered), allow through.
+            if active.scope == "channel":
+                if active.assistant_id and caller_channel_id != active.assistant_id:
                     logger.warning(
-                        f"[STEERING] Queue full for context_id={context_id} "
-                        f"(depth={active.message_queue.qsize()}), rejecting"
+                        f"[STEERING] Rejected steering for context_id={context_id}: "
+                        f"caller channel_id does not match stream assistant_id"
                     )
                     raise InvalidParamsError()
-                logger.info(
-                    f"[STEERING] Active stream found for context_id={context_id}, "
-                    f"queuing message for running orchestrator (queue depth: {active.message_queue.qsize() + 1})"
-                )
-                active.message_queue.put_nowait(context.message)
-                # Also put into orchestrator-local queue (read by SteeringMiddleware)
-                orch_queue = get_steering_queue(context_id)
-                if orch_queue is not None:
-                    orch_queue.put_nowait(context.message)
-                # Acknowledge-only: emit a status-update (NOT a raw Task object)
-                # so the SSE response has at least one event, then return.
-                # Using TaskStatusUpdateEvent avoids the "Task is already set"
-                # error on the client's ClientTaskManager when the event queue
-                # is a tapped child that also receives parent events.
-                await event_queue.enqueue_event(
-                    TaskStatusUpdateEvent(
-                        task_id=task.id,
-                        context_id=task.context_id,
-                        status=TaskStatus(
-                            state=task.status.state,
-                            message=task.status.message,
-                        ),
+            elif active.scope == "personal":
+                if active.owner_sub and caller_sub != active.owner_sub:
+                    logger.warning(
+                        f"[STEERING] Rejected steering for context_id={context_id}: "
+                        f"caller_sub={caller_sub} does not match stream owner"
                     )
+                    raise InvalidParamsError()
+            if active.message_queue.qsize() >= MAX_STEERING_QUEUE_DEPTH:
+                logger.warning(
+                    f"[STEERING] Queue full for context_id={context_id} "
+                    f"(depth={active.message_queue.qsize()}), rejecting"
                 )
-                return
+                raise InvalidParamsError()
+            logger.info(
+                f"[STEERING] Active stream found for context_id={context_id}, "
+                f"queuing message for running orchestrator (queue depth: {active.message_queue.qsize() + 1})"
+            )
+            active.message_queue.put_nowait(context.message)
+            # Also put into orchestrator-local queue (read by SteeringMiddleware)
+            steering_queue = get_steering_queue(context_id)
+            if steering_queue is not None:
+                steering_queue.put_nowait(context.message)
+            # Acknowledge-only: emit a status-update (NOT a raw Task object)
+            # so the SSE response has at least one event, then return.
+            # Using TaskStatusUpdateEvent avoids the "Task is already set"
+            # error on the client's ClientTaskManager when the event queue
+            # is a tapped child that also receives parent events.
+            await event_queue.enqueue_event(
+                TaskStatusUpdateEvent(
+                    task_id=task.id,
+                    context_id=task.context_id,
+                    status=TaskStatus(
+                        state=task.status.state,
+                        message=task.status.message,
+                    ),
+                )
+            )
+            return
 
-        # No active stream — register ourselves and proceed with execution
-        stream_info = ActiveStreamInfo(context_id=context_id, task_id=task.id, owner_sub=caller_sub)
+        # Turn claimed — set up the orchestrator-local steering queue and proceed.
         orch_queue: asyncio.Queue[Message] = asyncio.Queue()
-        async with _active_streams_lock:
-            _active_streams[context_id] = stream_info
         register_steering_queue(context_id, orch_queue)
 
         # ZERO-TRUST: Extract verified user_sub and token from call_context (set by RequestContextBuilder)
@@ -926,19 +928,22 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
                     except Exception:
                         logger.warning("Failed to persist bypass rules", exc_info=True)
 
-            # Log unconsumed steering messages before cleanup.
-            # These arrive between the last abefore_model call and stream
-            # completion — they will be handled as the next conversation turn.
-            unconsumed = get_orchestrator_pending_messages(context_id)
-            if unconsumed:
-                logger.warning(
-                    f"[STEERING] {len(unconsumed)} unconsumed steering message(s) "
-                    f"for context_id={context_id} after execution finished. "
-                    f"They will be handled as the next conversation turn."
+            # Log unconsumed steering messages before cleanup. Count via qsize() —
+            # get_orchestrator_pending_messages would DRAIN the queue just to count it.
+            # These messages were already acknowledged to their sender but nothing
+            # replays them once the queue is removed below, so this is a message drop
+            # and must be logged as one.
+            remaining_queue = get_steering_queue(context_id)
+            unconsumed_count = remaining_queue.qsize() if remaining_queue is not None else 0
+            if unconsumed_count:
+                logger.error(
+                    f"[STEERING] Dropping {unconsumed_count} unconsumed steering message(s) "
+                    f"for context_id={context_id}: they arrived after the post-completion "
+                    f"re-invocation check and the stream has ended. The sender was already "
+                    f"acked; the user must resend."
                 )
             # Deregister active stream and clean up orchestrator steering queue
-            async with _active_streams_lock:
-                _active_streams.pop(context_id, None)
+            await get_stream_coordinator().release(context_id)
             remove_steering_queue(context_id)
 
     async def _handle_stream_item(

--- a/packages/ringier-a2a-sdk/ringier_a2a_sdk/server/__init__.py
+++ b/packages/ringier-a2a-sdk/ringier_a2a_sdk/server/__init__.py
@@ -1,10 +1,21 @@
 """Server utilities for A2A applications."""
 
 from .context_builder import AuthRequestContextBuilder
-from .executor import ActiveStreamInfo, BaseAgentExecutor
+from .executor import (
+    ActiveStreamInfo,
+    BaseAgentExecutor,
+    InMemoryStreamCoordinator,
+    StreamCoordinator,
+    get_stream_coordinator,
+    set_stream_coordinator,
+)
 
 __all__ = [
     "AuthRequestContextBuilder",
     "BaseAgentExecutor",
     "ActiveStreamInfo",
+    "StreamCoordinator",
+    "InMemoryStreamCoordinator",
+    "get_stream_coordinator",
+    "set_stream_coordinator",
 ]

--- a/packages/ringier-a2a-sdk/ringier_a2a_sdk/server/executor.py
+++ b/packages/ringier-a2a-sdk/ringier_a2a_sdk/server/executor.py
@@ -95,8 +95,10 @@ class StreamCoordinator(ABC):
 class InMemoryStreamCoordinator(StreamCoordinator):
     """Per-process coordinator backed by the module-level registry (single-replica).
 
-    Uses the shared `_active_streams`/`_active_streams_lock` so callers that still touch
-    the registry directly (e.g. the orchestrator subclass) stay consistent with it.
+    The module-level `_active_streams`/`_active_streams_lock` remain the backing store
+    (tests seed them directly), but all runtime callers — including the orchestrator's
+    executor — must go through the coordinator API so that installing a cross-replica
+    implementation via set_stream_coordinator covers every executor.
     """
 
     async def try_register(self, info: ActiveStreamInfo) -> ActiveStreamInfo | None:
@@ -367,16 +369,19 @@ class BaseAgentExecutor(AgentExecutor, ABC):
 
             raise InternalError() from e
         finally:
-            # Log unconsumed steering messages before cleanup.
-            # These arrive between the last abefore_model call and stream
-            # completion — they will be picked up as a normal next turn.
+            # Log unconsumed steering messages before cleanup. Count via qsize() —
+            # get_pending_messages would DRAIN the queue just to count it. These
+            # messages were already acknowledged to their sender but nothing replays
+            # them once the queue is cleared below, so this is a message drop and
+            # must be logged as one.
             try:
-                unconsumed = self.agent.get_pending_messages(context_id)
-                if unconsumed:
-                    logger.warning(
-                        f"[STEERING] {len(unconsumed)} unconsumed steering message(s) "
-                        f"for context_id={context_id} after execution finished. "
-                        f"They will be handled as the next conversation turn."
+                unconsumed_count = stream_info.message_queue.qsize()
+                if unconsumed_count:
+                    logger.error(
+                        f"[STEERING] Dropping {unconsumed_count} unconsumed steering message(s) "
+                        f"for context_id={context_id}: they arrived after the post-completion "
+                        f"re-invocation check and the stream has ended. The sender was already "
+                        f"acked; the user must resend."
                     )
             except Exception:
                 pass  # Best-effort; don't mask the original result

--- a/packages/ringier-a2a-sdk/ringier_a2a_sdk/server/executor.py
+++ b/packages/ringier-a2a-sdk/ringier_a2a_sdk/server/executor.py
@@ -63,8 +63,66 @@ class ActiveStreamInfo:
 
 # Module-level registry of active streams, keyed by context_id.
 # Access is safe from a single asyncio event loop (no threading lock needed).
+# NOTE: this in-process registry only serializes concurrent turns within ONE replica.
+# Cross-replica serialization (so two pods can't run the same thread_id concurrently)
+# will come from a distributed StreamCoordinator impl (Postgres lease-lock) selected via
+# set_stream_coordinator(); the abstraction below is the seam for that.
 _active_streams: dict[str, ActiveStreamInfo] = {}
 _active_streams_lock = asyncio.Lock()
+
+
+class StreamCoordinator(ABC):
+    """Decides whether a turn may start for a context_id, or must fold into a running one.
+
+    Encapsulates the active-stream registry so the single-replica in-memory registry can
+    be swapped for a cross-replica (Postgres lease-lock) implementation without touching
+    the executor's control flow.
+    """
+
+    async def try_register(self, info: ActiveStreamInfo) -> ActiveStreamInfo | None:
+        """Atomically register `info` as the active stream for its context_id.
+
+        Returns None if registration succeeded (this caller owns the turn), or the already
+        -active ActiveStreamInfo if one exists (the caller must steer into it instead).
+        """
+        raise NotImplementedError
+
+    async def release(self, context_id: str) -> None:
+        """Release the active stream for a context_id (turn finished)."""
+        raise NotImplementedError
+
+
+class InMemoryStreamCoordinator(StreamCoordinator):
+    """Per-process coordinator backed by the module-level registry (single-replica).
+
+    Uses the shared `_active_streams`/`_active_streams_lock` so callers that still touch
+    the registry directly (e.g. the orchestrator subclass) stay consistent with it.
+    """
+
+    async def try_register(self, info: ActiveStreamInfo) -> ActiveStreamInfo | None:
+        async with _active_streams_lock:
+            existing = _active_streams.get(info.context_id)
+            if existing is not None:
+                return existing
+            _active_streams[info.context_id] = info
+            return None
+
+    async def release(self, context_id: str) -> None:
+        async with _active_streams_lock:
+            _active_streams.pop(context_id, None)
+
+
+_stream_coordinator: StreamCoordinator = InMemoryStreamCoordinator()
+
+
+def get_stream_coordinator() -> StreamCoordinator:
+    return _stream_coordinator
+
+
+def set_stream_coordinator(coordinator: StreamCoordinator) -> None:
+    """Install a coordinator (e.g. a Postgres lease-lock impl for multi-replica)."""
+    global _stream_coordinator
+    _stream_coordinator = coordinator
 
 
 class BaseAgentExecutor(AgentExecutor, ABC):
@@ -157,49 +215,46 @@ class BaseAgentExecutor(AgentExecutor, ABC):
 
         logger.debug(f"[ZERO-TRUST] Executing with verified user_sub: {user_sub}, sub_agent_id: {sub_agent_id}")
 
-        # --- Continuous Interaction Turn: route to active stream if one exists ---
-        async with _active_streams_lock:
-            active = _active_streams.get(context_id)
-            if active is not None:
-                # Verify the caller is the same user who started the stream
-                if active.owner_sub and user_sub != active.owner_sub:
-                    logger.warning(
-                        f"[STEERING] Rejected steering for context_id={context_id}: "
-                        f"caller_sub={user_sub} does not match stream owner"
-                    )
-                    raise InvalidParamsError()
-                if active.message_queue.qsize() >= MAX_STEERING_QUEUE_DEPTH:
-                    logger.warning(
-                        f"[STEERING] Queue full for context_id={context_id} "
-                        f"(depth={active.message_queue.qsize()}), rejecting"
-                    )
-                    raise InvalidParamsError()
-                logger.info(
-                    f"[STEERING] Active stream found for context_id={context_id}, "
-                    f"queuing message for running agent (queue depth: {active.message_queue.qsize() + 1})"
-                )
-                active.message_queue.put_nowait(context.message)
-                # Acknowledge-only: emit a status-update (NOT a raw Task object)
-                # so the SSE response has at least one event, then return.
-                # Using TaskStatusUpdateEvent avoids the "Task is already set"
-                # error on the client's ClientTaskManager when the event queue
-                # is a tapped child that also receives parent events.
-                await event_queue.enqueue_event(
-                    TaskStatusUpdateEvent(
-                        task_id=task.id,
-                        context_id=task.context_id,
-                        status=TaskStatus(
-                            state=task.status.state,
-                            message=task.status.message,
-                        ),
-                    )
-                )
-                return
-
-        # No active stream — register ourselves and proceed with execution
+        # --- Continuous Interaction Turn: register this turn, or route to the active one ---
+        # try_register atomically claims the turn for this context_id, or returns the
+        # already-active stream so we steer into it instead of starting a second execution.
         stream_info = ActiveStreamInfo(context_id=context_id, task_id=task.id, owner_sub=user_sub)
-        async with _active_streams_lock:
-            _active_streams[context_id] = stream_info
+        active = await get_stream_coordinator().try_register(stream_info)
+        if active is not None:
+            # Verify the caller is the same user who started the stream
+            if active.owner_sub and user_sub != active.owner_sub:
+                logger.warning(
+                    f"[STEERING] Rejected steering for context_id={context_id}: "
+                    f"caller_sub={user_sub} does not match stream owner"
+                )
+                raise InvalidParamsError()
+            if active.message_queue.qsize() >= MAX_STEERING_QUEUE_DEPTH:
+                logger.warning(
+                    f"[STEERING] Queue full for context_id={context_id} "
+                    f"(depth={active.message_queue.qsize()}), rejecting"
+                )
+                raise InvalidParamsError()
+            logger.info(
+                f"[STEERING] Active stream found for context_id={context_id}, "
+                f"queuing message for running agent (queue depth: {active.message_queue.qsize() + 1})"
+            )
+            active.message_queue.put_nowait(context.message)
+            # Acknowledge-only: emit a status-update (NOT a raw Task object)
+            # so the SSE response has at least one event, then return.
+            # Using TaskStatusUpdateEvent avoids the "Task is already set"
+            # error on the client's ClientTaskManager when the event queue
+            # is a tapped child that also receives parent events.
+            await event_queue.enqueue_event(
+                TaskStatusUpdateEvent(
+                    task_id=task.id,
+                    context_id=task.context_id,
+                    status=TaskStatus(
+                        state=task.status.state,
+                        message=task.status.message,
+                    ),
+                )
+            )
+            return
 
         # Share the message queue reference with the agent so SteeringMiddleware
         # can consume pending messages during graph execution.
@@ -326,8 +381,7 @@ class BaseAgentExecutor(AgentExecutor, ABC):
             except Exception:
                 pass  # Best-effort; don't mask the original result
             # Deregister active stream and clean up agent's message queue
-            async with _active_streams_lock:
-                _active_streams.pop(context_id, None)
+            await get_stream_coordinator().release(context_id)
             self.agent.clear_message_queue(context_id)
 
     async def _handle_stream_item(

--- a/packages/ringier-a2a-sdk/tests/test_stream_coordinator.py
+++ b/packages/ringier-a2a-sdk/tests/test_stream_coordinator.py
@@ -1,0 +1,40 @@
+"""Tests for the StreamCoordinator seam (single-replica in-memory impl)."""
+
+import pytest
+
+from ringier_a2a_sdk.server.executor import (
+    ActiveStreamInfo,
+    InMemoryStreamCoordinator,
+    get_stream_coordinator,
+    set_stream_coordinator,
+)
+
+
+@pytest.mark.asyncio
+async def test_try_register_claims_then_returns_active_for_steering():
+    coord = InMemoryStreamCoordinator()
+    ctx = "c-coord-claim"
+    try:
+        first = ActiveStreamInfo(context_id=ctx, task_id="t1", owner_sub="u1")
+        # First caller claims the turn.
+        assert await coord.try_register(first) is None
+        # A concurrent send for the same conversation finds the active stream to steer into.
+        second = ActiveStreamInfo(context_id=ctx, task_id="t2", owner_sub="u1")
+        active = await coord.try_register(second)
+        assert active is first
+        # After release, the conversation can start a fresh turn again.
+        await coord.release(ctx)
+        assert await coord.try_register(second) is None
+    finally:
+        await coord.release(ctx)
+
+
+@pytest.mark.asyncio
+async def test_set_stream_coordinator_swaps_the_active_impl():
+    original = get_stream_coordinator()
+    try:
+        replacement = InMemoryStreamCoordinator()
+        set_stream_coordinator(replacement)
+        assert get_stream_coordinator() is replacement
+    finally:
+        set_stream_coordinator(original)


### PR DESCRIPTION
## Summary

Makes the console web chat resilient to disconnects, reloads, and multi-tab use by decoupling a chat **Turn** from the socket connection that started it:

- **Turn identity** is bound to `(user_id, conversation_id)` at turn start, not the ephemeral socket session — a reply is persisted even if the client disconnects mid-turn.
- **Delivery by conversation room**: turn streams are emitted to a `conversation:<id>` Socket.IO room instead of a single sid, so reconnects (new sid) and additional tabs keep receiving the stream.
- **Resume-on-subscribe**: `subscribe_conversation` joins the room and returns a snapshot (reply-so-far + offset + pending HITL prompt); live chunks carry a cumulative `turnOffset` the client dedupes against, so mid-stream resume never gaps or double-appends.
- **Conversation-keyed turns**: at most one turn per conversation; a concurrent send becomes steering, and steering/cancel survive reconnects. Ownership is enforced before room join, orchestrator forward, cancel, and subscribe.
- **StreamCoordinator seam** in the a2a SDK: the active-stream registry is behind a `try_register`/`release` interface (in-memory impl today) as the seam for the planned cross-replica Postgres lease-lock. Both the base executor and the orchestrator executor go through it.

The final commit applies fixes from an adversarial code review of the branch, most notably: input-required HITL prompts now survive turn teardown so they can be restored on resubscribe; `turnOffset` dedup uses code-point offsets (UTF-16 `.length` dropped chunks on emoji); snapshots with `inFlight=false` reconcile stale client state (stuck spinner / swallowed next reply); turn teardown is identity-checked against superseding turns; the ownership gate no longer masks DB outages as "Conversation not found"; and unconsumed steering messages are counted without draining the queue.

## Known limitations (single-replica)

No cross-node Socket.IO client manager yet: rooms, `active_tasks`, and turn buffers are per-process, so resume assumes session affinity. Cross-pod coordination (Postgres lease-lock behind `set_stream_coordinator`) is planned; the seam for it lands here.

## Test plan

- `packages/console-backend`: 1254 passed (incl. new tests for room delivery, snapshot resume, ownership gates, conversation-keyed cancel, HITL prompt preservation, DB-error surfacing)
- `packages/ringier-a2a-sdk`: 331 passed (incl. new StreamCoordinator tests)
- `packages/orchestrator-agent`: 606 passed
- `packages/console-frontend`: `tsc -b` clean; eslint unchanged from baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)