### PR TITLE
fix(security): IDOR on skill activations, OIDC open redirect, file-analyzer SSRF

### DIFF
--- a/packages/console-backend/console_backend/controllers/auth_controller.py
+++ b/packages/console-backend/console_backend/controllers/auth_controller.py
@@ -1,7 +1,7 @@
 """Authentication controller for OIDC flow using Authlib."""
 
 import logging
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 from authlib.integrations.starlette_client import OAuth, OAuthError, StarletteOAuth2App
 from fastapi import HTTPException, Request, Response
@@ -97,13 +97,31 @@ class AuthController:
                 return True
 
             # In dev mode, allow http URLs to base_domain
-            if url.startswith("http://") and self.is_dev and self.base_domain in url:
+            if url.startswith("http://") and self.is_dev and self._host_matches_base_domain(url):
                 return True
 
             # In production, require https and base_domain
-            return url.startswith("https://") and self.base_domain in url
+            return url.startswith("https://") and self._host_matches_base_domain(url)
         except Exception:
             return False
+
+    def _host_matches_base_domain(self, url: str) -> bool:
+        """Return True only if the URL's host is the base domain or a subdomain of it.
+
+        Compares the parsed hostname (userinfo and port stripped) rather than doing a
+        substring match on the whole URL — a substring check accepts hostile hosts such
+        as ``https://<base_domain>.evil.com`` (base_domain appears as a prefix) or
+        ``https://evil.com/?x=<base_domain>`` (base_domain appears in the query), turning
+        the redirect into an open redirect.
+        """
+        hostname = (urlparse(url).hostname or "").lower()
+        if not hostname:
+            return False
+        # Strip any userinfo/port from the configured base domain before comparing.
+        base_host = self.base_domain.split("@")[-1].split(":")[0].lower()
+        if not base_host:
+            return False
+        return hostname == base_host or hostname.endswith("." + base_host)
 
     async def get_login(self, request: Request) -> RedirectResponse:
         """Initiate the OIDC login flow.

--- a/packages/console-backend/console_backend/routers/skill_activations_router.py
+++ b/packages/console-backend/console_backend/routers/skill_activations_router.py
@@ -275,7 +275,7 @@ async def update_activation(
 
     result = await db.execute(
         sa_text("""
-            SELECT s.name as agent_name
+            SELECT sa.sub_agent_id, sa.scope, sa.user_id, sa.group_id, s.name as agent_name
             FROM skill_activations sa
             JOIN sub_agents s ON s.id = sa.sub_agent_id
             WHERE sa.id = :id
@@ -285,6 +285,16 @@ async def update_activation(
     row = result.mappings().first()
     if not row:
         raise HTTPException(status_code=404, detail="Activation not found")
+
+    await _authorize_activation_mutation(
+        request,
+        db,
+        user,
+        scope=row["scope"],
+        owner_user_id=row["user_id"],
+        group_id=row["group_id"],
+        sub_agent_id=row["sub_agent_id"],
+    )
 
     try:
         new_hash = await activation_service.update_activation(
@@ -329,7 +339,7 @@ async def bulk_update_activations(
 
         result = await db.execute(
             sa_text("""
-                SELECT s.name as agent_name
+                SELECT sa.sub_agent_id, sa.scope, sa.user_id, sa.group_id, s.name as agent_name
                 FROM skill_activations sa
                 JOIN sub_agents s ON s.id = sa.sub_agent_id
                 WHERE sa.id = :id
@@ -338,6 +348,21 @@ async def bulk_update_activations(
         )
         row = result.mappings().first()
         if not row:
+            failed.append({"id": activation_id, "reason": "Activation not found"})
+            continue
+
+        try:
+            await _authorize_activation_mutation(
+                request,
+                db,
+                user,
+                scope=row["scope"],
+                owner_user_id=row["user_id"],
+                group_id=row["group_id"],
+                sub_agent_id=row["sub_agent_id"],
+            )
+        except HTTPException:
+            # Not authorized — report as not-found to avoid confirming existence.
             failed.append({"id": activation_id, "reason": "Activation not found"})
             continue
 

--- a/packages/console-backend/console_backend/routers/skill_activations_router.py
+++ b/packages/console-backend/console_backend/routers/skill_activations_router.py
@@ -48,6 +48,45 @@ async def _get_user_group_ids(request: Request, db: AsyncSession, user: User) ->
     return [g.id for g in groups] if groups else []
 
 
+def _get_sub_agent_service(request: Request):
+    return request.app.state.sub_agent_service
+
+
+async def _authorize_activation_mutation(
+    request: Request,
+    db: AsyncSession,
+    user: User,
+    *,
+    scope: str,
+    owner_user_id: str | None,
+    group_id: int | None,
+    sub_agent_id: int,
+) -> None:
+    """Authorize a mutation (deactivate/update) on a specific activation.
+
+    Activation rows are addressed by a sequential integer id, so resolving one by id
+    alone lets any authenticated user act on another user's or group's activation. Gate
+    the mutation on the activation's scope:
+      - personal: caller must own it
+      - group: caller must belong to the group
+      - sub-agent: caller must have write permission on the sub-agent
+
+    Raises 404 (not 403) on mismatch so existence of others' activations is not confirmed.
+    """
+    if scope == "personal":
+        if owner_user_id == user.id:
+            return
+    elif scope == "group":
+        if group_id is not None and group_id in await _get_user_group_ids(request, db, user):
+            return
+    elif scope == "sub-agent":
+        sub_agent_service = _get_sub_agent_service(request)
+        if await sub_agent_service.check_user_permission(db, sub_agent_id, user.id, "write"):
+            return
+
+    raise HTTPException(status_code=404, detail="Activation not found")
+
+
 # --- Response Models ---
 
 
@@ -178,7 +217,7 @@ async def deactivate_skill(
 
     result = await db.execute(
         sa_text("""
-            SELECT sa.sub_agent_id, s.name as agent_name
+            SELECT sa.sub_agent_id, sa.scope, sa.user_id, sa.group_id, s.name as agent_name
             FROM skill_activations sa
             JOIN sub_agents s ON s.id = sa.sub_agent_id
             WHERE sa.id = :id
@@ -188,6 +227,16 @@ async def deactivate_skill(
     row = result.mappings().first()
     if not row:
         raise HTTPException(status_code=404, detail="Activation not found")
+
+    await _authorize_activation_mutation(
+        request,
+        db,
+        user,
+        scope=row["scope"],
+        owner_user_id=row["user_id"],
+        group_id=row["group_id"],
+        sub_agent_id=row["sub_agent_id"],
+    )
 
     try:
         deactivated = await activation_service.deactivate(

--- a/packages/orchestrator-agent/app/agents/file_analyzer.py
+++ b/packages/orchestrator-agent/app/agents/file_analyzer.py
@@ -26,9 +26,13 @@ Model: the fleet's cheap/fast chat tier, resolved at runtime from the gateway
 (image/PDF/audio/video). No env var or hardcoded alias: models are registered at runtime.
 """
 
+import asyncio
+import ipaddress
 import logging
 import re
+import socket
 from typing import Any, Dict, List, Optional, cast
+from urllib.parse import urlparse
 
 import httpx
 from agent_common.a2a.base import LocalA2ARunnable, SubAgentInput
@@ -160,6 +164,60 @@ When analyzing a file:
 Always provide actionable, useful information based on what is actually in the file — not what you imagine might be there."""
 
 
+class SSRFError(ValueError):
+    """Raised when a URL targets a non-public address (SSRF guard)."""
+
+
+def _is_blocked_address(ip: str) -> bool:
+    """True if an IP is loopback/private/link-local/reserved (i.e. not publicly routable)."""
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return True
+    return (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local  # blocks 169.254.0.0/16, incl. the cloud metadata endpoint
+        or addr.is_reserved
+        or addr.is_multicast
+        or addr.is_unspecified
+    )
+
+
+async def _assert_public_url(url: str) -> None:
+    """Reject URLs whose host resolves to a non-public address.
+
+    The file-analyzer fetches attacker-supplied URLs server-side (from inside the
+    orchestrator pod) and returns their body, so an unrestricted fetch is an SSRF that
+    can reach cluster-internal services and cloud-metadata endpoints. Resolve the host
+    and refuse any URL that maps to a loopback/private/link-local/reserved address.
+
+    Note: this validates at resolution time and does not pin the connection to the
+    resolved IP, so it does not defend against active DNS rebinding; combine with an
+    egress NetworkPolicy for defense-in-depth.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise SSRFError(f"Unsupported URL scheme: {parsed.scheme!r}")
+    host = parsed.hostname
+    if not host:
+        raise SSRFError("URL has no host")
+
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    try:
+        loop = asyncio.get_running_loop()
+        infos = await loop.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except socket.gaierror as e:
+        raise SSRFError(f"Could not resolve host {host!r}: {e}")
+
+    resolved = {info[4][0] for info in infos}
+    if not resolved:
+        raise SSRFError(f"Host {host!r} did not resolve")
+    for ip in resolved:
+        if _is_blocked_address(ip):
+            raise SSRFError(f"Refusing to fetch a URL that resolves to a non-public address ({ip})")
+
+
 def _get_file_extension(url: str) -> str:
     """Extract file extension from URL, ignoring query parameters."""
     path = url.split("?")[0]
@@ -178,8 +236,10 @@ async def _detect_file_type(url: str, client: httpx.AsyncClient) -> str:
     Returns one of: 'text', 'image', 'document', 'audio', 'video', 'unknown'
     """
     try:
-        # Use Range GET instead of HEAD - S3 presigned URLs are signed for GET only
-        response = await client.get(url, headers={"Range": "bytes=0-0"}, follow_redirects=True)
+        # Use Range GET instead of HEAD - S3 presigned URLs are signed for GET only.
+        # follow_redirects stays off so a redirect can't bounce the SSRF-guarded URL
+        # into an internal/metadata address after validation.
+        response = await client.get(url, headers={"Range": "bytes=0-0"}, follow_redirects=False)
         # Accept both 200 (full content) and 206 (partial content) as success
         content_type = response.headers.get("content-type", "").lower().split(";")[0].strip()
 
@@ -353,6 +413,8 @@ class FileAnalyzerRunnable(LocalA2ARunnable):
 
         for file_url in urls:
             logger.info(f"Processing: {file_url[:80]}...")
+            # SSRF guard: refuse URLs pointing at internal/metadata addresses before any fetch.
+            await _assert_public_url(file_url)
             file_type = await _detect_file_type(file_url, client)
 
             if file_type == "text":


### PR DESCRIPTION
## Summary

Fixes four security findings surfaced by a security review of the codebase. Each finding is a separate commit. All affected files compile; the redirect matcher and the SSRF address classifier were validated against the actual bypass/attack inputs.

| Severity | Finding | Commit |
|---|---|---|
| High | **IDOR** — any authenticated user could delete any skill activation | `fix(skills): enforce ownership before deactivating a skill activation` |
| High | **IDOR** — any authenticated user could force-refresh any activation | `fix(skills): enforce ownership before updating a skill activation` |
| Medium | **Open redirect** in OIDC login/logout | `fix(auth): validate redirect host instead of substring-matching base_domain` |
| Medium | **SSRF** in the orchestrator file-analyzer | `fix(file-analyzer): block SSRF to internal/metadata addresses` |

## Details

### 1 & 2 — Broken object-level authorization on skill activations
`deactivate_skill`, `update_activation`, and `bulk_update_activations` resolved an activation by its sequential integer `id` alone and then deleted it / re-pinned its content hash with **no ownership predicate** — `user_id` was used only for the docstore snapshot path, never for authorization. Any authenticated user could iterate ids and act on another user's personal activation or any group's activation.

**Fix:** a shared `_authorize_activation_mutation` guard — personal scope requires ownership, group scope requires membership, sub-agent scope requires `write` permission on the sub-agent (via the existing `SubAgentService.check_user_permission`). Returns 404 (not 403) on mismatch so the existence of other users' activations isn't confirmed. The bulk endpoint reports unauthorized ids as "Activation not found" to preserve its partial-success semantics.

### 3 — Open redirect in OIDC login/logout
`_is_valid_redirect_url` validated the `redirectTo` parameter with `base_domain in url` — an unanchored substring match that accepts hostile hosts like `https://<base_domain>.evil.com` and `https://evil.com/?x=<base_domain>`. The value flows verbatim into a 303 `Location` on the post-login and post-logout callbacks, and `/api/v1/auth/login` is reachable pre-auth — a phishing-grade open redirect originating from the trusted domain.

**Fix:** compare the parsed hostname (userinfo and port stripped) against the base domain, accepting only an exact match or a true subdomain suffix.

### 4 — SSRF in the file-analyzer
The file-analyzer extracts URLs from task text and fetches them server-side from inside the orchestrator pod, returning the body of text responses to the user. With no destination restriction, an authenticated user (or prompt injection in an analyzed document) could make the pod read cluster-internal services and the cloud-metadata endpoint and receive the response.

**Fix:** `_assert_public_url` resolves each URL's host and refuses any that maps to a loopback/private/link-local/reserved address (incl. `169.254.169.254`), applied at the single fetch choke point before type detection; the type-detection probe no longer follows redirects (so a redirect can't bounce a validated URL into an internal address).

> Note: the guard validates at DNS-resolution time and does not pin the connection to the resolved IP, so it does not by itself defend against active DNS rebinding. The cluster's IMDSv2 + hop-limit-1 node hardening already blocks the metadata-credential path; an egress `NetworkPolicy` remains the recommended defense-in-depth.

## Test plan
- [ ] `deactivate` / `update` / `bulk-update` reject activations the caller doesn't own (personal), isn't a member of (group), or lacks write on (sub-agent), returning 404
- [ ] Owner/member/write-capable caller still succeeds on their own activations
- [ ] OIDC login/logout accept only base-domain and subdomain redirect targets; `…evil.com` and query-string tricks are rejected
- [ ] file-analyzer refuses `http://169.254.169.254/…` and internal hosts, still analyzes public URLs

## Not included (below the review's confidence bar; flagged for follow-up)
- Agent-card fetches use `verify=False` (`discovery.py`, `agent-runner/agent/core.py`) — MITM-gated TLS-verification disable.
- `aud`/`azp` not validated on bearer-token auth (acknowledged TODO).
- `activate_skill` doesn't verify group membership for group-scoped activations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
