### PR TITLE
feat(file-analyzer): audio/PDF base64 inlining, video rejection, and model-edit persistence

### DIFF
--- a/packages/console-backend/console_backend/routers/admin_model_gateway_router.py
+++ b/packages/console-backend/console_backend/routers/admin_model_gateway_router.py
@@ -70,6 +70,15 @@ def _with_default_vertex_location(litellm_params: dict, provider: str) -> dict:
     return litellm_params
 
 
+def _gateway_model_id(result: object) -> str | None:
+    """The gateway deployment id from a /model/new (register or re-register) response, or None.
+
+    Both the register and edit endpoints read it the same way; the result is the raw gateway
+    response, so tolerate a non-dict / missing model_info defensively.
+    """
+    return (result.get("model_info") or {}).get("id") if isinstance(result, dict) else None
+
+
 # NOTE: Registrations carry NO per-model provider credentials. The proxy is the auth
 # authority for every provider: Vertex via pod ADC (GOOGLE_APPLICATION_CREDENTIALS, a file
 # projected from the GCP_KEY secret), Bedrock via the pod IAM role, Azure via the proxy's
@@ -270,7 +279,7 @@ async def register_model(
             detail=f"Rate card created but gateway registration failed ({e}); retry or clean up the rate card.",
         )
 
-    gateway_model_id = (result.get("model_info") or {}).get("id") if isinstance(result, dict) else None
+    gateway_model_id = _gateway_model_id(result)
     logger.info("Registered model %s (gateway id=%s) by %s", body.model_name, gateway_model_id, user.id)
     return ModelRegistrationResponse(
         model_name=body.model_name,
@@ -309,18 +318,39 @@ async def edit_model(
     model_info = {**body.model_info, "input_modes": body.input_modes, "mode": body.mode}
     litellm_params = _with_default_vertex_location(body.litellm_params, body.provider)
     try:
-        await svc.update_model(model_id, litellm_params, model_info)
+        result = await svc.update_model(model_id, body.model_name, litellm_params, model_info)
     except ModelGatewayError as e:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=f"Rate card updated but gateway update failed ({e}); retry.",
         )
-    logger.info("Updated model %s (gateway id=%s) by %s", body.model_name, model_id, user.id)
+    # update_model re-creates the deployment, so the gateway id changes.
+    new_model_id = _gateway_model_id(result)
+    # If the old deployment couldn't be deleted it lingers under the same model_name and the
+    # gateway load-balances across both — the edit is only partially applied. Surface that as a
+    # distinct status (instead of a clean "updated") so an admin knows to remove the stale one.
+    stale_duplicate_id = result.get("_stale_duplicate_deployment_id") if isinstance(result, dict) else None
+    if stale_duplicate_id:
+        logger.warning(
+            "Updated model %s (new gateway id=%s) but old deployment id=%s remains live "
+            "(delete failed); gateway will serve both until it is removed.",
+            body.model_name,
+            new_model_id,
+            stale_duplicate_id,
+        )
+    else:
+        logger.info(
+            "Updated model %s (old gateway id=%s, new gateway id=%s) by %s",
+            body.model_name,
+            model_id,
+            new_model_id,
+            user.id,
+        )
     return ModelRegistrationResponse(
         model_name=body.model_name,
         rate_card_entry_ids=entry_ids,
-        gateway_model_id=model_id,
-        status="updated",
+        gateway_model_id=new_model_id,
+        status="updated_with_stale_duplicate" if stale_duplicate_id else "updated",
     )
 
 

--- a/packages/console-backend/console_backend/services/feature_status.py
+++ b/packages/console-backend/console_backend/services/feature_status.py
@@ -165,6 +165,10 @@ async def collect_system_status(request: "Request", db: "AsyncSession") -> list[
     # Web search — the web_search tool, backed by the selected Search Provider (gateway-native).
     features.append(_web_search_feature(defaults.get("search"), model_info_by_name, registered))
 
+    # Audio transcription — the file-analyzer can only transcribe/analyze audio when its resolved
+    # model (chat:low → chat) declares audio input (i.e. a Gemini tier).
+    features.append(_audio_transcription_feature(defaults, model_info_by_name))
+
     # Catalog — embedding default registered + Google OAuth for source connection.
     features.append(await _catalog_feature(request, db))
 
@@ -382,6 +386,70 @@ def _web_search_feature(
             f"the cheapest capable model."
         )
     return FeatureStatus(key=key, name=name, status="ready", detail=detail, caveat=caveat)
+
+
+def _audio_transcription_feature(
+    defaults: dict[str, str], model_info_by_name: dict[str, dict] | None
+) -> FeatureStatus:
+    """Whether the file-analyzer can transcribe/analyze audio attachments.
+
+    The file-analyzer runs on the Low chat tier (``chat:low``), falling back to the Chat default —
+    the same resolution as ``model_factory.get_default_fast_model()``. Audio input requires that
+    resolved model to be **audio-capable**: it must declare ``audio`` in its gateway ``input_modes``
+    (in practice a Gemini model). On a text/vision-only tier (e.g. Claude on Bedrock) the
+    file-analyzer rejects audio with a clear message instead of attempting it — so surface the
+    requirement here so an admin knows what to configure.
+    """
+    key, name = "audio_transcription", "Audio transcription (file-analyzer)"
+    alias = defaults.get("chat:low") or defaults.get("chat")
+    tier = "Low tier (chat:low)" if defaults.get("chat:low") else "Chat default"
+
+    if not alias:
+        return FeatureStatus(
+            key=key,
+            name=name,
+            status="disabled",
+            detail="No chat model default is set, so the file-analyzer has no model to run.",
+            remediation="Set a Chat default (and ideally a Low tier) in Admin → Model Gateway.",
+        )
+
+    # Gateway list unreadable → fail open (don't hard-disable on a blip), matching the other rows.
+    if model_info_by_name is None:
+        return FeatureStatus(
+            key=key,
+            name=name,
+            status="ready",
+            detail=f"Gateway list unavailable — can't confirm audio support of '{alias}'.",
+        )
+
+    info = model_info_by_name.get(alias)
+    if info is None:
+        # Not found in the gateway list — the "Chat models" row already flags an unregistered
+        # default; here just note we can't confirm audio support rather than double-reporting.
+        return FeatureStatus(
+            key=key,
+            name=name,
+            status="degraded",
+            detail=f"The file-analyzer model '{alias}' ({tier}) isn't registered on the gateway.",
+            remediation="Register the model, or pick a registered default, in Admin → Model Gateway.",
+        )
+
+    if "audio" in (info.get("input_modes") or []):
+        return FeatureStatus(
+            key=key,
+            name=name,
+            status="ready",
+            detail=f"Enabled — the file-analyzer model '{alias}' ({tier}) accepts audio input.",
+        )
+    return FeatureStatus(
+        key=key,
+        name=name,
+        status="disabled",
+        detail=f"The file-analyzer model '{alias}' ({tier}) doesn't accept audio input — "
+        "audio files can't be transcribed.",
+        remediation="Set an audio-capable model (e.g. a Gemini model with 'audio' in its input "
+        "modes) as the Low chat tier (chat:low), or as the Chat default, in Admin → Model Gateway.",
+    )
 
 
 def _voice_agent_feature() -> FeatureStatus:

--- a/packages/console-backend/console_backend/services/model_gateway_service.py
+++ b/packages/console-backend/console_backend/services/model_gateway_service.py
@@ -205,9 +205,39 @@ class ModelGatewayService:
         self._invalidate_list_cache()
         return result
 
-    async def update_model(self, model_id: str, litellm_params: dict, model_info: dict | None = None) -> dict:
-        payload = {"litellm_params": litellm_params, "model_info": {**(model_info or {}), "id": model_id}}
-        result = await self._request("POST", "/model/update", json=payload)
+    async def update_model(
+        self, model_id: str, model_name: str, litellm_params: dict, model_info: dict | None = None
+    ) -> dict:
+        """Edit a registered deployment by re-creating it (register new, then delete old).
+
+        LiteLLM's /model/update does NOT persist custom model_info keys (input_modes, mode,
+        the default flag, …) — only /model/new does (see model_defaults_service). So a plain
+        /model/update silently drops our capability metadata, leaving edits (e.g. adding the
+        'file' input mode) with no runtime effect. Re-registering forces model_info to stick.
+
+        Register-before-delete avoids a window where the alias has no live deployment; LiteLLM
+        allows multiple deployments per public model_name, so the brief overlap is safe. Returns
+        the newly registered deployment (carrying the NEW gateway model id).
+
+        If deleting the old deployment fails, the re-registration still stands but a stale
+        duplicate remains live under the same public model_name — the gateway will load-balance
+        across both, so the edit is only partially applied until the old one is removed. That is
+        signalled to the caller via ``_stale_duplicate_deployment_id`` on the returned dict (a
+        private key, never serialized to the API client) so the endpoint can surface it rather
+        than reporting a clean success.
+        """
+        result = await self.register_model(model_name, litellm_params, model_info)
+        try:
+            await self.delete_model(model_id)
+        except ModelGatewayError:
+            logger.warning(
+                "update_model: re-registered '%s' but failed to delete old deployment id %s; "
+                "a duplicate deployment may remain — delete it manually.",
+                model_name,
+                model_id,
+            )
+            if isinstance(result, dict):
+                result["_stale_duplicate_deployment_id"] = model_id
         self._invalidate_list_cache()
         return result
 

--- a/packages/console-backend/tests/test_feature_status.py
+++ b/packages/console-backend/tests/test_feature_status.py
@@ -12,6 +12,7 @@ import pytest
 
 import console_backend.services.model_status as model_status
 from console_backend.services.feature_status import (
+    _audio_transcription_feature,
     _catalog_feature,
     _chat_tiers_feature,
     _web_search_feature,
@@ -271,3 +272,49 @@ def test_web_search_fails_open_when_gateway_unreadable():
     f = _web_search_feature("gemini-flash", None, None)
     assert f.status == "ready"
     assert "gemini-flash" in f.detail
+
+
+# _audio_transcription_feature: the file-analyzer transcribes audio only when its resolved model
+# (chat:low → chat) declares "audio" in its gateway input_modes (i.e. a Gemini tier). model_info_by_name
+# maps model_name → model_info (with input_modes).
+
+
+def test_audio_ready_when_low_tier_model_declares_audio():
+    info = {"gemini-flash": {"input_modes": ["text", "image", "audio", "video"]}}
+    f = _audio_transcription_feature({"chat": "claude", "chat:low": "gemini-flash"}, info)
+    assert f.status == "ready"
+    assert "gemini-flash" in f.detail
+    assert "Low tier" in f.detail
+
+
+def test_audio_disabled_when_model_lacks_audio_mode():
+    info = {"claude": {"input_modes": ["text", "image", "file"]}}
+    f = _audio_transcription_feature({"chat": "claude"}, info)
+    assert f.status == "disabled"
+    assert "doesn't accept audio input" in f.detail
+    assert "Gemini" in (f.remediation or "")
+
+
+def test_audio_falls_back_to_chat_default_when_no_low_tier():
+    info = {"gemini-flash": {"input_modes": ["text", "audio"]}}
+    f = _audio_transcription_feature({"chat": "gemini-flash"}, info)
+    assert f.status == "ready"
+    assert "Chat default" in f.detail
+
+
+def test_audio_disabled_when_no_chat_default():
+    f = _audio_transcription_feature({}, {})
+    assert f.status == "disabled"
+    assert "No chat model default" in f.detail
+
+
+def test_audio_degraded_when_model_not_registered():
+    f = _audio_transcription_feature({"chat:low": "ghost-model"}, {})
+    assert f.status == "degraded"
+    assert "isn't registered" in f.detail
+
+
+def test_audio_fails_open_when_gateway_unreadable():
+    f = _audio_transcription_feature({"chat:low": "gemini-flash"}, None)
+    assert f.status == "ready"
+    assert "can't confirm" in f.detail

--- a/packages/console-backend/tests/test_model_gateway_service.py
+++ b/packages/console-backend/tests/test_model_gateway_service.py
@@ -99,6 +99,77 @@ async def test_list_models_cached_and_invalidated_on_write(svc, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_update_model_recreates_deployment_to_persist_model_info(svc, monkeypatch):
+    """update_model re-registers (so custom model_info like input_modes actually persists),
+    then deletes the old deployment — it must NOT call LiteLLM's /model/update, which drops
+    custom model_info keys. Register happens before delete so the alias is never without a
+    live deployment."""
+    calls: list[tuple[str, dict]] = []
+
+    async def _fake_request(method, path, **kwargs):
+        calls.append((path, kwargs.get("json") or {}))
+        if path == "/model/new":
+            return {"model_info": {"id": "new-id"}}
+        return {}
+
+    monkeypatch.setattr(svc, "_request", _fake_request)
+
+    result = await svc.update_model(
+        "old-id",
+        "claude-sonnet-4-6",
+        {"model": "eu.anthropic.claude-sonnet-4-6"},
+        {"input_modes": ["text", "image", "file"], "mode": "chat"},
+    )
+
+    paths = [p for p, _ in calls]
+    assert "/model/update" not in paths  # the whole point: /model/update can't persist model_info
+    assert paths == ["/model/new", "/model/delete"]  # register first, then delete old
+
+    _, new_body = calls[0]
+    assert new_body["model_name"] == "claude-sonnet-4-6"
+    assert new_body["model_info"]["input_modes"] == ["text", "image", "file"]
+    assert calls[1][1] == {"id": "old-id"}  # old deployment deleted by id
+    assert result["model_info"]["id"] == "new-id"
+
+
+@pytest.mark.asyncio
+async def test_update_model_survives_failed_old_delete(svc, monkeypatch):
+    """If deleting the old deployment fails, the re-registration still stands (it was created
+    first) — update_model logs and returns rather than raising, so the edit isn't lost. It also
+    signals the lingering old deployment via _stale_duplicate_deployment_id so the endpoint can
+    report a partial success instead of a clean 'updated'."""
+
+    async def _fake_request(method, path, **kwargs):
+        if path == "/model/new":
+            return {"model_info": {"id": "new-id"}}
+        if path == "/model/delete":
+            raise ModelGatewayError("gateway unreachable")
+        return {}
+
+    monkeypatch.setattr(svc, "_request", _fake_request)
+
+    result = await svc.update_model("old-id", "m", {"model": "x"}, {"input_modes": ["file"]})
+    assert result["model_info"]["id"] == "new-id"
+    assert result["_stale_duplicate_deployment_id"] == "old-id"
+
+
+@pytest.mark.asyncio
+async def test_update_model_no_stale_signal_on_clean_delete(svc, monkeypatch):
+    """On the happy path (old delete succeeds) no stale-duplicate marker is attached, so the
+    endpoint reports a clean 'updated'."""
+
+    async def _fake_request(method, path, **kwargs):
+        if path == "/model/new":
+            return {"model_info": {"id": "new-id"}}
+        return {}
+
+    monkeypatch.setattr(svc, "_request", _fake_request)
+
+    result = await svc.update_model("old-id", "m", {"model": "x"}, {"input_modes": ["file"]})
+    assert "_stale_duplicate_deployment_id" not in result
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "litellm_model,provider,expect_dimensions",
     [

--- a/packages/orchestrator-agent/AGENTS.md
+++ b/packages/orchestrator-agent/AGENTS.md
@@ -137,6 +137,21 @@ The orchestrator's whitelisted tools always include `scheduler_*` and `console_*
 
 `file-analyzer` is created with `sub_agent_id=None`. This means its LLM costs are attributed to the orchestrator (not to any user-created sub-agent). This is intentional — it's a system capability.
 
+### File-Analyzer Media Support & the Video Gap
+
+`file-analyzer` (`app/agents/file_analyzer.py`) supports **images, PDFs, text, and audio**; **video is deliberately rejected** with a clear message (`_fetch_files`).
+
+How each type reaches the model (all traffic goes through the gateway as a langchain `ChatOpenAI` client speaking OpenAI **Chat Completions** — ADR-0001):
+- **Images** → `image_url` (a URL is valid for images in Chat Completions; LiteLLM fetches it for Bedrock).
+- **PDFs** → fetched and **inlined as base64** (`file` block with `base64`). A `file` block carrying a *URL* is rejected at payload build ("file URLs … with Chat Completions"), and Bedrock/Vertex accept base64 document sources only — so base64 is the one portable form. Do **not** provider-gate this.
+- **Text** → fetched inline as a text block.
+- **Audio** → fetched and **inlined as base64** (same wire reason as PDFs — a URL `file` block is rejected). Kept because audio is a first-class chat input. **Capability-gated:** requires the resolved model to declare `audio` input (i.e. be audio-capable, e.g. Gemini — the fleet's cheap tier is `gemini-3.5-flash`); Claude has no audio modality. On a non-audio tier, audio is **rejected up front** with a clear message (`_reject_unsupported_media`) — *not* silently dropped to text (which read as "No processable files" and triggered pointless re-delegation to general-purpose). LiteLLM's Vertex path accepts base64 `file` blocks.
+
+`get_supported_input_modes()` reflects this honestly: it narrows the model's declared modes to `_HANDLEABLE_MODES` — always drops `video`, and offers `audio`/`file` only when the model declares them — so the agent card and orchestrator routing don't over-promise. The **System Status** page has an "Audio transcription (file-analyzer)" row (`feature_status._audio_transcription_feature`) so an admin can see whether audio works and what to configure (an audio-capable model on the `chat:low`/`chat` default).
+- **Video** → **rejected.** Model *capability* is no longer the blocker — the cheap tier is `gemini-3.5-flash`, which handles video. The blocker is **transport**: (1) a URL `file` block is rejected at payload build ("file URLs … with Chat Completions"), and (2) base64 doesn't scale to video (Gemini inline ~20 MB, request cap 32 MB). So neither form we can currently send works.
+
+**Enabling video later — it's an upload pipeline, not a client tweak.** Vertex `fileData.file_uri` requires a `gs://` GCS URI or a **Gemini File API** handle; it will **not** fetch an arbitrary S3 presigned HTTPS URL (confirmed). Our attachments live in **S3**, so the real work is: (a) stage the video into a Gemini-reachable location — an S3→GCS copy (`gs://`) or a Gemini File API upload — which pulls **GCP credentials app-side** (the proxy holds Vertex creds, but the upload is orchestrator-side), a staging bucket + lifecycle cleanup, and File-API retention/size limits; (b) provider-aware model routing (video ⇒ Gemini); (c) emit the `file` block with the resulting URI + `format`/`video_metadata`. **Client choice for step (c):** patch `_GatewayChatOpenAI` to pre-rewrite the media block into the raw OpenAI `file` shape before the base translator runs — do **not** switch to `langchain-litellm`/`ChatLiteLLM` (a second client that bypasses the proxy and loses cost tracking, virtual keys, and the reasoning/`thinking_blocks`/`cache_control` handling). Bedrock video is limited to TwelveLabs Pegasus via a non-content-block `mediaSource` param the `ChatOpenAI` path can't express.
+
 ### Error Classification for Sub-Agent Failures
 
 `ErrorClassificationMiddleware` classifies errors from sub-agent execution (auth failures, tool errors, etc.) to provide actionable feedback to the orchestrator's planning loop.

--- a/packages/orchestrator-agent/app/agents/file_analyzer.py
+++ b/packages/orchestrator-agent/app/agents/file_analyzer.py
@@ -1,10 +1,10 @@
 """File Analyzer Sub-Agent.
 
-A local sub-agent for analyzing files (images, PDFs, text, audio, video) using multimodal capabilities.
+A local sub-agent for analyzing files (images, PDFs, text, audio) using multimodal capabilities.
 This is a built-in capability, not an external A2A service, providing:
 
 1. Clean LangSmith observability (separate agent trace)
-2. A multimodal model (the fleet's cheap chat tier, resolved at runtime) supporting audio/video natively
+2. A multimodal model (the fleet's cheap chat tier, resolved at runtime)
 3. Consistent sub-agent interface with the rest of the system
 
 The sub-agent accepts any HTTPS URL directly (public URLs work as-is).
@@ -12,21 +12,28 @@ For S3 URIs (s3://...), the orchestrator should first convert them to
 presigned HTTPS URLs using the generate_presigned_url tool.
 
 Supported file types:
-- Images: PNG, JPG, JPEG, GIF, WebP, BMP, TIFF
-- Documents: PDF
-- Text: TXT, JSON, CSV, MD, XML, YAML, HTML
-- Audio: MP3, WAV, M4A, MPEG, OGG, WEBM (with transcription)
-- Video: MP4, WEBM, AVI, MOV (with audio analysis)
+- Images: PNG, JPG, JPEG, GIF, WebP, BMP, TIFF (sent as image_url)
+- Documents: PDF (fetched and inlined as base64)
+- Text: TXT, JSON, CSV, MD, XML, YAML, HTML (fetched inline)
+- Audio: MP3, WAV, M4A, MPEG, OGG, WEBM (first-class chat input; inlined as base64 —
+  requires an audio-capable resolved model, e.g. Gemini; Claude has no audio modality)
+
+NOT supported (rejected with a clear message — see the video branch in _fetch_files):
+- Video. Blocked by transport, not capability (the Gemini tier can do video): the ChatOpenAI
+  wire format (ADR-0001) rejects a URL `file` block, and base64 doesn't scale to video. Real
+  support is an upload pipeline — Vertex needs a gs:// (or Gemini File API) URI and won't fetch
+  our S3 presigned URLs, so the file must be staged there first. See AGENTS.md ("the Video Gap").
 
 This module uses LocalA2ARunnable to provide the same response format
 as remote A2A agents, ensuring consistent middleware behavior.
 
 Model: the fleet's cheap/fast chat tier, resolved at runtime from the gateway
-(model_factory.get_default_fast_model). The configured default must be multimodal-capable
-(image/PDF/audio/video). No env var or hardcoded alias: models are registered at runtime.
+(model_factory.get_default_fast_model). No env var or hardcoded alias: models are
+registered at runtime.
 """
 
 import asyncio
+import base64
 import ipaddress
 import logging
 import re
@@ -62,7 +69,8 @@ logger = logging.getLogger(__name__)
 FILE_ANALYZER_NAME = "file-analyzer"
 FILE_ANALYZER_DESCRIPTION = (
     "Analyzes the content of attached files or files at HTTPS URLs and answers questions about them. "
-    "Automatically detects and handles: images, PDFs, text files, audio files, and videos. "
+    "Handles images, PDFs, text, and audio files. "
+    "Video is NOT supported yet — do not route video files here. "
     "Attached files from the user's message are forwarded automatically — just describe what analysis you need. "
     "For HTTPS URLs in text, include the full URL. "
     "Do NOT assume the file type - let the analyzer determine it. "
@@ -132,6 +140,49 @@ VIDEO_EXTENSIONS = {".mp4", ".webm", ".avi", ".mov", ".mkv", ".flv", ".wmv"}
 # Maximum text file size to fetch (1MB)
 MAX_TEXT_FETCH_BYTES = 1 * 1024 * 1024
 
+# Maximum document (PDF) size to fetch and inline as base64. Documents are sent to the
+# model as base64 (see _fetch_files) because the Chat Completions wire format the gateway
+# speaks rejects file *URLs* — only base64/file_id file sources are accepted. Base64 inflates
+# ~33%, and Anthropic/Bedrock cap the whole request near 32MB, so keep the raw file well under.
+MAX_DOC_FETCH_BYTES = 20 * 1024 * 1024
+
+# Maximum audio size to fetch and inline as base64. Audio is inlined for the same wire-format
+# reason as PDFs (a file URL can't be expressed in Chat Completions), and Gemini's inline-data
+# path caps the whole request near 20MB. Chat voice recordings are far smaller than this.
+MAX_AUDIO_FETCH_BYTES = 20 * 1024 * 1024
+
+# Content types the file-analyzer can process end-to-end, in advertised order. Used by
+# get_supported_input_modes() to narrow the resolved model's declared input_modes. Excludes
+# "video" (the gateway path can't carry it — see _fetch_files); "audio"/"file" pass through
+# only when the model also declares them (audio needs an audio-capable model, e.g. Gemini).
+_HANDLEABLE_MODES = ("text", "image", "file", "audio")
+
+# Audio extension → MIME type for the base64 file block. Extensions not listed fall back to
+# audio/mpeg (covers .mp3 and anything unrecognized). Detection accepts more (AUDIO_EXTENSIONS);
+# this only needs the wire MIME for the formats we tag distinctly.
+_AUDIO_EXT_TO_MIME = {
+    ".wav": "audio/wav",
+    ".ogg": "audio/ogg",
+    ".webm": "audio/webm",
+    ".m4a": "audio/m4a",
+    ".flac": "audio/flac",
+}
+
+# User-facing rejection messages. Shared between the preflight (_reject_unsupported_media,
+# which routes on the declared block type) and _fetch_files (which routes on the type detected
+# from the actual content) so both entry points emit the same message — audio/video can be
+# discovered at either stage (e.g. a user-pasted URL only surfaces its type in _fetch_files).
+_VIDEO_UNSUPPORTED_MSG = (
+    "Video files aren't supported for analysis yet — "
+    "I can analyze images, PDFs, audio, and text files."
+)
+_AUDIO_UNAVAILABLE_MSG = (
+    "Audio transcription isn't available: the configured file-analyzer model doesn't "
+    "accept audio input. An admin must set an audio-capable model (e.g. a Gemini model "
+    "with 'audio' input mode) as the Low chat tier or the Chat default in "
+    "Admin → Model Gateway."
+)
+
 # System prompt for the file analyzer
 FILE_ANALYZER_SYSTEM_PROMPT = """<role>
 You are a file analysis assistant. Your job is to analyze files and answer questions about their content.
@@ -150,7 +201,6 @@ When analyzing a file:
 - PDFs: Extract and summarize text, describe layouts, identify key information.
 - Text files: Summarize content, answer questions, extract specific data.
 - Audio files (audio/webm, audio/wav, etc.): Transcribe speech EXACTLY as spoken, word for word. Do not describe visual content — audio files have no video.
-- Video files (video/mp4, video/webm, etc.): Describe visual content AND transcribe audio EXACTLY as spoken.
 </file_type_guidelines>
 
 <audio_transcription_rules>
@@ -277,12 +327,37 @@ async def _detect_file_type(url: str, client: httpx.AsyncClient) -> str:
     return "unknown"
 
 
+async def _fetch_bytes_capped(
+    client: httpx.AsyncClient, url: str, max_bytes: int, too_large_msg: str
+) -> bytes:
+    """GET ``url`` and return its body, aborting as soon as it exceeds ``max_bytes``.
+
+    Streams the response so an oversized (or malicious) URL is never fully buffered before the
+    limit is enforced: a declared ``Content-Length`` over the cap is rejected before reading the
+    body, and the incremental read still caps memory at ~``max_bytes`` when the header is absent
+    or lies. Raises ``ValueError(too_large_msg)`` when the cap is exceeded.
+    """
+    async with client.stream("GET", url) as response:
+        response.raise_for_status()
+        cl = response.headers.get("content-length")
+        if cl and cl.strip().isdigit() and int(cl) > max_bytes:
+            raise ValueError(too_large_msg)
+        buf = bytearray()
+        async for chunk in response.aiter_bytes():
+            buf.extend(chunk)
+            if len(buf) > max_bytes:
+                raise ValueError(too_large_msg)
+        return bytes(buf)
+
+
 def _create_file_analyzer_model(callbacks: Optional[List] = None):
     """Create the model for file analysis.
 
     Runs on the fleet's cheap/fast chat tier, resolved at runtime from the gateway
     (model_factory.get_default_fast_model). File analysis needs a multimodal-capable model
-    (image/PDF/audio/video), so the admin's chat / chat:low default must support file content.
+    (image/PDF/audio), so the admin's chat / chat:low default must support file content. Audio
+    additionally requires an audio-capable tier (e.g. Gemini); video is not supported (see
+    _fetch_files / AGENTS.md "the Video Gap").
 
     Args:
         callbacks: Optional list of callbacks to attach to the model
@@ -296,10 +371,11 @@ def _create_file_analyzer_model(callbacks: Optional[List] = None):
 
 
 class FileAnalyzerRunnable(LocalA2ARunnable):
-    """Local sub-agent for analyzing files (images, PDFs, text, audio, video).
+    """Local sub-agent for analyzing files (images, PDFs, text, audio).
 
     Uses multimodal LLM capabilities (default: Gemini) to analyze file content.
-    Natively supports audio transcription and video analysis without separate services.
+    Supports audio transcription (on an audio-capable tier) without a separate service; video is
+    not supported through the gateway path (see _fetch_files / AGENTS.md "the Video Gap").
     Uses CostTrackingCallback for automatic cost tracking through LangChain.
     Extends LocalA2ARunnable to ensure consistent response format with remote A2A agents.
 
@@ -338,24 +414,64 @@ class FileAnalyzerRunnable(LocalA2ARunnable):
         return FILE_ANALYZER_NAME
 
     def get_supported_input_modes(self) -> List[str]:
-        """Get list of input modes supported by the file analyzer.
+        """Content types the file-analyzer actually handles end-to-end.
 
-        Derived from the resolved model's gateway-declared input_modes (set at registration),
-        so the advertised modes track the actual multimodal capability of whatever the admin
-        configured as the cheap chat tier — rather than assuming full audio/video support.
-        Falls back to text+image when no default is configured or the gateway snapshot is
-        unavailable.
+        Starts from the resolved model's gateway-declared input_modes (set at registration) and
+        narrows to what this agent can genuinely process (`_HANDLEABLE_MODES`):
+        - **Video is always dropped** — the gateway path can't carry it (see `_fetch_files`),
+          regardless of what the model declares.
+        - **Audio / file (PDF) are offered only when the model declares them** — audio needs an
+          audio-capable model (e.g. Gemini); a text/vision-only tier (e.g. Claude/Bedrock) can't
+          transcribe audio, so we neither advertise nor attempt it.
 
-        Returns:
-            List of supported content types
+        This is both the agent-card capability (so the orchestrator routes honestly) and the
+        input to the base block-strip. Falls back to text+image when no default is configured
+        or the gateway snapshot is unavailable.
         """
         model_type = self.get_model_type()
+        model_modes: List[str] = ["text", "image"]
         if model_type:
             try:
-                return get_model_input_capabilities(model_type)  # type: ignore[arg-type]
+                model_modes = list(get_model_input_capabilities(model_type))  # type: ignore[arg-type]
             except Exception:
                 pass
-        return ["text", "image"]
+        return [m for m in _HANDLEABLE_MODES if m in model_modes]
+
+    def _supports_audio(self) -> bool:
+        """Whether the resolved file-analyzer model accepts audio input.
+
+        True only when the model declares `audio` in its gateway input_modes — in practice an
+        audio-capable model such as Gemini. On a text/vision-only tier (e.g. Claude on Bedrock)
+        audio transcription is unavailable and audio attachments are rejected with a clear
+        message (see `_reject_unsupported_media`) rather than attempted and silently failed.
+        """
+        return "audio" in self.get_supported_input_modes()
+
+    def _reject_unsupported_media(self, input_data: SubAgentInput) -> None:
+        """Fail fast with a clear, user-facing message for media this agent can't process.
+
+        Runs before the base block-strip so unsupported media doesn't get silently rewritten to
+        a text description — which surfaces as the generic "No processable files" error and, worse,
+        prompts the orchestrator to pointlessly re-delegate to general-purpose.
+
+        - **Video** is never supported (the gateway path can't carry it — see `_fetch_files`).
+        - **Audio** requires an audio-capable resolved model (e.g. Gemini). On a text/vision-only
+          tier there's no point attempting it.
+
+        Gated on the block's declared type (the same signal the base strip routes on), so no fetch
+        happens first.
+        """
+        if not input_data.messages:
+            return
+        content = input_data.messages[-1].content
+        if not isinstance(content, list):
+            return
+        types = {b.get("type") for b in content if isinstance(b, dict)}
+
+        if "video" in types:
+            raise ValueError(_VIDEO_UNSUPPORTED_MSG)
+        if "audio" in types and not self._supports_audio():
+            raise ValueError(_AUDIO_UNAVAILABLE_MSG)
 
     def get_model_type(self) -> str | None:
         """Return the file analyzer model type for provider-specific transforms.
@@ -439,57 +555,79 @@ class FileAnalyzerRunnable(LocalA2ARunnable):
                 content_blocks.append(image_block)
 
             elif file_type == "document":
-                logger.info("Detected document file, adding to request...")
+                # Documents must be sent as base64, NOT as a URL — and this is NOT a
+                # Bedrock-specific choice, so don't gate it on the provider. Every model goes
+                # through the gateway as a langchain ChatOpenAI client speaking OpenAI Chat
+                # Completions (ADR-0001), whose file content part has no URL form: a file block
+                # carrying a `url` is rejected at payload build ("file URLs ... with Chat
+                # Completions"), for every provider. base64 is the one source that works across
+                # all of them (Bedrock/Vertex additionally accept base64 only at the provider
+                # layer). Images differ — image_url accepts a URL — which is why only documents
+                # need this. Revisit only if we ever route documents through a native
+                # (non-ChatOpenAI) client or the Responses API.
+                logger.info("Detected document file, fetching bytes to inline as base64...")
+                content = await _fetch_bytes_capped(
+                    client,
+                    file_url,
+                    MAX_DOC_FETCH_BYTES,
+                    f"PDF too large. Maximum is {MAX_DOC_FETCH_BYTES:,} bytes.",
+                )
+
+                filename = file_url.split("?")[0].rsplit("/", 1)[-1] or "document.pdf"
                 file_block: FileContentBlock = {
                     "type": "file",
-                    "url": file_url,
+                    "base64": base64.b64encode(content).decode("ascii"),
                     "mime_type": "application/pdf",
+                    "filename": filename,
                 }
                 content_blocks.append(file_block)
 
             elif file_type == "audio":
-                logger.info("Detected audio file, adding to multimodal request...")
-                # Audio files are passed as file blocks with MIME type detection
-                # Gemini models will transcribe and analyze the audio content
-                content_type = "audio/mpeg"  # Default; can be refined based on extension
-                ext = _get_file_extension(file_url)
-                if ext == ".wav":
-                    content_type = "audio/wav"
-                elif ext == ".ogg":
-                    content_type = "audio/ogg"
-                elif ext == ".webm":
-                    content_type = "audio/webm"
-                elif ext == ".m4a":
-                    content_type = "audio/m4a"
-                elif ext == ".flac":
-                    content_type = "audio/flac"
+                # Audio must be inlined as base64, NOT sent as a URL — same wire-format reason as
+                # documents: a `file` block carrying a `url` is rejected at payload build ("file
+                # URLs ... with Chat Completions"). base64 is viable here because chat voice
+                # recordings are small; the resolved model must be audio-capable (e.g. Gemini) —
+                # Claude has no audio modality. LiteLLM's Vertex path accepts base64 `file` blocks.
+                # Capability gate — also enforced here, not only in the preflight. The preflight
+                # (_reject_unsupported_media) routes on the declared block type, but audio can be
+                # discovered here for the first time when it wasn't typed "audio" upstream — e.g. a
+                # user-pasted audio URL (regex fallback, no block) or a file block whose mime isn't
+                # audio/*. Without this check such audio would be inlined and fail opaquely deep in
+                # the model call on a text/vision-only tier, instead of the clear message below.
+                if not self._supports_audio():
+                    raise ValueError(_AUDIO_UNAVAILABLE_MSG)
+                logger.info("Detected audio file, fetching bytes to inline as base64...")
+                content_type = _AUDIO_EXT_TO_MIME.get(_get_file_extension(file_url), "audio/mpeg")
 
+                content = await _fetch_bytes_capped(
+                    client,
+                    file_url,
+                    MAX_AUDIO_FETCH_BYTES,
+                    f"Audio file too large. Maximum is {MAX_AUDIO_FETCH_BYTES:,} bytes.",
+                )
+
+                filename = file_url.split("?")[0].rsplit("/", 1)[-1] or "audio"
                 file_block: FileContentBlock = {
                     "type": "file",
-                    "url": file_url,
+                    "base64": base64.b64encode(content).decode("ascii"),
                     "mime_type": content_type,
+                    "filename": filename,
                 }
                 content_blocks.append(file_block)
 
             elif file_type == "video":
-                logger.info("Detected video file, adding to multimodal request...")
-                # Video files are passed as file blocks
-                # Gemini models will analyze both video and audio content
-                content_type = "video/mp4"  # Default; can be refined based on extension
-                ext = _get_file_extension(file_url)
-                if ext == ".webm":
-                    content_type = "video/webm"
-                elif ext == ".avi":
-                    content_type = "video/avi"
-                elif ext == ".mov":
-                    content_type = "video/quicktime"
-
-                file_block: FileContentBlock = {
-                    "type": "file",
-                    "url": file_url,
-                    "mime_type": content_type,
-                }
-                content_blocks.append(file_block)
+                # KNOWN GAP: video is not supported through the current gateway path. Reject with
+                # a clear message rather than emitting a block that fails opaquely deep in the
+                # model call. The blocker is TRANSPORT, not model capability (the Gemini tier can
+                # do video): a URL `file` block is rejected at payload build ("file URLs ... with
+                # Chat Completions", ADR-0001's ChatOpenAI wire format), and base64 doesn't scale
+                # to video (Gemini inline ~20MB, request cap 32MB) — so neither form we can send
+                # works. Real support is an upload pipeline: Vertex requires a gs:// (or Gemini
+                # File API) URI — it won't fetch our S3 presigned URLs — so the file must be
+                # staged into a Gemini-reachable location first. See AGENTS.md ("the Video Gap").
+                # (Audio is kept above: small enough to base64, and the Gemini tier handles it.)
+                logger.info("Rejecting unsupported video file: %s", file_url[:80])
+                raise ValueError(_VIDEO_UNSUPPORTED_MSG)
 
             else:
                 logger.info("Unknown file type, adding as generic file...")
@@ -579,18 +717,23 @@ class FileAnalyzerRunnable(LocalA2ARunnable):
         an unnecessary decompose/recompose roundtrip, then applies file-analyzer-
         specific processing:
         1. Image blocks passed through directly (natively supported by multimodal models)
-        2. Other file blocks (audio, video, documents) routed through _fetch_files
-           for proper MIME type detection — critical for audio/webm correction
-           where browsers send video/webm but Gemini requires audio/webm
+        2. Other file blocks (audio, documents) routed through _fetch_files for content-type
+           detection and base64 inlining; video blocks reach _fetch_files only to be rejected
+           (unsupported through the gateway path)
         3. Regex URL fallback when no file blocks are present (user-typed URLs)
 
         S3 URI validation is handled by the base _extract_and_validate_blocks().
 
         Raises:
-            ValueError: For user-facing input issues (S3 URIs, no URLs, no processable files)
+            ValueError: For user-facing input issues (S3 URIs, no URLs, no processable files,
+                unsupported media — see _reject_unsupported_media)
             httpx.HTTPStatusError: For HTTP errors during file fetching
             httpx.TimeoutException: For timeout during file fetching
         """
+        # Fail fast on media this agent can't process, with a clear message — before the base
+        # block-strip silently converts it to a text description ("No processable files").
+        self._reject_unsupported_media(input_data)
+
         text_content, file_blocks = await self._extract_and_validate_blocks(input_data)
 
         if file_blocks:

--- a/packages/orchestrator-agent/tests/test_file_analyzer.py
+++ b/packages/orchestrator-agent/tests/test_file_analyzer.py
@@ -1,0 +1,272 @@
+"""Tests for FileAnalyzerRunnable._fetch_files document handling.
+
+Documents (PDFs) must be inlined as base64, not forwarded as a URL: the Chat Completions
+wire format the gateway speaks rejects file *URLs* (only base64/file_id file sources are
+accepted), so a url-carrying file block fails during payload construction. These tests lock
+in that documents come back as base64 file blocks and that oversized PDFs are rejected.
+"""
+
+import base64
+
+import pytest
+from app.agents import file_analyzer
+from app.agents.file_analyzer import MAX_DOC_FETCH_BYTES, FileAnalyzerRunnable
+
+
+class _FakeResponse:
+    def __init__(self, content: bytes):
+        self.content = content
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _FakeStreamResponse:
+    """Mirrors the slice of httpx's streaming response that _fetch_bytes_capped uses."""
+
+    def __init__(self, content: bytes, *, send_content_length: bool = True):
+        self._content = content
+        self.headers = {"content-length": str(len(content))} if send_content_length else {}
+
+    def raise_for_status(self) -> None:
+        return None
+
+    async def aiter_bytes(self, chunk_size: int = 65536):
+        for i in range(0, len(self._content), chunk_size):
+            yield self._content[i : i + chunk_size]
+
+
+class _FakeStreamCtx:
+    def __init__(self, response: _FakeStreamResponse):
+        self._response = response
+
+    async def __aenter__(self) -> _FakeStreamResponse:
+        return self._response
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+
+class _FakeClient:
+    def __init__(self, content: bytes, *, send_content_length: bool = True):
+        self._content = content
+        self._send_content_length = send_content_length
+
+    async def get(self, url, **kwargs):
+        return _FakeResponse(self._content)
+
+    def stream(self, method, url, **kwargs):
+        return _FakeStreamCtx(
+            _FakeStreamResponse(self._content, send_content_length=self._send_content_length)
+        )
+
+
+@pytest.fixture
+def _stub_detection(monkeypatch):
+    """Force document detection and bypass the SSRF guard for these unit tests."""
+
+    async def _noop_assert(_url):
+        return None
+
+    async def _detect_document(_url, _client):
+        return "document"
+
+    monkeypatch.setattr(file_analyzer, "_assert_public_url", _noop_assert)
+    monkeypatch.setattr(file_analyzer, "_detect_file_type", _detect_document)
+
+
+@pytest.mark.asyncio
+async def test_document_is_inlined_as_base64_not_url(_stub_detection):
+    pdf_bytes = b"%PDF-1.7\nfake pdf body\n%%EOF"
+    runnable = FileAnalyzerRunnable()
+
+    blocks = await runnable._fetch_files(
+        ["https://example.com/uploads/Report%20Final.pdf?sig=abc"],
+        _FakeClient(pdf_bytes),
+    )
+
+    assert len(blocks) == 1
+    block = blocks[0]
+    assert block["type"] == "file"
+    assert "url" not in block  # the whole point: no URL survives to the wire payload
+    assert block.get("mime_type") == "application/pdf"
+    assert block.get("base64") == base64.b64encode(pdf_bytes).decode("ascii")
+    assert block.get("filename") == "Report%20Final.pdf"
+
+
+@pytest.mark.asyncio
+async def test_oversized_document_is_rejected(_stub_detection):
+    """Server declares Content-Length over the cap → rejected before the body is read."""
+    runnable = FileAnalyzerRunnable()
+    too_big = b"x" * (MAX_DOC_FETCH_BYTES + 1)
+
+    with pytest.raises(ValueError, match="PDF too large"):
+        await runnable._fetch_files(["https://example.com/huge.pdf"], _FakeClient(too_big))
+
+
+@pytest.mark.asyncio
+async def test_oversized_document_rejected_without_content_length(_stub_detection):
+    """No/lying Content-Length → the incremental streaming read still caps memory and rejects
+    once the accumulated body exceeds the limit (never buffering the whole thing first)."""
+    runnable = FileAnalyzerRunnable()
+    too_big = b"x" * (MAX_DOC_FETCH_BYTES + 1)
+
+    with pytest.raises(ValueError, match="PDF too large"):
+        await runnable._fetch_files(
+            ["https://example.com/huge.pdf"],
+            _FakeClient(too_big, send_content_length=False),
+        )
+
+
+@pytest.mark.asyncio
+async def test_video_is_rejected_with_clear_message(monkeypatch):
+    """Video isn't supported through the gateway path (no media-URL in Chat Completions,
+    base64 doesn't scale). Reject with a clear, user-facing message rather than emitting a
+    block that fails opaquely inside the model call. Audio, by contrast, is kept."""
+
+    async def _noop_assert(_url):
+        return None
+
+    async def _detect_video(_url, _client):
+        return "video"
+
+    monkeypatch.setattr(file_analyzer, "_assert_public_url", _noop_assert)
+    monkeypatch.setattr(file_analyzer, "_detect_file_type", _detect_video)
+
+    runnable = FileAnalyzerRunnable()
+    with pytest.raises(ValueError, match="Video files aren't supported"):
+        await runnable._fetch_files(["https://example.com/clip.mp4"], _FakeClient(b""))
+
+
+@pytest.mark.asyncio
+async def test_audio_is_inlined_as_base64_not_url(monkeypatch):
+    """Audio is a first-class chat input in this fleet — it must NOT be rejected. Like PDFs it
+    is inlined as base64 (a URL file block is rejected by the Chat Completions translator);
+    the resolved model must be audio-capable (e.g. Gemini)."""
+
+    async def _noop_assert(_url):
+        return None
+
+    async def _detect_audio(_url, _client):
+        return "audio"
+
+    monkeypatch.setattr(file_analyzer, "_assert_public_url", _noop_assert)
+    monkeypatch.setattr(file_analyzer, "_detect_file_type", _detect_audio)
+    # Audio inlining requires an audio-capable resolved model (the _fetch_files capability gate).
+    monkeypatch.setattr(file_analyzer, "get_default_fast_model", lambda: "gemini-x")
+    monkeypatch.setattr(
+        file_analyzer, "get_model_input_capabilities",
+        lambda _m: ["text", "image", "audio", "file"],
+    )
+
+    audio_bytes = b"OggS\x00fake-opus-voice-recording"
+    runnable = FileAnalyzerRunnable()
+    blocks = await runnable._fetch_files(
+        ["https://example.com/voice.ogg?sig=x"], _FakeClient(audio_bytes)
+    )
+
+    assert len(blocks) == 1
+    block = blocks[0]
+    assert block["type"] == "file"
+    assert "url" not in block  # URL file blocks are rejected on the wire
+    assert block.get("mime_type") == "audio/ogg"
+    assert block.get("base64") == base64.b64encode(audio_bytes).decode("ascii")
+    assert block.get("filename") == "voice.ogg"
+
+
+@pytest.mark.asyncio
+async def test_audio_via_fetch_files_rejected_on_non_audio_model(monkeypatch):
+    """The capability gate must hold in _fetch_files too, not only in the preflight: audio can be
+    discovered here for the first time (a user-pasted URL has no typed block for the preflight to
+    inspect). On a text/vision-only tier it must raise the clear message rather than inline the
+    audio and fail opaquely deep in the model call."""
+
+    async def _noop_assert(_url):
+        return None
+
+    async def _detect_audio(_url, _client):
+        return "audio"
+
+    monkeypatch.setattr(file_analyzer, "_assert_public_url", _noop_assert)
+    monkeypatch.setattr(file_analyzer, "_detect_file_type", _detect_audio)
+    monkeypatch.setattr(file_analyzer, "get_default_fast_model", lambda: "claude-x")
+    monkeypatch.setattr(
+        file_analyzer, "get_model_input_capabilities", lambda _m: ["text", "image", "file"]
+    )
+
+    runnable = FileAnalyzerRunnable()
+    with pytest.raises(ValueError, match="Audio transcription isn't available"):
+        await runnable._fetch_files(
+            ["https://example.com/voice.ogg?sig=x"], _FakeClient(b"OggS\x00fake")
+        )
+
+
+# --- Capability gate: honest advertised modes + preflight rejection ---
+# get_supported_input_modes narrows the model's declared modes to what the file-analyzer can
+# handle: video is always dropped; audio/file only when the model declares them. Unsupported
+# media is rejected up front with a clear message (not the generic "No processable files").
+
+from types import SimpleNamespace  # noqa: E402
+
+
+def _input_with_blocks(*blocks):
+    return SimpleNamespace(messages=[SimpleNamespace(content=list(blocks))])
+
+
+def test_supported_modes_drops_video_keeps_declared_audio(monkeypatch):
+    monkeypatch.setattr(file_analyzer, "get_default_fast_model", lambda: "gemini-x")
+    monkeypatch.setattr(
+        file_analyzer, "get_model_input_capabilities",
+        lambda _m: ["text", "image", "audio", "video", "file"],
+    )
+    modes = FileAnalyzerRunnable().get_supported_input_modes()
+    assert "video" not in modes  # gateway can't carry video
+    assert modes == ["text", "image", "file", "audio"]
+
+
+def test_supported_modes_excludes_audio_when_model_lacks_it(monkeypatch):
+    monkeypatch.setattr(file_analyzer, "get_default_fast_model", lambda: "claude-x")
+    monkeypatch.setattr(
+        file_analyzer, "get_model_input_capabilities", lambda _m: ["text", "image", "file"]
+    )
+    modes = FileAnalyzerRunnable().get_supported_input_modes()
+    assert modes == ["text", "image", "file"]
+    assert not FileAnalyzerRunnable()._supports_audio()
+
+
+def test_preflight_rejects_video(monkeypatch):
+    monkeypatch.setattr(file_analyzer, "get_default_fast_model", lambda: "gemini-x")
+    monkeypatch.setattr(
+        file_analyzer, "get_model_input_capabilities",
+        lambda _m: ["text", "image", "audio", "file"],
+    )
+    runnable = FileAnalyzerRunnable()
+    with pytest.raises(ValueError, match="Video files aren't supported"):
+        runnable._reject_unsupported_media(
+            _input_with_blocks({"type": "video", "url": "https://x/clip.mp4"})
+        )
+
+
+def test_preflight_rejects_audio_when_model_not_audio_capable(monkeypatch):
+    monkeypatch.setattr(file_analyzer, "get_default_fast_model", lambda: "claude-x")
+    monkeypatch.setattr(
+        file_analyzer, "get_model_input_capabilities", lambda _m: ["text", "image", "file"]
+    )
+    runnable = FileAnalyzerRunnable()
+    with pytest.raises(ValueError, match="Audio transcription isn't available"):
+        runnable._reject_unsupported_media(
+            _input_with_blocks({"type": "audio", "url": "https://x/voice.webm"})
+        )
+
+
+def test_preflight_allows_audio_when_model_is_audio_capable(monkeypatch):
+    monkeypatch.setattr(file_analyzer, "get_default_fast_model", lambda: "gemini-x")
+    monkeypatch.setattr(
+        file_analyzer, "get_model_input_capabilities",
+        lambda _m: ["text", "image", "audio", "file"],
+    )
+    runnable = FileAnalyzerRunnable()
+    # No raise: audio is allowed through to fetching when the model supports it.
+    runnable._reject_unsupported_media(
+        _input_with_blocks({"type": "audio", "url": "https://x/voice.webm"})
+    )


### PR DESCRIPTION
## Summary

Two related capabilities plus supporting review fixes.

### File-analyzer media handling (`app/agents/file_analyzer.py`)
- **PDFs & audio inlined as base64.** A URL-carrying `file` block is rejected by the OpenAI Chat Completions wire format the gateway speaks (ADR-0001), for every provider — base64 is the one portable form. Not a Bedrock-specific choice, so it is **not** provider-gated.
- **Streaming memory cap.** `_fetch_bytes_capped` streams the body and aborts as soon as it exceeds the limit (early `Content-Length` reject + incremental cap), so an oversized or hostile URL is never fully buffered before rejection.
- **Video rejected with a clear message.** The blocker is transport, not model capability (the Gemini tier can do video) — see AGENTS.md "the Video Gap".
- **Audio capability gate** enforced in *both* the preflight (routes on the declared block type) *and* `_fetch_files` (routes on the type detected from content), so audio discovered via a pasted URL or a mistyped block is rejected cleanly on a non-audio tier instead of failing opaquely deep in the model call.
- `get_supported_input_modes()` narrows the model's declared modes to what the agent can actually process.

### Model gateway edit (`services/model_gateway_service.py`, `routers/admin_model_gateway_router.py`)
- `update_model` now **re-registers (register-before-delete)** so custom `model_info` (`input_modes`, `mode`) actually persists — LiteLLM's `/model/update` silently drops it.
- If deleting the old deployment fails, the lingering duplicate is **surfaced to the caller** (`status="updated_with_stale_duplicate"` + warning log) rather than reported as a clean success.

### System status (`services/feature_status.py`)
- New **"Audio transcription (file-analyzer)"** row so an admin can see whether the resolved `chat:low`/`chat` tier accepts audio and what to configure.

## Tests
- `packages/orchestrator-agent/tests/test_file_analyzer.py` (new): base64 inlining, video/audio rejection, capability gate, streaming size cap (with and without `Content-Length`).
- `packages/console-backend/tests/test_model_gateway_service.py`, `test_feature_status.py`: re-registration path, stale-duplicate signal, and the audio-status row.

All target suites green: file_analyzer 11 passed, console-backend gateway/feature-status 39 passed.

## Scope note
This PR is scoped to the 8 feature files. Unrelated working-tree drift (`voice-agent/uv.lock` version bumps, a `console-backend/uv.lock` change with no matching pyproject edit, and `console-frontend` codegen churn) was deliberately left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)