### PR TITLE
fix(console-backend): serialize sub-agent config version creation with a row lock

### DIFF
--- a/packages/console-backend/console_backend/repositories/sub_agent_repository.py
+++ b/packages/console-backend/console_backend/repositories/sub_agent_repository.py
@@ -578,6 +578,23 @@ class SubAgentRepository(AuditedRepository):
             fetch_before=True,
         )
 
+    async def lock_for_update(
+        self,
+        db: AsyncSession,
+        sub_agent_id: int,
+    ) -> None:
+        """Acquire a row lock on the sub-agent, serializing concurrent config updates.
+
+        Version numbers are assigned via MAX(version)+1, and skill add/remove
+        rebuilds the skills list from the current config — both are
+        read-then-write, so concurrent transactions must be serialized per
+        agent. The lock is held until the surrounding transaction commits.
+        """
+        await db.execute(
+            text("SELECT id FROM sub_agents WHERE id = :id FOR UPDATE"),
+            {"id": sub_agent_id},
+        )
+
     async def update_current_version(
         self,
         db: AsyncSession,

--- a/packages/console-backend/console_backend/services/sub_agent_service.py
+++ b/packages/console-backend/console_backend/services/sub_agent_service.py
@@ -892,6 +892,10 @@ class SubAgentService:
         - Name updates go to sub_agents table
         - Configuration changes (description, model, config) create a new version
         """
+        # Serialize concurrent updates per agent: version numbers are assigned
+        # MAX(version)+1 from the config read below, so both must happen under
+        # the row lock (released on commit).
+        await self.repo.lock_for_update(db, sub_agent_id)
         existing = await self.get_sub_agent_by_id(db, sub_agent_id)
         if not existing:
             return None
@@ -2100,6 +2104,10 @@ class SubAgentService:
         Raises:
             ValueError: If the agent has no default version
         """
+        # Lock before reading the skills list: concurrent activations each
+        # rebuild the list from the current config, so an unserialized read
+        # would drop the other transaction's skill.
+        await self.repo.lock_for_update(db, sub_agent_id)
         existing = await self.get_sub_agent_by_id(db, sub_agent_id)
         if not existing or not existing.config_version:
             raise ValueError(
@@ -2159,6 +2167,7 @@ class SubAgentService:
             new_hash: Updated content hash
             actor: User performing the update
         """
+        await self.repo.lock_for_update(db, sub_agent_id)
         existing = await self.get_sub_agent_by_id(db, sub_agent_id)
         if not existing or not existing.config_version:
             return
@@ -2221,6 +2230,7 @@ class SubAgentService:
             registry_id: UUID of the skill to remove
             actor: User performing the action
         """
+        await self.repo.lock_for_update(db, sub_agent_id)
         existing = await self.get_sub_agent_by_id(db, sub_agent_id)
         if not existing or not existing.config_version:
             return
@@ -2289,6 +2299,8 @@ class SubAgentService:
         is_admin: bool = False,
     ) -> SubAgent | None:
         """Revert to a previous version by creating a new version with its config."""
+        # Serialize with other version-creating updates (see lock_for_update)
+        await self.repo.lock_for_update(db, sub_agent_id)
         existing = await self.get_sub_agent_by_id(db, sub_agent_id)
         if not existing:
             return None

--- a/packages/console-backend/tests/test_sub_agent_service.py
+++ b/packages/console-backend/tests/test_sub_agent_service.py
@@ -2110,3 +2110,119 @@ async def test_pricing_config_read_write_integration(
     assert sub_agent_read.config_version is not None
     assert sub_agent_read.config_version.pricing_config is not None
     assert sub_agent_read.config_version.pricing_config == pricing_config
+
+
+class TestConcurrentVersionCreation:
+    """Concurrent config updates must serialize on the sub-agent row lock.
+
+    Regression: parallel MCP skill activations each computed the same
+    MAX(version)+1 and violated the (sub_agent_id, version) unique constraint;
+    concurrent skill adds could also silently drop each other's skill.
+    """
+
+    def _session_factory(self, postgres_with_migrations):
+        from sqlalchemy.ext.asyncio import create_async_engine
+        from sqlalchemy.orm import sessionmaker
+
+        engine = create_async_engine(postgres_with_migrations["dsn"], echo=False)
+        factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        schema = postgres_with_migrations["schema"]
+        return engine, factory, schema
+
+    @pytest.mark.asyncio
+    async def test_concurrent_updates_create_distinct_versions(
+        self,
+        sub_agent_service: SubAgentService,
+        pg_session: AsyncSession,
+        test_user_db: User,
+        postgres_with_migrations,
+    ):
+        import asyncio
+
+        from sqlalchemy import text
+
+        service = sub_agent_service
+        user = test_user_db
+        agent = await _create_sub_agent(pg_session, user, "Concurrent Update Agent", service)
+
+        engine, factory, schema = self._session_factory(postgres_with_migrations)
+
+        async def do_update(i: int) -> None:
+            async with factory() as session:
+                await session.execute(text(f"SET search_path TO {schema}"))
+                await service.update_sub_agent(
+                    session,
+                    agent.id,
+                    SubAgentUpdate(description=f"Concurrent update {i}"),
+                    user,
+                )
+
+        try:
+            await asyncio.gather(*(do_update(i) for i in range(5)))
+        finally:
+            await engine.dispose()
+
+        versions = (
+            (
+                await pg_session.execute(
+                    text(
+                        "SELECT version FROM sub_agent_config_versions "
+                        "WHERE sub_agent_id = :id ORDER BY version"
+                    ),
+                    {"id": agent.id},
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert versions == [1, 2, 3, 4, 5, 6]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_skill_adds_keep_all_skills(
+        self,
+        sub_agent_service: SubAgentService,
+        pg_session: AsyncSession,
+        test_user_db: User,
+        postgres_with_migrations,
+    ):
+        import asyncio
+        import uuid
+
+        from sqlalchemy import text
+
+        service = sub_agent_service
+        user = test_user_db
+        agent = await _create_sub_agent(pg_session, user, "Concurrent Skill Agent", service)
+
+        registry_ids = [str(uuid.uuid4()) for _ in range(3)]
+        engine, factory, schema = self._session_factory(postgres_with_migrations)
+
+        async def add_skill(i: int) -> None:
+            async with factory() as session:
+                await session.execute(text(f"SET search_path TO {schema}"))
+                await service.add_skill_to_config(
+                    db=session,
+                    sub_agent_id=agent.id,
+                    registry_id=registry_ids[i],
+                    skill_name=f"skill-{i}",
+                    skill_description=f"Skill {i}",
+                    content_hash=f"hash-{i}",
+                    actor=user,
+                )
+
+        try:
+            await asyncio.gather(*(add_skill(i) for i in range(3)))
+        finally:
+            await engine.dispose()
+
+        skills = (
+            await pg_session.execute(
+                text(
+                    "SELECT skills FROM sub_agent_config_versions "
+                    "WHERE sub_agent_id = :id ORDER BY version DESC LIMIT 1"
+                ),
+                {"id": agent.id},
+            )
+        ).scalar_one()
+        stored_ids = {ref["registry_id"] for ref in skills}
+        assert stored_ids == set(registry_ids)


### PR DESCRIPTION
## Problem

Creating skills via the MCP endpoint (`POST /api/v1/skills/registry/mcp/skills`) failed with 500s when the chat agent activated several skills on the same sub-agent concurrently:

```
UniqueViolationError: duplicate key value violates unique constraint
"sub_agent_config_versions_sub_agent_id_version_key"
DETAIL:  Key (sub_agent_id, version)=(31, 7) already exists.
```

Two bugs in the same path:

1. **Version collision** — `update_sub_agent` computes the next version with a non-atomic `SELECT MAX(version)+1` followed by an INSERT. Under READ COMMITTED, concurrent transactions can't see each other's uncommitted inserts, so they compute the same number and the loser hits the unique constraint (observed in the log: two failures 16 ms apart on `(31, 6)`, then a retry wave colliding on `(31, 7)`).
2. **Silent skill drop** — `add_skill_to_config` / `remove_skill_from_config` / `update_skill_hash_in_config` rebuild the skills list from the current config before writing a new version. Two concurrent activations reading the same base would each omit the other's skill; the unique constraint was the only thing preventing the lost update.

## Fix

New `SubAgentRepository.lock_for_update` takes a `SELECT ... FOR UPDATE` row lock on the `sub_agents` row, held until the transaction commits. It is acquired **before the config read** in every version-creating path:

- `update_sub_agent` (covers all callers, including MCP skill activation)
- `add_skill_to_config`, `update_skill_hash_in_config`, `remove_skill_from_config` (their skills-list read must also be under the lock)
- `revert_to_version` (same race via `current_version + 1`)

Each of these runs as a single transaction with one commit at the end, so the lock spans the whole read-then-write window and serializes updates per agent. Cost in the common single-writer case is one indexed row lookup.

## Verification

Added `TestConcurrentVersionCreation` with two regression tests using genuinely concurrent operations over separate DB connections:

- 5 parallel `update_sub_agent` calls → versions must come out 1–6 with no gaps
- 3 parallel `add_skill_to_config` calls → all three skills must survive in the final config (mirrors the production scenario)

Both tests fail with the exact production error when `FOR UPDATE` is removed, and pass with it. Full sub-agent + skill suites pass (84 + 137 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)