### PR TITLE
feat(orchestrator): GP sub-agent loads its tool registry as a lazy catalog

### DIFF
--- a/packages/agent-common/agent_common/agents/dynamic_agent.py
+++ b/packages/agent-common/agent_common/agents/dynamic_agent.py
@@ -79,10 +79,12 @@ from agent_common.backends.attachments_store import (
 )
 from agent_common.core.graph_utils import (
     build_sub_agent_graph,
+    code_interpreter_ptc_enabled,
     denest_parent_pregel_context,
     isolate_parent_stream_context,
 )
 from agent_common.core.model_factory import get_model_input_capabilities
+from agent_common.core.tool_catalog import TOOL_CATALOG_PROMPT_ADDENDUM, ToolCatalogMiddleware
 from agent_common.middleware.conversation_context_tools_middleware import ContextGatedTool
 from agent_common.utils import get_language_display_name
 
@@ -217,6 +219,7 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         sandbox_pool: SandboxPool | None = None,
         extra_middlewares: Optional[List[Any]] = None,
         inject_all_tools: Optional[List[BaseTool]] = None,
+        tool_catalog: Optional[dict[str, BaseTool]] = None,
         risk_scorer: RiskScorerFn | None = None,
         tool_risk_cache: ToolRiskCache | None = None,
         tool_bypass_rules: dict[str, Any] | None = None,
@@ -246,6 +249,14 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
             extra_middlewares: Optional list of middleware instances to prepend to the standard stack.
             inject_all_tools: Optional pre-discovered tools to use directly (bypasses MCP discovery).
                 When set, these tools are used as the agent's MCP tools without gateway discovery.
+            tool_catalog: Optional name -> BaseTool mapping (held by reference) of a large
+                pre-discovered catalog exposed via lazy discovery instead of binding. Unlike
+                ``inject_all_tools``, catalog tools are NEVER materialized into ``create_agent``
+                (per-tool schema conversion over a huge catalog is what OOM-killed the
+                orchestrator): under PTC they are exposed inside ``eval`` via the runtime
+                context (``expose_context_registry``); without PTC the model reaches them
+                through the native ``search_tools``/``describe_tool``/``call_tool`` meta-tools
+                (``ToolCatalogMiddleware``). Takes precedence over ``inject_all_tools``.
             risk_scorer: Optional function to score tool calls for conditional HITL.
             tool_risk_cache: Optional cache for tool risk scores to optimize conditional HITL.
             tool_bypass_rules: Optional dict of tool bypass rules for conditional HITL.
@@ -282,6 +293,7 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         self.sandbox_pool = sandbox_pool
         self.extra_middlewares = extra_middlewares
         self.inject_all_tools = inject_all_tools
+        self.tool_catalog = tool_catalog
         self._risk_scorer: RiskScorerFn | None = risk_scorer
         self._tool_risk_cache: ToolRiskCache | None = tool_risk_cache
         self._tool_bypass_rules: dict[str, Any] = tool_bypass_rules if tool_bypass_rules is not None else {}
@@ -834,6 +846,9 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         """Get the effective tools for this agent.
 
         Logic:
+        - If tool_catalog is set: bind ONLY essential orchestrator tools — the catalog
+          stays out of the graph and is reached via discovery (PTC ``eval`` or the
+          native catalog meta-tools added by ``ToolCatalogMiddleware``)
         - If inject_all_tools is set: use those directly + essential orchestrator tools
         - If mcp_tools is a non-empty list: use discovered tools + essential orchestrator tools
         - Otherwise (None or empty list): only essential orchestrator tools (NO MCP tools)
@@ -861,6 +876,19 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
             "catalog_search",
         ]
         essential_tools = [tool for tool in self.orchestrator_tools if tool.name in essential_tool_names]
+
+        # Catalog mode: bind only the essential core. The catalog itself is never
+        # passed to create_agent — schema-converting hundreds of MCP tools at graph
+        # build is what OOM-killed the orchestrator. Catalog tools stay callable via
+        # PTC ``eval`` (expose_context_registry) or, without PTC, via the
+        # search_tools/describe_tool/call_tool meta-tools that
+        # ToolCatalogMiddleware contributes in _build_graph.
+        if self.tool_catalog is not None:
+            logger.info(
+                f"Catalog mode for '{self.name}': binding {len(essential_tools)} essential tools; "
+                f"{len(self.tool_catalog)} catalog tools stay unbound (lazy discovery)"
+            )
+            return [_validate_tool_schema(tool) for tool in essential_tools]
 
         # If inject_all_tools is set, use those directly (pre-discovered by orchestrator)
         if self.inject_all_tools is not None:
@@ -969,7 +997,10 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         # The instance is sourced from any available pool; the middleware injects
         # it only in the allowed conversation contexts.
         gated_pool = (
-            list(self.orchestrator_tools) + list(self.inject_all_tools or []) + list(self._discovered_tools or [])
+            list(self.orchestrator_tools)
+            + list(self.inject_all_tools or [])
+            + list((self.tool_catalog or {}).values())
+            + list(self._discovered_tools or [])
         )
         seen_gated: set[str] = set()
         gated_tools: list[ContextGatedTool] = []
@@ -1000,6 +1031,13 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         if self_improvement_addendum:
             system_prompt += self_improvement_addendum
             logger.debug(f"Added self-improvement addendum to {self.name} system prompt")
+
+        # Catalog mode without PTC: tell the model how to reach the unbound catalog
+        # (search_tools/describe_tool/call_tool). Under PTC the code-interpreter
+        # middleware renders its own discovery instruction inside the eval prompt.
+        if self.tool_catalog is not None and not code_interpreter_ptc_enabled():
+            system_prompt += TOOL_CATALOG_PROMPT_ADDENDUM
+            logger.debug(f"Added tool-catalog addendum to {self.name} system prompt")
 
         # Get provider-specific response_format strategy (may mutate tools list for Bedrock/Anthropic+thinking)
         response_format = get_response_format(
@@ -1083,11 +1121,23 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
             A compiled CompiledStateGraph
         """
         # Combine instance-level extra_middlewares with call-level ones
-        combined_middlewares = list(self.extra_middlewares or []) + list(extra_middlewares or []) or None
+        combined_middlewares = list(self.extra_middlewares or []) + list(extra_middlewares or [])
 
-        # Build tool_server_map from tool metadata for server slug resolution
+        # Catalog mode without PTC: contribute the native discovery surface
+        # (search_tools/describe_tool) and the call_tool dispatch. Inserted with the
+        # extra middlewares (outer to HITL/retry) so a rewritten call_tool request
+        # reaches the inner chain under the real tool's name. Under PTC the catalog
+        # is exposed inside ``eval`` instead (expose_context_registry below).
+        exposed_catalog = self._exposed_catalog()
+        if exposed_catalog is not None and not code_interpreter_ptc_enabled():
+            combined_middlewares.append(ToolCatalogMiddleware(exposed_catalog))
+
+        # Build tool_server_map from tool metadata for server slug resolution.
+        # Include catalog tools: the PTC guard and HITL bypass rules resolve
+        # per-server rules through this map, and catalog tools are no longer in
+        # _cached_tools.
         tool_server_map: dict[str, str] = {}
-        for tool in self._cached_tools or []:
+        for tool in list(self._cached_tools or []) + list((exposed_catalog or {}).values()):
             metadata = getattr(tool, "metadata", None)
             if metadata and isinstance(metadata, dict):
                 server_name = metadata.get("server_name")
@@ -1111,7 +1161,24 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
             tool_risk_cache=self._tool_risk_cache,
             tool_server_map=tool_server_map or None,
             context_gated_tools=self._cached_context_gated_tools or None,
+            expose_context_registry=exposed_catalog is not None,
         ).with_config({"recursion_limit": _SUB_AGENT_RECURSION_LIMIT})
+
+    def _exposed_catalog(self) -> dict[str, BaseTool] | None:
+        """The tool_catalog subset reachable via lazy discovery, or ``None``.
+
+        Context-gated tools (``_CONTEXT_GATED_TOOL_RULES``) are excluded: they are
+        injected per-conversation-context by ``ConversationContextToolsMiddleware``,
+        and exposing them through the catalog (eval bridge / call_tool) would bypass
+        that gate.
+        """
+        if self.tool_catalog is None:
+            return None
+        return {
+            name: tool
+            for name, tool in self.tool_catalog.items()
+            if isinstance(tool, BaseTool) and name not in _CONTEXT_GATED_TOOL_RULES
+        }
 
     def _build_attachments_backend(self, input_data: SubAgentInput) -> "AttachmentsStoreBackend | None":
         """Build an ephemeral attachments backend from the incoming message.
@@ -1352,6 +1419,16 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                 tool_risk_cache=self._tool_risk_cache,
                 _pending_bypass_rules=self._pending_bypass_rules,
             )
+            # Catalog mode: expose the catalog through the runtime context so the
+            # PTC middleware (expose_context_registry=True) can route it into
+            # ``eval`` — mirroring how the orchestrator's own graph reaches its
+            # registry. Whitelist = the full exposed catalog: unlike the
+            # orchestrator (which binds only console-enabled tools), the catalog
+            # handed to this agent is already the intended exposure set.
+            exposed_catalog = self._exposed_catalog()
+            if exposed_catalog is not None:
+                subagent_context.tool_registry = exposed_catalog
+                subagent_context.whitelisted_tool_names = set(exposed_catalog)
 
             # Stream the agent with custom events and messages using v2 format
             # v2: every chunk is a StreamPart dict: {"type": ..., "ns": ..., "data": ...}
@@ -1550,6 +1627,7 @@ def create_dynamic_local_subagent(
     sandbox_pool: SandboxPool | None = None,
     extra_middlewares: Optional[List[Any]] = None,
     inject_all_tools: Optional[List[BaseTool]] = None,
+    tool_catalog: Optional[dict[str, BaseTool]] = None,
     risk_scorer: RiskScorerFn | None = None,
     tool_risk_cache: ToolRiskCache | None = None,
     tool_bypass_rules: dict[str, Any] | None = None,
@@ -1580,6 +1658,9 @@ def create_dynamic_local_subagent(
         group_ids: User's group IDs for group playbook loading (all groups)
         extra_middlewares: Optional middleware instances to prepend to the standard stack.
         inject_all_tools: Optional pre-discovered tools (bypasses MCP discovery).
+        tool_catalog: Optional name -> BaseTool mapping of a large pre-discovered catalog
+            exposed via lazy discovery (PTC ``eval`` or native catalog meta-tools) instead
+            of being bound into the graph. See ``DynamicLocalAgentRunnable``.
         tool_bypass_rules: User's persisted HITL bypass rules keyed by tool/server.
         pending_bypass_rules: Per-turn pending bypass rules list shared with executor persistence.
 
@@ -1618,6 +1699,7 @@ def create_dynamic_local_subagent(
         sandbox_pool=sandbox_pool,
         extra_middlewares=extra_middlewares,
         inject_all_tools=inject_all_tools,
+        tool_catalog=tool_catalog,
         risk_scorer=risk_scorer,
         tool_risk_cache=tool_risk_cache,
         tool_bypass_rules=tool_bypass_rules,

--- a/packages/agent-common/agent_common/core/graph_utils.py
+++ b/packages/agent-common/agent_common/core/graph_utils.py
@@ -1228,6 +1228,7 @@ def build_common_middleware_stack(
     tool_server_map: dict[str, str] | None = None,
     context_gated_tools: list[ContextGatedTool] | None = None,
     broaden_baseline_tools: list[BaseTool] | None = None,
+    expose_context_registry: bool = False,
 ) -> list:
     """Build the common middleware stack shared by every LangGraph agent in this project.
 
@@ -1297,6 +1298,12 @@ def build_common_middleware_stack(
         hitl_guarded_tools: Optional dict of tool names -> config for
             HumanInTheLoopMiddleware. When provided, adds HITL middleware
             that interrupts execution for approval before running these tools.
+        expose_context_registry: Forwarded to
+            ``build_code_interpreter_middlewares``: when ``True`` and PTC is
+            enabled, the runtime context's ``tool_registry`` (filtered by
+            ``whitelisted_tool_names``) is exposed inside ``eval`` instead of
+            being bound to the model. Used by catalog-mode agents (GP) whose
+            large tool catalog must stay out of ``create_agent``.
 
     Returns:
         Ordered list of middleware instances ready to be included in a
@@ -1318,6 +1325,7 @@ def build_common_middleware_stack(
         middleware += build_code_interpreter_middlewares(
             backend,
             broaden_baseline_tools=broaden_baseline_tools,
+            expose_context_registry=expose_context_registry,
             risk_scorer=risk_scorer,
             tool_risk_cache=tool_risk_cache,
             default_risk_threshold=default_risk_threshold,
@@ -1674,6 +1682,7 @@ def build_sub_agent_graph(
     tool_risk_cache: ToolRiskCache | None = None,
     tool_server_map: dict[str, str] | None = None,
     context_gated_tools: list[ContextGatedTool] | None = None,
+    expose_context_registry: bool = False,
     **kwargs: Any,
 ) -> CompiledStateGraph:
     """Build a standard deep-agent LangGraph graph.
@@ -1742,6 +1751,7 @@ def build_sub_agent_graph(
         tool_server_map=tool_server_map,
         context_gated_tools=context_gated_tools,
         broaden_baseline_tools=all_tools,
+        expose_context_registry=expose_context_registry,
     )
     if extra_middlewares:
         # Insert extra middlewares *after* GatewayAttributionMiddleware (always

--- a/packages/agent-common/tests/test_tool_catalog.py
+++ b/packages/agent-common/tests/test_tool_catalog.py
@@ -1,0 +1,287 @@
+"""Unit tests for the native lazy tool-catalog surface (tool_catalog.py).
+
+Covers the three meta-tools (search_tools/describe_tool/call_tool), the
+call_tool -> real-tool request rewrite in ToolCatalogMiddleware, and the
+DynamicLocalAgentRunnable catalog-mode seams (bound tools, exposed catalog,
+runtime context).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from langchain.agents.middleware.types import ToolCallRequest
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from agent_common.a2a.models import LocalLangGraphSubAgentConfig
+from agent_common.agents.dynamic_agent import DynamicLocalAgentRunnable
+from agent_common.core.tool_catalog import (
+    CATALOG_CALL_TOOL_NAME,
+    CATALOG_DESCRIBE_TOOL_NAME,
+    CATALOG_SEARCH_TOOL_NAME,
+    ToolCatalogMiddleware,
+)
+
+
+class _CampaignArgs(BaseModel):
+    campaign_id: str = Field(description="Cockpit campaign id")
+
+
+def _make_tool(name: str, description: str) -> StructuredTool:
+    async def _impl(campaign_id: str) -> str:
+        return f"{name}:{campaign_id}"
+
+    return StructuredTool.from_function(
+        coroutine=_impl,
+        name=name,
+        description=description,
+        args_schema=_CampaignArgs,
+    )
+
+
+@pytest.fixture
+def catalog() -> dict[str, StructuredTool]:
+    return {
+        "cockpit_get_campaign": _make_tool(
+            "cockpit_get_campaign", "Fetch one Cockpit campaign by id."
+        ),
+        "cockpit_list_campaigns": _make_tool(
+            "cockpit_list_campaigns", "List Cockpit campaigns for an advertiser."
+        ),
+        "gam_get_report": _make_tool("gam_get_report", "Fetch a GAM delivery report."),
+    }
+
+
+@pytest.fixture
+def middleware(catalog) -> ToolCatalogMiddleware:
+    return ToolCatalogMiddleware(catalog)
+
+
+def _meta_tool(middleware: ToolCatalogMiddleware, name: str):
+    return next(t for t in middleware.tools if t.name == name)
+
+
+class TestMetaTools:
+    def test_contributes_three_meta_tools(self, middleware):
+        assert {t.name for t in middleware.tools} == {
+            CATALOG_SEARCH_TOOL_NAME,
+            CATALOG_DESCRIBE_TOOL_NAME,
+            CATALOG_CALL_TOOL_NAME,
+        }
+
+    @pytest.mark.asyncio
+    async def test_search_ranks_name_matches_first(self, middleware):
+        search = _meta_tool(middleware, CATALOG_SEARCH_TOOL_NAME)
+        hits = await search.coroutine(query="list campaigns")
+        names = [h["name"] for h in hits]
+        assert names[0] == "cockpit_list_campaigns"
+        assert "gam_get_report" not in names
+
+    @pytest.mark.asyncio
+    async def test_search_empty_query_returns_nothing(self, middleware):
+        search = _meta_tool(middleware, CATALOG_SEARCH_TOOL_NAME)
+        assert await search.coroutine(query="???") == []
+
+    @pytest.mark.asyncio
+    async def test_describe_returns_parameters_schema(self, middleware):
+        describe = _meta_tool(middleware, CATALOG_DESCRIBE_TOOL_NAME)
+        text = await describe.coroutine(name="cockpit_get_campaign")
+        assert "cockpit_get_campaign" in text
+        assert "campaign_id" in text
+
+    @pytest.mark.asyncio
+    async def test_describe_unknown_suggests_and_points_to_search(self, middleware):
+        describe = _meta_tool(middleware, CATALOG_DESCRIBE_TOOL_NAME)
+        text = await describe.coroutine(name="cockpit_campaign")
+        assert "No tool named" in text
+        assert CATALOG_SEARCH_TOOL_NAME in text
+        # Close names are suggested
+        assert "cockpit_get_campaign" in text
+
+    @pytest.mark.asyncio
+    async def test_call_stub_fails_loudly_without_middleware(self, middleware):
+        call = _meta_tool(middleware, CATALOG_CALL_TOOL_NAME)
+        with pytest.raises(RuntimeError, match="ToolCatalogMiddleware"):
+            await call.coroutine(
+                name="cockpit_get_campaign", args={"campaign_id": "c1"}
+            )
+
+
+def _request(tool_call: dict) -> ToolCallRequest:
+    return ToolCallRequest(
+        tool_call=tool_call, tool=None, state={}, runtime=MagicMock()
+    )
+
+
+class TestCallToolDispatch:
+    @pytest.mark.asyncio
+    async def test_rewrites_to_real_tool_and_args(self, middleware, catalog):
+        request = _request(
+            {
+                "name": CATALOG_CALL_TOOL_NAME,
+                "args": {"name": "cockpit_get_campaign", "args": {"campaign_id": "c1"}},
+                "id": "call-1",
+            }
+        )
+        seen: list[ToolCallRequest] = []
+
+        async def handler(req):
+            seen.append(req)
+            return ToolMessage(
+                content="ok",
+                tool_call_id=req.tool_call["id"],
+                name=req.tool_call["name"],
+            )
+
+        result = await middleware.awrap_tool_call(request, handler)
+        assert len(seen) == 1
+        rewritten = seen[0]
+        # Inner middlewares (HITL, retry) must see the REAL tool call
+        assert rewritten.tool is catalog["cockpit_get_campaign"]
+        assert rewritten.tool_call["name"] == "cockpit_get_campaign"
+        assert rewritten.tool_call["args"] == {"campaign_id": "c1"}
+        # The provider matches on tool_call_id, which must be preserved
+        assert rewritten.tool_call["id"] == "call-1"
+        assert result.content == "ok"
+
+    @pytest.mark.asyncio
+    async def test_other_tools_pass_through_untouched(self, middleware):
+        request = _request({"name": "get_current_time", "args": {}, "id": "call-2"})
+
+        async def handler(req):
+            assert req is request
+            return ToolMessage(
+                content="12:00", tool_call_id="call-2", name="get_current_time"
+            )
+
+        result = await middleware.awrap_tool_call(request, handler)
+        assert result.content == "12:00"
+
+    @pytest.mark.asyncio
+    async def test_unknown_inner_name_returns_error_with_suggestions(self, middleware):
+        request = _request(
+            {
+                "name": CATALOG_CALL_TOOL_NAME,
+                "args": {"name": "cockpit_get_campaig", "args": {}},
+                "id": "call-3",
+            }
+        )
+
+        async def handler(req):  # pragma: no cover - must not be reached
+            raise AssertionError("handler must not run for unknown catalog tools")
+
+        result = await middleware.awrap_tool_call(request, handler)
+        assert isinstance(result, ToolMessage)
+        assert result.status == "error"
+        assert result.tool_call_id == "call-3"
+        assert "cockpit_get_campaign" in result.content
+
+    @pytest.mark.asyncio
+    async def test_non_dict_args_returns_error(self, middleware):
+        request = _request(
+            {
+                "name": CATALOG_CALL_TOOL_NAME,
+                "args": {"name": "cockpit_get_campaign", "args": "campaign_id=c1"},
+                "id": "call-4",
+            }
+        )
+
+        async def handler(req):  # pragma: no cover - must not be reached
+            raise AssertionError("handler must not run for malformed args")
+
+        result = await middleware.awrap_tool_call(request, handler)
+        assert isinstance(result, ToolMessage)
+        assert result.status == "error"
+        assert CATALOG_DESCRIBE_TOOL_NAME in result.content
+
+
+class TestDynamicAgentCatalogMode:
+    @pytest.fixture
+    def config(self):
+        return LocalLangGraphSubAgentConfig(
+            type="langgraph",
+            name="general-purpose",
+            description="GP agent",
+            system_prompt="You are the general-purpose agent.",
+        )
+
+    def _essential(self, name: str) -> StructuredTool:
+        async def _impl(campaign_id: str) -> str:
+            return name
+
+        return StructuredTool.from_function(
+            coroutine=_impl,
+            name=name,
+            description=f"{name} essential",
+            args_schema=_CampaignArgs,
+        )
+
+    def test_effective_tools_bind_essentials_only(self, config, catalog):
+        essentials = [
+            self._essential("get_current_time"),
+            self._essential("docstore_search"),
+        ]
+        runnable = DynamicLocalAgentRunnable(
+            config=config,
+            model=MagicMock(),
+            orchestrator_tools=essentials + [self._essential("not_essential")],
+            tool_catalog=catalog,
+        )
+        tools = runnable._get_effective_tools()
+        assert {t.name for t in tools} == {"get_current_time", "docstore_search"}
+
+    def test_exposed_catalog_excludes_context_gated_tools(self, config, catalog):
+        gated = dict(catalog)
+        gated["read_personal_file"] = _make_tool(
+            "read_personal_file", "Read a personal workspace file."
+        )
+        runnable = DynamicLocalAgentRunnable(
+            config=config,
+            model=MagicMock(),
+            tool_catalog=gated,
+        )
+        exposed = runnable._exposed_catalog()
+        assert "read_personal_file" not in exposed
+        assert set(exposed) == set(catalog)
+
+    def test_exposed_catalog_none_without_catalog(self, config):
+        runnable = DynamicLocalAgentRunnable(config=config, model=MagicMock())
+        assert runnable._exposed_catalog() is None
+
+    def _build_graph_kwargs(self, config, catalog, monkeypatch, ptc_enabled: bool) -> dict:
+        """Call _build_graph with a patched builder and return its kwargs."""
+        import agent_common.agents.dynamic_agent as da
+
+        monkeypatch.setattr(da, "code_interpreter_ptc_enabled", lambda: ptc_enabled)
+        captured: dict = {}
+
+        def fake_build(**kwargs):
+            captured.update(kwargs)
+            graph = MagicMock()
+            graph.with_config.return_value = graph
+            return graph
+
+        monkeypatch.setattr(da, "build_sub_agent_graph", fake_build)
+        runnable = DynamicLocalAgentRunnable(config=config, model=MagicMock(), tool_catalog=catalog)
+        runnable._cached_tools = []
+        runnable._build_graph()
+        return captured
+
+    def test_build_graph_forwards_context_registry_flag(self, config, catalog, monkeypatch):
+        kwargs = self._build_graph_kwargs(config, catalog, monkeypatch, ptc_enabled=True)
+        assert kwargs["expose_context_registry"] is True
+        # Under PTC the native meta-tool middleware must NOT be added (eval covers it)
+        assert not any(isinstance(m, ToolCatalogMiddleware) for m in kwargs["extra_middlewares"])
+
+    def test_build_graph_adds_catalog_middleware_without_ptc(self, config, catalog, monkeypatch):
+        kwargs = self._build_graph_kwargs(config, catalog, monkeypatch, ptc_enabled=False)
+        assert any(isinstance(m, ToolCatalogMiddleware) for m in kwargs["extra_middlewares"])
+
+    def test_build_graph_server_map_covers_catalog(self, config, monkeypatch):
+        tool = _make_tool("cockpit_get_campaign", "Fetch one Cockpit campaign by id.")
+        tool.metadata = {"server_name": "alloy-riad-stg"}
+        kwargs = self._build_graph_kwargs(
+            config, {"cockpit_get_campaign": tool}, monkeypatch, ptc_enabled=True
+        )
+        assert kwargs["tool_server_map"] == {"cockpit_get_campaign": "alloy-riad-stg"}

--- a/packages/orchestrator-agent/app/utils.py
+++ b/packages/orchestrator-agent/app/utils.py
@@ -58,6 +58,17 @@ def _wrap_tool_with_agent_name(tool: Any, agent_name: str) -> Any:
     )
 
 
+def _gp_tool_catalog_enabled() -> bool:
+    """Whether the GP agent gets its registry as a lazy catalog (default on).
+
+    ``GP_TOOL_CATALOG=false`` restores the legacy bind-all path (all registry
+    tools materialized into ``create_agent``) as a rollback lever. Bind-all is
+    known to OOM the orchestrator on large registries (~700 tools once a whole
+    API is exposed as an MCP server), so only disable it to bisect regressions.
+    """
+    return os.getenv("GP_TOOL_CATALOG", "true").strip().lower() not in {"0", "false", "no", "off"}
+
+
 def build_runtime_context(
     user_config: UserConfig,
     agent_settings: AgentSettings | None = None,
@@ -368,41 +379,61 @@ def build_runtime_context(
                     # layer re-surfaces and the orchestrator maps to TaskState.TASK_STATE_AUTH_REQUIRED.
                     subagent_extra_middlewares: list[Any] = [AuthErrorDetectionMiddleware()]
                     gp_inject_all_tools = None
+                    gp_tool_catalog = None
                     if config.name == "general-purpose":
-                        # Inject ALL MCP tools from tool_registry (already discovered by orchestrator).
-                        # Under PTC these are exposed (bridge-installed) inside ``eval``; the model
-                        # finds the relevant ones at runtime via ``tools.search`` / ``tools.describe``.
-                        gp_inject_all_tools = [t for t in tool_registry.values() if isinstance(t, BaseTool)]
-                        # ToolsetSelectorMiddleware (per-turn LLM tool filtering) is only needed on the
-                        # native (PTC-off) path, where the full catalog would otherwise be bound to the
-                        # model. Under PTC, ``tools.search`` supersedes it (runtime discovery, no recall
-                        # ceiling, no per-turn selection LLM call) AND keeping the selector would re-break
-                        # prompt caching by varying the bound/exposed set per turn. So gate it on PTC-off.
-                        if not code_interpreter_ptc_enabled():
-                            subagent_extra_middlewares.append(
-                                ToolsetSelectorMiddleware(
-                                    always_include=[
-                                        "get_current_time",
-                                        "generate_presigned_url",
-                                        "docstore_search",
-                                        "semantic_search_file",
-                                        "docstore_export",
-                                        "copy_file",
-                                        # The PTC code interpreter (`eval`) is the gateway to all
-                                        # PTC-exposed tools; it is a "base" tool (no server_name) so
-                                        # it survives Phase 1, but Phase 2 tool-selection can drop it.
-                                        # Pin it so the GP model never loses `tools.*` access.
-                                        PTC_CODE_INTERPRETER_TOOL_NAME,
-                                    ],
-                                    cost_logger=cost_logger,
-                                    compression_server_slug=AgentSettings.GATANA_COMPRESSION_SERVER_SLUG,
-                                )
+                        if _gp_tool_catalog_enabled():
+                            # Catalog mode (default): hand the registry to GP as a lazy
+                            # catalog — NEVER materialized into create_agent. Binding the
+                            # full registry (~700 tools once a whole API is exposed as an
+                            # MCP server) schema-converts every tool at graph build and
+                            # OOM-killed the orchestrator. The model reaches the catalog
+                            # via discovery instead: ``tools.search``/``tools.describe``
+                            # inside ``eval`` under PTC (expose_context_registry), or the
+                            # native search_tools/describe_tool/call_tool meta-tools
+                            # (ToolCatalogMiddleware) when PTC is off — same surface
+                            # either way, so no per-mode special-casing downstream.
+                            gp_tool_catalog = {
+                                name: t for name, t in tool_registry.items() if isinstance(t, BaseTool)
+                            }
+                            logger.info(
+                                f"GP agent: catalog mode with {len(gp_tool_catalog)} tools "
+                                f"(PTC={'on' if code_interpreter_ptc_enabled() else 'off'})"
                             )
-                        _selector_state = "off (PTC runtime discovery)" if code_interpreter_ptc_enabled() else "on"
-                        logger.info(
-                            f"GP agent: injecting {len(gp_inject_all_tools)} tools from tool_registry "
-                            f"(ToolsetSelectorMiddleware={_selector_state})"
-                        )
+                        else:
+                            # Legacy bind-all mode (GP_TOOL_CATALOG=false rollback lever).
+                            # Inject ALL MCP tools from tool_registry; under PTC these are
+                            # exposed inside ``eval`` via the request.tools harvest.
+                            gp_inject_all_tools = [t for t in tool_registry.values() if isinstance(t, BaseTool)]
+                            # ToolsetSelectorMiddleware (per-turn LLM tool filtering) is only needed on the
+                            # native (PTC-off) path, where the full catalog would otherwise be bound to the
+                            # model. Under PTC, ``tools.search`` supersedes it (runtime discovery, no recall
+                            # ceiling, no per-turn selection LLM call) AND keeping the selector would re-break
+                            # prompt caching by varying the bound/exposed set per turn. So gate it on PTC-off.
+                            if not code_interpreter_ptc_enabled():
+                                subagent_extra_middlewares.append(
+                                    ToolsetSelectorMiddleware(
+                                        always_include=[
+                                            "get_current_time",
+                                            "generate_presigned_url",
+                                            "docstore_search",
+                                            "semantic_search_file",
+                                            "docstore_export",
+                                            "copy_file",
+                                            # The PTC code interpreter (`eval`) is the gateway to all
+                                            # PTC-exposed tools; it is a "base" tool (no server_name) so
+                                            # it survives Phase 1, but Phase 2 tool-selection can drop it.
+                                            # Pin it so the GP model never loses `tools.*` access.
+                                            PTC_CODE_INTERPRETER_TOOL_NAME,
+                                        ],
+                                        cost_logger=cost_logger,
+                                        compression_server_slug=AgentSettings.GATANA_COMPRESSION_SERVER_SLUG,
+                                    )
+                                )
+                            _selector_state = "off (PTC runtime discovery)" if code_interpreter_ptc_enabled() else "on"
+                            logger.info(
+                                f"GP agent: injecting {len(gp_inject_all_tools)} tools from tool_registry "
+                                f"(ToolsetSelectorMiddleware={_selector_state})"
+                            )
 
                     # Auto-expand non-GP sub-agent MCP whitelist with compression
                     # server tools when any whitelisted tool is from a compression-enabled server
@@ -452,6 +483,7 @@ def build_runtime_context(
                         sandbox_pool=sandbox_pool if getattr(config, "sandbox_enabled", False) else None,
                         extra_middlewares=subagent_extra_middlewares,
                         inject_all_tools=gp_inject_all_tools,
+                        tool_catalog=gp_tool_catalog,
                         risk_scorer=_get_risk_scorer(),
                         tool_risk_cache=tool_risk_cache,
                         tool_bypass_rules=user_config.tool_bypass_rules,


### PR DESCRIPTION
## Problem

Prod incident 2026-07-08: the orchestrator pod was repeatedly **OOMKilled (exit 137)** whenever a conversation dispatched `task(general-purpose)`. GP injects the orchestrator's entire per-user tool registry into `create_agent`; after exposing the whole cockpit API as the `alloy-riad-stg` MCP server, that registry grew to ~700 tools, and per-tool schema conversion at graph build blew the container memory limit within ~2s of `Creating LangGraph agent 'general-purpose' with 701 tools`. To users this surfaced as `StreamReset ... remote_reset:True` send failures when the pod died mid-turn.

Note: deployed **v1.3.1 does not contain this fix** — its release commit (d7de462d) accidentally swept in the unwired `tool_catalog.py` module from the working tree, but none of the wiring. The OOM stays live until this merges and releases.

## Change

GP never materializes the registry into `create_agent` anymore. It binds only the essential core and receives the registry as a `tool_catalog` mapping **by reference**, reached through discovery — the same surface whether PTC is on or off:

- **PTC on**: the catalog flows through the sub-agent runtime context with `expose_context_registry=True` — the orchestrator's own proven path — into `eval`, where the existing `tools.search`/`tools.describe` discovery and core-only prompt rendering take over.
- **PTC off**: `ToolCatalogMiddleware` contributes native `search_tools`/`describe_tool`/`call_tool` meta-tools and rewrites each `call_tool` request to the real catalog tool via `request.override(tool=..., tool_call=...)` (the `DynamicToolDispatchMiddleware` pattern), so conditional-HITL, retry, and result eviction fire on the **real** tool name. Replaces `ToolsetSelectorMiddleware` for GP in this mode (kept for the legacy path; follow-up PR will delete it once catalog mode has survived a release).

Preserved behaviors:
- Context-gated tools (`read_personal_file`) are excluded from catalog exposure — they stay routed through `ConversationContextToolsMiddleware`.
- `tool_server_map` covers catalog tools so per-server HITL bypass rules keep resolving.
- `GP_TOOL_CATALOG=false` restores the legacy bind-all path as a rollback lever.

Side benefit: the model-facing tool prefix becomes small and turn-invariant (schemas move from per-request prefix to on-demand conversation content), so prompt caching actually hits and TTFT drops — compounding the first-token-watchdog fix (#119).

## Testing

- 16 new tests (`test_tool_catalog.py`): search ranking, describe schemas, `call_tool` rewrite (tool identity, args, preserved `tool_call_id`), pass-through, unknown-name suggestions, malformed args, effective-tools binding, gated-tool exclusion, graph-build wiring for both PTC modes, server-map coverage.
- Full suites green: agent-common 694, orchestrator-agent 615.
- Smoke test: GP runnable with a 500-tool catalog builds under both PTC modes with only the essentials bound and the full catalog exposed for discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)