### PR TITLE
fix(orchestrator): recover reasoning turns truncated by output-budget exhaustion

### DIFF
--- a/packages/agent-common/agent_common/core/graph_utils.py
+++ b/packages/agent-common/agent_common/core/graph_utils.py
@@ -74,6 +74,7 @@ from agent_common.core.ptc_discovery import (
     build_discovery_tools,
 )
 from agent_common.core.ptc_signatures import render_tools_namespace
+from agent_common.middleware.continue_on_truncation import ContinueOnTruncationMiddleware
 from agent_common.middleware.conversation_context_tools_middleware import (
     ContextGatedTool,
     ConversationContextToolsMiddleware,
@@ -1240,6 +1241,10 @@ def build_common_middleware_stack(
        (``sub_agent:``/``sub_agent_config_version:``/``conversation:``/``scheduled_job:``)
        so litellm spend logs bill the right user / sub-agent / config version, even
        for in-process sub-agent calls.
+    1b. ``ContinueOnTruncationMiddleware`` - always second. Detects a turn cut off
+        mid-generation (``finish_reason == "length"`` with no tool call) and re-runs it
+        with a wrap-up nudge and raised ``max_tokens``, so a reasoning turn that overran
+        its budget isn't laundered into a fake "Task completed successfully".
 
     The following run only when *exclude_deep_agents_middlewares* is ``False``:
 
@@ -1312,7 +1317,7 @@ def build_common_middleware_stack(
     # Outermost: stamp gateway cost-attribution ContextVars from each model call's
     # own tags, so in-process sub-agent LLM calls are billed to the sub-agent
     # (not the orchestrator) regardless of which dispatch path invoked them.
-    middleware: list = [GatewayAttributionMiddleware()]
+    middleware: list = [GatewayAttributionMiddleware(), ContinueOnTruncationMiddleware()]
     if not exclude_deep_agents_middlewares:
         summarization_defaults = compute_summarization_defaults(model)
         fs_cls = _FilesystemMiddlewareWithDocstoreHint if add_docstore_hint else FilesystemMiddleware

--- a/packages/agent-common/agent_common/core/model_factory.py
+++ b/packages/agent-common/agent_common/core/model_factory.py
@@ -267,6 +267,38 @@ def get_reasoning_effort(
     return value
 
 
+# When reasoning is on, thinking tokens are drawn from the SAME output budget as the
+# visible response (Anthropic: thinking counts toward max_tokens; the gateway's
+# OpenAI-compatible surface reports the exhaustion as finish_reason="length"). If we send
+# no max_tokens the gateway applies its own low default (~4096), so a deep-reasoning turn
+# can spend the entire budget thinking and get cut off before emitting content or the
+# FinalResponseSchema tool call — surfacing as an empty "Task completed successfully".
+# Give higher effort tiers proportionally more headroom above the thinking budget. Keyed by
+# the resolved reasoning_effort; only applied when reasoning is active (thinking-off turns
+# keep the gateway default so we don't raise the ceiling for non-reasoning models that may
+# cap output lower). Opus 4.8 — the fleet default — supports 128k output, so these are safe.
+_MAX_TOKENS_BY_EFFORT: dict[str, int] = {
+    "minimal": 8192,
+    "low": 8192,
+    "medium": 16000,
+    "high": 32000,
+    "xhigh": 32000,
+}
+_DEFAULT_REASONING_MAX_TOKENS = 16000
+
+
+def max_tokens_for_effort(effort: str | None) -> int | None:
+    """Output-token ceiling to request for a given reasoning ``effort``.
+
+    Returns ``None`` when no effort is active (reasoning off) — callers should leave
+    ``max_tokens`` unset so the gateway default applies and we don't lower a non-reasoning
+    model's own output cap. See ``_MAX_TOKENS_BY_EFFORT`` for the rationale.
+    """
+    if not effort:
+        return None
+    return _MAX_TOKENS_BY_EFFORT.get(effort, _DEFAULT_REASONING_MAX_TOKENS)
+
+
 def create_model(
     model_type: ModelType,
     thinking_level: ThinkingLevel | None = None,
@@ -297,6 +329,12 @@ def create_model(
     if effort:
         model_kwargs["reasoning_effort"] = effort
 
+    # Reasoning shares the output budget — give it headroom so thinking doesn't consume the
+    # whole (low) gateway-default max_tokens and truncate the answer. Unset for reasoning-off
+    # turns (leave the gateway default). ContinueOnTruncationMiddleware raises this further
+    # per-retry when a turn still gets cut off. See max_tokens_for_effort.
+    max_tokens = max_tokens_for_effort(effort)
+
     # NOTE: Native Gemini server-side web search (googleSearch) is NOT enabled here.
     # Enabling it for a tool-using deep agent requires `include_server_side_tool_invocations`
     # (so LiteLLM doesn't drop the search tool when function tools are present). But that flag
@@ -307,7 +345,16 @@ def create_model(
     # unrelated multi-region caching fix); whether that bump also resolves this tools+cached-content
     # 400 is UNVERIFIED — re-test before enabling server-side tools.
 
-    logger.info("Creating gateway model alias=%s thinking=%s streaming=%s", model_type, effort, streaming)
+    logger.info(
+        "Creating gateway model alias=%s thinking=%s streaming=%s max_tokens=%s",
+        model_type,
+        effort,
+        streaming,
+        max_tokens,
+    )
+    optional: dict = {}
+    if max_tokens is not None:
+        optional["max_tokens"] = max_tokens
     return ChatOpenAI(
         base_url=_gateway_base_url(),
         api_key=_gateway_api_key(),
@@ -317,6 +364,7 @@ def create_model(
         callbacks=callbacks,
         http_async_client=build_attribution_http_client(),  # per-request attribution
         model_kwargs=model_kwargs,
+        **optional,
     )
 
 

--- a/packages/agent-common/agent_common/middleware/continue_on_truncation.py
+++ b/packages/agent-common/agent_common/middleware/continue_on_truncation.py
@@ -1,0 +1,128 @@
+"""Recover a model turn that was cut off (``finish_reason == "length"``) mid-generation.
+
+When reasoning is on, thinking tokens are drawn from the same output budget as the
+visible response. A deep-reasoning turn can spend the entire ``max_tokens`` budget
+thinking and get cut off before it emits any content or the terminal
+``FinalResponseSchema`` tool call. The gateway's OpenAI-compatible surface reports this as
+``finish_reason == "length"`` on an ``AIMessage`` that has empty content and no tool calls
+— and, downstream, the orchestrator's ``parse_agent_response`` finds no structured response
+and falls back to the hardcoded "Task completed successfully". A truncated turn is silently
+laundered into a fake success.
+
+``model_factory.max_tokens_for_effort`` gives reasoning turns headroom so this is rare, but
+a pathological turn can still exhaust even a generous budget. This middleware makes such a
+turn *recoverable in place*: it detects the truncation, discards the poisoned generation
+(so the partial/empty thinking block never enters the message history — replaying a
+truncated thinking block is fragile and would just resume the overthinking), and re-invokes
+the model with (a) a nudge instructing it to stop reasoning and produce its answer now, and
+(b) a raised ``max_tokens`` for the retry. Only the final, complete response is returned to
+the graph. If every retry still truncates, the last (truncated) response is returned
+unchanged so the downstream truncation guard can surface a failure rather than a fake
+success.
+
+Added to the common middleware stack, so both the orchestrator and in-process sub-agents
+get the behavior.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+
+from langchain.agents.middleware import AgentMiddleware, ModelRequest, ModelResponse
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+
+logger = logging.getLogger(__name__)
+
+# Retry ceilings, escalating per attempt. Opus 4.8 (the fleet default) supports 128k output,
+# so these are safe headroom; they only ever apply on a turn that already truncated, i.e. one
+# the model has shown it can produce long output for.
+_RETRY_MAX_TOKENS: tuple[int, ...] = (32000, 48000)
+_DEFAULT_MAX_RETRIES = 2
+
+_NUDGE = (
+    "SYSTEM: Your previous response was cut off — it exhausted the output token budget while "
+    "thinking, before producing any answer. You have already reasoned more than enough. Do "
+    "NOT think further. Produce your final answer now by calling the FinalResponseSchema "
+    "tool (or, if no tool applies, respond directly). Be decisive and concise."
+)
+
+
+def _last_ai_message(messages: list[BaseMessage]) -> AIMessage | None:
+    for msg in reversed(messages):
+        if isinstance(msg, AIMessage):
+            return msg
+    return None
+
+
+def _is_truncated(response: ModelResponse) -> bool:
+    """True when the turn was cut off mid-generation with no usable output.
+
+    Truncation that still produced a tool call is a normal agentic continuation (the graph
+    runs the tool and loops) — we only recover the dead case: cut off with no tool call and
+    no parsed structured response.
+    """
+    if getattr(response, "structured_response", None) is not None:
+        return False
+    msg = _last_ai_message(response.result or [])
+    if msg is None:
+        return False
+    if getattr(msg, "tool_calls", None):
+        return False
+    return msg.response_metadata.get("finish_reason") == "length"
+
+
+class ContinueOnTruncationMiddleware(AgentMiddleware):
+    """Re-run a ``finish_reason == "length"`` turn with a wrap-up nudge and more budget."""
+
+    def __init__(self, max_retries: int = _DEFAULT_MAX_RETRIES) -> None:
+        self._max_retries = max_retries
+
+    def _nudged(self, request: ModelRequest, attempt: int) -> ModelRequest:
+        """Append the wrap-up nudge and raise ``max_tokens`` for the retry.
+
+        The nudge goes in ``messages`` (not ``system_message``, which would change the cached
+        prefix). ``model_settings`` is bound over the model at invocation, so the raised
+        ``max_tokens`` reaches the gateway without rebuilding the model.
+        """
+        ceiling = _RETRY_MAX_TOKENS[min(attempt, len(_RETRY_MAX_TOKENS) - 1)]
+        return request.override(
+            messages=[*request.messages, HumanMessage(content=_NUDGE)],
+            model_settings={**request.model_settings, "max_tokens": ceiling},
+        )
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelResponse:
+        response = handler(request)
+        for attempt in range(self._max_retries):
+            if not _is_truncated(response):
+                return response
+            logger.warning(
+                "Model turn truncated (finish_reason=length, no tool call); "
+                "nudging to wrap up (retry %d/%d)",
+                attempt + 1,
+                self._max_retries,
+            )
+            response = handler(self._nudged(request, attempt))
+        return response
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        response = await handler(request)
+        for attempt in range(self._max_retries):
+            if not _is_truncated(response):
+                return response
+            logger.warning(
+                "Model turn truncated (finish_reason=length, no tool call); "
+                "nudging to wrap up (retry %d/%d)",
+                attempt + 1,
+                self._max_retries,
+            )
+            response = await handler(self._nudged(request, attempt))
+        return response

--- a/packages/agent-common/tests/test_continue_on_truncation_middleware.py
+++ b/packages/agent-common/tests/test_continue_on_truncation_middleware.py
@@ -1,0 +1,160 @@
+"""Tests for ContinueOnTruncationMiddleware.
+
+A reasoning turn can exhaust its output budget while thinking and get cut off
+(``finish_reason == "length"``) before emitting content or a tool call. The middleware
+detects that, discards the poisoned generation, and re-runs the model with a wrap-up nudge
+and raised ``max_tokens`` — recovering the turn in place instead of letting it be laundered
+into a fake "Task completed successfully".
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain.agents.middleware import ModelResponse
+from langchain_core.messages import AIMessage, HumanMessage
+
+from agent_common.middleware.continue_on_truncation import (
+    ContinueOnTruncationMiddleware,
+    _is_truncated,
+)
+
+
+class _FakeRequest:
+    """Minimal stand-in for ModelRequest: the middleware only touches these fields."""
+
+    def __init__(self, messages=None, model_settings=None):
+        self.messages = messages or [HumanMessage(content="do the thing")]
+        self.model_settings = model_settings or {}
+
+    def override(self, **overrides):
+        new = _FakeRequest(
+            messages=overrides.get("messages", self.messages),
+            model_settings=overrides.get("model_settings", self.model_settings),
+        )
+        return new
+
+
+def _truncated() -> ModelResponse:
+    """A turn cut off mid-thinking: empty content, no tool call, finish_reason=length."""
+    return ModelResponse(
+        result=[AIMessage(content="", response_metadata={"finish_reason": "length"})]
+    )
+
+
+def _complete(text: str = "here is the answer") -> ModelResponse:
+    return ModelResponse(
+        result=[AIMessage(content=text, response_metadata={"finish_reason": "stop"})]
+    )
+
+
+def _with_tool_call() -> ModelResponse:
+    msg = AIMessage(
+        content="",
+        response_metadata={"finish_reason": "length"},
+        tool_calls=[{"name": "search", "args": {}, "id": "t1"}],
+    )
+    return ModelResponse(result=[msg])
+
+
+class _Handler:
+    """Stub model handler returning a scripted sequence of responses, recording requests."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.requests: list[_FakeRequest] = []
+
+    def __call__(self, request):
+        self.requests.append(request)
+        return self._responses.pop(0)
+
+
+class _AsyncHandler(_Handler):
+    async def __call__(self, request):  # type: ignore[override]
+        self.requests.append(request)
+        return self._responses.pop(0)
+
+
+# --- _is_truncated -----------------------------------------------------------------
+
+
+def test_is_truncated_detects_length_cutoff():
+    assert _is_truncated(_truncated()) is True
+
+
+def test_is_truncated_false_for_normal_completion():
+    assert _is_truncated(_complete()) is False
+
+
+def test_is_truncated_false_when_tool_call_present():
+    # A length cutoff that still produced a tool call is a normal agentic continuation.
+    assert _is_truncated(_with_tool_call()) is False
+
+
+def test_is_truncated_false_when_structured_response_present():
+    resp = _truncated()
+    resp.structured_response = {"message": "done"}
+    assert _is_truncated(resp) is False
+
+
+# --- retry behavior ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recovers_after_one_truncation():
+    handler = _AsyncHandler([_truncated(), _complete("recovered answer")])
+    mw = ContinueOnTruncationMiddleware(max_retries=2)
+
+    resp = await mw.awrap_model_call(_FakeRequest(), handler)
+
+    assert resp.result[0].content == "recovered answer"
+    assert len(handler.requests) == 2  # original + one retry
+    # The retry appended the wrap-up nudge and raised max_tokens.
+    retry_req = handler.requests[1]
+    assert isinstance(retry_req.messages[-1], HumanMessage)
+    assert "cut off" in retry_req.messages[-1].content
+    assert retry_req.model_settings.get("max_tokens")
+
+
+@pytest.mark.asyncio
+async def test_no_retry_when_first_response_complete():
+    handler = _AsyncHandler([_complete()])
+    mw = ContinueOnTruncationMiddleware(max_retries=2)
+
+    resp = await mw.awrap_model_call(_FakeRequest(), handler)
+
+    assert resp.result[0].content == "here is the answer"
+    assert len(handler.requests) == 1  # no retry
+
+
+@pytest.mark.asyncio
+async def test_exhausts_retries_and_returns_last_truncated():
+    handler = _AsyncHandler([_truncated(), _truncated(), _truncated()])
+    mw = ContinueOnTruncationMiddleware(max_retries=2)
+
+    resp = await mw.awrap_model_call(_FakeRequest(), handler)
+
+    # All attempts truncated: original + 2 retries, and the (still truncated) response is
+    # returned so the downstream guard can surface an honest failure.
+    assert len(handler.requests) == 3
+    assert _is_truncated(resp)
+
+
+@pytest.mark.asyncio
+async def test_tool_calling_turn_is_not_retried():
+    handler = _AsyncHandler([_with_tool_call()])
+    mw = ContinueOnTruncationMiddleware(max_retries=2)
+
+    resp = await mw.awrap_model_call(_FakeRequest(), handler)
+
+    assert len(handler.requests) == 1
+    assert resp.result[0].tool_calls
+
+
+def test_sync_recovers_after_one_truncation():
+    handler = _Handler([_truncated(), _complete("sync recovered")])
+    mw = ContinueOnTruncationMiddleware(max_retries=2)
+
+    resp = mw.wrap_model_call(_FakeRequest(), handler)
+
+    assert resp.result[0].content == "sync recovered"
+    assert len(handler.requests) == 2

--- a/packages/agent-common/tests/test_max_tokens_for_effort.py
+++ b/packages/agent-common/tests/test_max_tokens_for_effort.py
@@ -1,0 +1,41 @@
+"""Tests for max_tokens_for_effort — the reasoning-effort → output-budget mapping.
+
+When reasoning is on, thinking tokens share the output budget with the visible response.
+Without an explicit max_tokens the gateway applies a low default (~4096), so a deep-reasoning
+turn can spend the whole budget thinking and get cut off before producing an answer. The
+mapping gives higher effort tiers proportionally more headroom; reasoning-off turns get
+None so the gateway default is left untouched.
+"""
+
+import pytest
+
+from agent_common.core.model_factory import (
+    _DEFAULT_REASONING_MAX_TOKENS,
+    _MAX_TOKENS_BY_EFFORT,
+    max_tokens_for_effort,
+)
+
+
+def test_none_effort_leaves_max_tokens_unset():
+    # Reasoning off → don't raise (or lower) a non-reasoning model's own output cap.
+    assert max_tokens_for_effort(None) is None
+    assert max_tokens_for_effort("") is None
+
+
+@pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high", "xhigh"])
+def test_every_known_effort_maps_to_its_ceiling(effort):
+    assert max_tokens_for_effort(effort) == _MAX_TOKENS_BY_EFFORT[effort]
+
+
+def test_ceiling_grows_with_effort():
+    # Deeper reasoning needs more room above the thinking budget for the answer.
+    assert max_tokens_for_effort("low") < max_tokens_for_effort("medium") < max_tokens_for_effort("high")
+
+
+def test_xhigh_gets_the_most_headroom():
+    # "Extra high" is the UI's deepest tier and the one that truncated in production.
+    assert max_tokens_for_effort("xhigh") == max(_MAX_TOKENS_BY_EFFORT.values())
+
+
+def test_unknown_effort_falls_back_to_default():
+    assert max_tokens_for_effort("mystery-tier") == _DEFAULT_REASONING_MAX_TOKENS

--- a/packages/orchestrator-agent/app/core/graph_factory.py
+++ b/packages/orchestrator-agent/app/core/graph_factory.py
@@ -38,6 +38,7 @@ from agent_common.core.model_factory import (
 )
 from agent_common.core.tool_risk_scorer import score_tool_risk
 from agent_common.middleware.conditional_hitl import ConditionalHumanInTheLoopMiddleware
+from agent_common.middleware.continue_on_truncation import ContinueOnTruncationMiddleware
 from agent_common.middleware.conversation_context_tools_middleware import ConversationContextToolsMiddleware
 from agent_common.middleware.prompt_caching import LiteLLMPromptCachingMiddleware
 from agent_common.middleware.steering_middleware import SteeringMiddleware
@@ -674,6 +675,13 @@ class GraphFactory:
         )
 
         middleware_stack: list[Any] = [
+            # Outermost model-call wrapper: recover a turn cut off mid-generation
+            # (finish_reason == "length", no tool call) by re-running with a wrap-up
+            # nudge + raised max_tokens, instead of ending on an empty/truncated turn.
+            # Only implements wrap_model_call, so it doesn't affect the tool-dispatch
+            # ordering below. Must live here too — the orchestrator's own graph does not
+            # go through build_common_middleware_stack (which only reaches sub-agents).
+            ContinueOnTruncationMiddleware(),
             context_gate_middleware,
             dynamic_tool_middleware,
             storage_paths_middleware,

--- a/packages/orchestrator-agent/app/handlers/stream_handler.py
+++ b/packages/orchestrator-agent/app/handlers/stream_handler.py
@@ -589,6 +589,25 @@ class StreamHandler:
         # FALLBACK: No structured_response (unexpected) - default to completed
         logger.warning("[STREAM HANDLER] No structured_response found, defaulting to completed")
         messages = final_state.get("messages", []) if isinstance(final_state, dict) else []
+
+        # TRUNCATION GUARD: distinguish a genuinely-empty completion from a turn that was
+        # cut off mid-generation. When a reasoning turn exhausts its output budget while
+        # thinking, the last AIMessage carries finish_reason == "length" with empty content
+        # and no tool call, and never reaches FinalResponseSchema. ContinueOnTruncationMiddleware
+        # normally recovers this in-turn; if it's still truncated here every nudge-retry was
+        # exhausted. Surface that honestly (input_required, so the user can ask to continue)
+        # instead of laundering it into "Task completed successfully".
+        if StreamHandler._current_turn_truncated(messages):
+            logger.warning("[STREAM HANDLER] Current turn truncated (finish_reason=length) and unrecovered")
+            return AgentStreamResponse(
+                state=TaskState.TASK_STATE_INPUT_REQUIRED,
+                content=(
+                    "I ran out of room before finishing that response. Ask me to continue "
+                    "and I'll pick up where I left off."
+                ),
+                metadata={"truncated": True},
+            )
+
         if messages:
             last_message = messages[-1]
             content = getattr(last_message, "content", str(last_message))
@@ -597,6 +616,21 @@ class StreamHandler:
             content = "Task completed successfully"
 
         return AgentStreamResponse(state=TaskState.TASK_STATE_COMPLETED, content=content)
+
+    @staticmethod
+    def _current_turn_truncated(messages: list) -> bool:
+        """True when the current turn's last AIMessage was cut off with no usable output.
+
+        Truncation signature: finish_reason == "length" (the gateway's OpenAI-compatible
+        rendering of an output-budget cutoff) with no tool call. A truncated-but-tool-calling
+        turn is a normal continuation and is not flagged.
+        """
+        for msg in reversed(StreamHandler._extract_current_turn_messages(messages)):
+            if isinstance(msg, AIMessage):
+                if getattr(msg, "tool_calls", None):
+                    return False
+                return getattr(msg, "response_metadata", {}).get("finish_reason") == "length"
+        return False
 
     @staticmethod
     def build_working_response(content: str, metadata: Optional[Dict[str, Any]] = None) -> AgentStreamResponse:

--- a/packages/orchestrator-agent/tests/test_graph_factory.py
+++ b/packages/orchestrator-agent/tests/test_graph_factory.py
@@ -13,6 +13,7 @@ Graph creation with actual models should be tested in integration tests.
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from agent_common.middleware.continue_on_truncation import ContinueOnTruncationMiddleware
 from agent_common.middleware.prompt_caching import LiteLLMPromptCachingMiddleware
 from agent_common.middleware.storage_paths_middleware import StoragePathsInstructionMiddleware
 from langchain.agents.middleware import ToolRetryMiddleware
@@ -113,35 +114,61 @@ class TestMiddlewareStack:
         # cache, user prefs after steering, playbook after prefs, then the code
         # interpreter (_PTCToleranceCodeInterpreterMiddleware, which exposes the
         # eval REPL + PTC bridge and hides PTC-exposed tools from the model itself).
-        assert len(stack) == 17
-        assert stack[0].__class__.__name__ == "ConversationContextToolsMiddleware"
-        assert isinstance(stack[1], DynamicToolDispatchMiddleware)
-        assert isinstance(stack[2], StoragePathsInstructionMiddleware)
+        assert len(stack) == 18
+        # stack[0] = ContinueOnTruncationMiddleware — outermost model-call wrapper; re-runs a
+        # turn cut off mid-generation with a nudge + raised max_tokens. Only implements
+        # wrap_model_call, so the context gate remains the outermost *tool-shaping* middleware.
+        assert stack[0].__class__.__name__ == "ContinueOnTruncationMiddleware"
+        assert stack[1].__class__.__name__ == "ConversationContextToolsMiddleware"
+        assert isinstance(stack[2], DynamicToolDispatchMiddleware)
+        assert isinstance(stack[3], StoragePathsInstructionMiddleware)
         # Provider-agnostic caching under the gateway: the cache breakpoint
         # is injected as an OpenAI-format cache_control block that LiteLLM translates
         # per provider, replacing the old Bedrock-only BedrockPromptCachingMiddleware.
-        assert isinstance(stack[3], LiteLLMPromptCachingMiddleware)
-        # stack[4] = SteeringMiddleware (from ringier_a2a_sdk)
-        assert stack[4].__class__.__name__ == "SteeringMiddleware"
-        assert isinstance(stack[5], UserPreferencesMiddleware)
-        # stack[6] = PlaybookInjectionMiddleware
-        assert stack[6].__class__.__name__ == "PlaybookInjectionMiddleware"
-        # stack[7] = CodeInterpreterMiddleware (eval REPL + PTC bridge; also hides
+        assert isinstance(stack[4], LiteLLMPromptCachingMiddleware)
+        # stack[5] = SteeringMiddleware (from ringier_a2a_sdk)
+        assert stack[5].__class__.__name__ == "SteeringMiddleware"
+        assert isinstance(stack[6], UserPreferencesMiddleware)
+        # stack[7] = PlaybookInjectionMiddleware
+        assert stack[7].__class__.__name__ == "PlaybookInjectionMiddleware"
+        # stack[8] = CodeInterpreterMiddleware (eval REPL + PTC bridge; also hides
         # every PTC-exposed tool from the model's bound tool list)
-        assert stack[7].__class__.__name__ == "_PTCToleranceCodeInterpreterMiddleware"
-        # stack[8] = ToolStatusMiddleware (emits status for tool calls)
-        assert stack[8].__class__.__name__ == "ToolStatusMiddleware"
-        assert isinstance(stack[9], RepeatedToolCallMiddleware)
-        assert isinstance(stack[10], AuthErrorDetectionMiddleware)
-        assert stack[11].__class__.__name__ == "ErrorClassificationMiddleware"
-        # stack[12] = ConditionalHumanInTheLoopMiddleware
-        assert stack[12].__class__.__name__ == "ConditionalHumanInTheLoopMiddleware"
-        assert isinstance(stack[13], ToolRetryMiddleware)
-        assert isinstance(stack[14], A2ATaskTrackingMiddleware)
-        assert isinstance(stack[15], TodoStatusMiddleware)
+        assert stack[8].__class__.__name__ == "_PTCToleranceCodeInterpreterMiddleware"
+        # stack[9] = ToolStatusMiddleware (emits status for tool calls)
+        assert stack[9].__class__.__name__ == "ToolStatusMiddleware"
+        assert isinstance(stack[10], RepeatedToolCallMiddleware)
+        assert isinstance(stack[11], AuthErrorDetectionMiddleware)
+        assert stack[12].__class__.__name__ == "ErrorClassificationMiddleware"
+        # stack[13] = ConditionalHumanInTheLoopMiddleware
+        assert stack[13].__class__.__name__ == "ConditionalHumanInTheLoopMiddleware"
+        assert isinstance(stack[14], ToolRetryMiddleware)
+        assert isinstance(stack[15], A2ATaskTrackingMiddleware)
+        assert isinstance(stack[16], TodoStatusMiddleware)
         # Innermost: strips duplicate plain-text content from AIMessages that
         # carry a FinalResponseSchema tool call.
-        assert stack[16].__class__.__name__ == "FinalResponseTextStripMiddleware"
+        assert stack[17].__class__.__name__ == "FinalResponseTextStripMiddleware"
+
+    @patch("app.core.graph_factory._has_aws_credentials", return_value=True)
+    @patch("langgraph.store.postgres.aio.AsyncPostgresStore")
+    def test_continue_on_truncation_wired_into_orchestrator_stack(self, mock_pg_store, _mock_creds, mock_config):
+        """Regression guard: ContinueOnTruncationMiddleware MUST be in the orchestrator's own
+        middleware stack, as the outermost model-call wrapper.
+
+        The orchestrator's graph is assembled here (not via build_common_middleware_stack,
+        which only reaches sub-agents). When the middleware was wired only into the common
+        stack, a truncated orchestrator turn (finish_reason=length, no tool call) never got
+        the nudge+retry and fell through to the honest-fallback path — verified live. If this
+        assertion ever fails, the recovery is silently gone for the orchestrator's own turns.
+        """
+        factory = GraphFactory(config=mock_config)
+        stack = factory._create_middleware_stack(model=Mock())
+
+        assert any(isinstance(m, ContinueOnTruncationMiddleware) for m in stack), (
+            "ContinueOnTruncationMiddleware missing from the orchestrator stack — truncated "
+            "orchestrator turns will no longer be recovered"
+        )
+        # Outermost so its retry re-runs the full inner request-shaping chain.
+        assert isinstance(stack[0], ContinueOnTruncationMiddleware)
 
     @patch("app.core.graph_factory._has_aws_credentials", return_value=True)
     @patch("langgraph.store.postgres.aio.AsyncPostgresStore")
@@ -165,7 +192,7 @@ class TestMiddlewareStack:
         # LiteLLM caching is present even for non-Bedrock models...
         assert any(isinstance(m, LiteLLMPromptCachingMiddleware) for m in stack)
         # ...and the stack matches the Bedrock case (no provider-conditional branch).
-        assert len(stack) == 17
+        assert len(stack) == 18
 
     @patch("app.core.graph_factory._has_aws_credentials", return_value=True)
     @patch("langgraph.store.postgres.aio.AsyncPostgresStore")
@@ -209,7 +236,7 @@ class TestMiddlewareStack:
         factory = GraphFactory(config=mock_config)
 
         stack = factory._create_middleware_stack()
-        dynamic_middleware = stack[1]
+        dynamic_middleware = next(m for m in stack if isinstance(m, DynamicToolDispatchMiddleware))
 
         assert isinstance(dynamic_middleware, DynamicToolDispatchMiddleware)
         # Static tools are added directly to graph, not via middleware

--- a/packages/orchestrator-agent/tests/test_graph_factory_context_gate.py
+++ b/packages/orchestrator-agent/tests/test_graph_factory_context_gate.py
@@ -9,12 +9,18 @@ present in ``_create_middleware_stack`` and configured with the channel-only
 
 from unittest.mock import MagicMock
 
+from agent_common.middleware.continue_on_truncation import ContinueOnTruncationMiddleware
 from agent_common.middleware.conversation_context_tools_middleware import (
     ConversationContextToolsMiddleware,
 )
 
 from app.core.graph_factory import GraphFactory
 from app.middleware import DynamicToolDispatchMiddleware
+
+
+def _gate(stack):
+    """The conversation-context gate, located by type (index-agnostic)."""
+    return next(m for m in stack if isinstance(m, ConversationContextToolsMiddleware))
 
 
 def _make_factory() -> GraphFactory:
@@ -32,18 +38,21 @@ def _make_factory() -> GraphFactory:
     return factory
 
 
-def test_context_gate_is_outermost():
+def test_context_gate_is_outermost_tool_shaping_middleware():
     stack = _make_factory()._create_middleware_stack()
 
-    assert isinstance(stack[0], ConversationContextToolsMiddleware)
-    # DynamicToolDispatch stays the first tool-call handler (the gate has no
-    # tool-call hook), so it must immediately follow the gate.
-    assert isinstance(stack[1], DynamicToolDispatchMiddleware)
+    # ContinueOnTruncationMiddleware is the outermost middleware overall, but it only
+    # wraps the model call — it shapes no tools. The context gate must remain the
+    # outermost *tool-shaping* middleware, immediately followed by DynamicToolDispatch
+    # (the first tool-call handler), so the gate's injected tool flows through it.
+    assert isinstance(stack[0], ContinueOnTruncationMiddleware)
+    assert isinstance(stack[1], ConversationContextToolsMiddleware)
+    assert isinstance(stack[2], DynamicToolDispatchMiddleware)
 
 
 def test_context_gate_rules_read_personal_file_channel_only():
     stack = _make_factory()._create_middleware_stack()
-    gate = stack[0]
+    gate = _gate(stack)
     assert isinstance(gate, ConversationContextToolsMiddleware)
 
     assert gate._runtime_gated_tools == {"read_personal_file": frozenset({"channel"})}
@@ -57,7 +66,7 @@ def test_gate_injects_read_personal_file_from_registry_in_channel():
 
     from langchain_core.tools import BaseTool
 
-    gate = _make_factory()._create_middleware_stack()[0]
+    gate = _gate(_make_factory()._create_middleware_stack())
 
     read_personal_file = MagicMock(spec=BaseTool)
     read_personal_file.name = "read_personal_file"

--- a/packages/orchestrator-agent/tests/test_stream_handler.py
+++ b/packages/orchestrator-agent/tests/test_stream_handler.py
@@ -194,6 +194,37 @@ class TestParseAgentResponse:
         assert response.state == TaskState.TASK_STATE_COMPLETED
         assert response.content == ""
 
+    def test_parse_agent_response_truncated_turn_not_faked_as_completed(self):
+        """A turn cut off mid-generation (finish_reason=length, no tool call, no structured
+        response) must NOT be reported as a successful completion — surface input_required so
+        the user can ask to continue."""
+        final_state = {
+            "messages": [
+                HumanMessage(content="Do a hard reasoning task"),
+                AIMessage(content="", response_metadata={"finish_reason": "length"}),
+            ]
+        }
+
+        response = StreamHandler.parse_agent_response(final_state)
+
+        assert response.state == TaskState.TASK_STATE_INPUT_REQUIRED
+        assert response.content != "Task completed successfully"
+        assert response.metadata and response.metadata.get("truncated") is True
+
+    def test_parse_agent_response_empty_but_not_truncated_stays_completed(self):
+        """An empty completion that stopped normally (finish_reason=stop) is a real empty
+        answer, not a truncation — it stays completed."""
+        final_state = {
+            "messages": [
+                HumanMessage(content="Test"),
+                AIMessage(content="", response_metadata={"finish_reason": "stop"}),
+            ]
+        }
+
+        response = StreamHandler.parse_agent_response(final_state)
+
+        assert response.state == TaskState.TASK_STATE_COMPLETED
+
 
 class TestStreamHandlerEdgeCases:
     """Test edge cases and error handling."""


### PR DESCRIPTION
## Problem

Extended-thinking turns (especially at **extra-high** effort) draw their thinking tokens from the **same output budget** as the visible response. With no explicit `max_tokens`, the gateway applies a low default (~4096), so a deep-reasoning turn can spend the entire budget *thinking* and get cut off (`finish_reason == "length"`) before emitting any content or the terminal `FinalResponseSchema` tool call.

Downstream, `parse_agent_response` found no structured response and fell back to a hardcoded **"Task completed successfully"** — a truncated, failed turn was silently laundered into a fake success (the empty replies users were seeing).

## Fix — three layers

1. **Give reasoning headroom** — `model_factory.max_tokens_for_effort` scales `max_tokens` with the reasoning tier (`low` 8k → `high`/`xhigh` 32k), so thinking no longer consumes the whole budget. Left unset for reasoning-off turns (preserves the gateway default; doesn't lower a non-reasoning model's own cap).

2. **Recover truncation in place** — `ContinueOnTruncationMiddleware` detects a `finish_reason == "length"` turn with no tool call, **discards the poisoned generation** (so the partial thinking block never enters history), and re-runs with a wrap-up nudge (*"you've reasoned enough, answer now"*) + a raised `max_tokens`. Only the final, complete response reaches the graph. Wired into **both** the sub-agent common stack **and** the orchestrator's own graph (`graph_factory`).

3. **Honest fallback** — if every nudge-retry still truncates, `parse_agent_response` returns `INPUT_REQUIRED` ("ask me to continue") instead of a fake completion.

## Verification

- Unit + integration tests across `agent-common` and `orchestrator-agent` (incl. a regression guard that the middleware stays wired into the orchestrator stack).
- **Live, end-to-end**: temporarily forced a 512-token base budget and drove a real chat turn through the console. Confirmed at the gateway (litellm spend logs):
  - **before** the orchestrator-wiring fix: 1 gateway call, 512 tok (truncated) → honest fallback message;
  - **after**: 2 calls (512 truncated → 470 completed) → **full correct answer**.

Live verification is what caught that layer 2 initially only reached sub-agents, not the orchestrator's own turns (commit `75bc1459`).

## Commits
- `recover thinking turns truncated by output-budget exhaustion` — the three layers + tests
- `wire ContinueOnTruncationMiddleware into the orchestrator's own graph` — the gap found in live verification
- `guard ContinueOnTruncationMiddleware wiring in the orchestrator stack` — regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)