### PR TITLE
fix(console-frontend): stop long tokens from clipping the version history panel

### DIFF
--- a/packages/console-frontend/src/components/subagents/ExpandableText.tsx
+++ b/packages/console-frontend/src/components/subagents/ExpandableText.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface ExpandableTextProps {
+  text: string;
+  className?: string;
+}
+
+/**
+ * Two-line-clamped text with a "Show more"/"Show less" toggle that only
+ * renders when the text is actually truncated. Uses wrap-anywhere so long
+ * unbroken tokens don't inflate the intrinsic width of ancestors (Radix
+ * ScrollArea wraps content in a display:table div that grows to min-content).
+ */
+export function ExpandableText({ text, className }: ExpandableTextProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [isClamped, setIsClamped] = useState(false);
+  const textRef = useRef<HTMLParagraphElement>(null);
+
+  useEffect(() => {
+    const el = textRef.current;
+    if (!el || expanded) return;
+    const check = () => setIsClamped(el.scrollHeight > el.clientHeight + 1);
+    check();
+    const observer = new ResizeObserver(check);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [text, expanded]);
+
+  return (
+    <>
+      <p ref={textRef} className={cn('wrap-anywhere', !expanded && 'line-clamp-2', className)}>
+        {text}
+      </p>
+      {(isClamped || expanded) && (
+        <button
+          type="button"
+          aria-expanded={expanded}
+          onClick={(e) => {
+            e.stopPropagation();
+            setExpanded((v) => !v);
+          }}
+          className="mb-1.5 flex items-center gap-0.5 text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+        >
+          {expanded ? 'Show less' : 'Show more'}
+          <ChevronDown className={cn('h-3 w-3 transition-transform', expanded && 'rotate-180')} />
+        </button>
+      )}
+    </>
+  );
+}

--- a/packages/console-frontend/src/components/subagents/VersionHistoryPanel.tsx
+++ b/packages/console-frontend/src/components/subagents/VersionHistoryPanel.tsx
@@ -39,6 +39,7 @@ import {
   setDefaultVersionApiV1SubAgentsSubAgentIdDefaultVersionPut,
   submitVersionForApprovalApiV1SubAgentsSubAgentIdVersionsVersionSubmitPost,
 } from '@/api/generated/sdk.gen';
+import { ExpandableText } from './ExpandableText';
 import { VersionDiffViewer } from './VersionDiffViewer';
 import type { SubAgent, SubAgentConfigVersion, SubAgentStatus } from './types';
 
@@ -243,9 +244,10 @@ export function VersionHistoryPanel({ subAgent, versions, isOwner, isAdmin: _isA
                     </div>
 
                     {version.change_summary && (
-                      <p className="mt-1 text-sm text-muted-foreground line-clamp-2">
-                        {version.change_summary}
-                      </p>
+                      <ExpandableText
+                        text={version.change_summary}
+                        className="mt-1 text-sm text-muted-foreground"
+                      />
                     )}
 
                     <p className="mt-1 text-xs text-muted-foreground">
@@ -253,7 +255,7 @@ export function VersionHistoryPanel({ subAgent, versions, isOwner, isAdmin: _isA
                     </p>
 
                     {status === 'rejected' && version.rejection_reason && (
-                      <div className="mt-2 rounded-md bg-destructive/10 px-2 py-1 text-xs text-destructive">
+                      <div className="mt-2 rounded-md bg-destructive/10 px-2 py-1 text-xs text-destructive wrap-anywhere">
                         <strong>Rejected:</strong> {version.rejection_reason}
                       </div>
                     )}

--- a/packages/console-frontend/src/components/subagents/VersionSidebar.tsx
+++ b/packages/console-frontend/src/components/subagents/VersionSidebar.tsx
@@ -41,6 +41,7 @@ import {
   setDefaultVersionApiV1SubAgentsSubAgentIdDefaultVersionPut,
   submitVersionForApprovalApiV1SubAgentsSubAgentIdVersionsVersionSubmitPost,
 } from '@/api/generated/sdk.gen';
+import { ExpandableText } from './ExpandableText';
 import { VersionDiffViewer } from './VersionDiffViewer';
 import type { SubAgent, SubAgentConfigVersion, SubAgentStatus } from './types';
 
@@ -452,9 +453,10 @@ export function VersionSidebar({
 
                     {/* Change summary */}
                     {version.change_summary && (
-                      <p className="text-xs text-muted-foreground line-clamp-2 mb-1">
-                        {version.change_summary}
-                      </p>
+                      <ExpandableText
+                        text={version.change_summary}
+                        className="text-xs text-muted-foreground mb-1"
+                      />
                     )}
 
                     {/* Date */}
@@ -464,7 +466,7 @@ export function VersionSidebar({
 
                     {/* Rejection reason */}
                     {status === 'rejected' && version.rejection_reason && (
-                      <div className="mt-2 rounded-md bg-destructive/10 px-2 py-1 text-xs text-destructive">
+                      <div className="mt-2 rounded-md bg-destructive/10 px-2 py-1 text-xs text-destructive wrap-anywhere">
                         <strong>Rejected:</strong> {version.rejection_reason}
                       </div>
                     )}


### PR DESCRIPTION
## Problem

On prod, the sub-agent detail page's Version History sidebar rendered clipped on the right: all cards cut mid-text at the panel edge, kebab menus pushed out of view, no horizontal scrollbar, zoom no help.

## Root cause

- Radix ScrollArea wraps its content in a `display: table; min-width: 100%` div, which sizes to the **min-content** width of its content instead of staying at the panel's `w-72`.
- One version's change summary contained a 52-char unbroken token (`mention/review_requested/assign/author/participating` — slashes/underscores create no line-break opportunities), pushing min-content past the panel width.
- Two aggravating subtleties: text hidden by `line-clamp-2` still participates in intrinsic sizing (so the trigger was invisible on the page), and the wrapper spans the whole list, so one bad summary widens **every** card.

Reproduced and verified in headless Chromium with the exact prod data: wrapper measured 358px inside the 286px viewport; with the fix it returns to exactly 286px.

## Fix

- `overflow-wrap: anywhere` (Tailwind `wrap-anywhere`) on version change summaries and rejection reasons — unlike `break-words`, `anywhere` reduces the min-content contribution, which is the property that matters here.
- New `ExpandableText` component replacing the raw clamped paragraphs in `VersionSidebar` and `VersionHistoryPanel`: clamps to 2 lines and shows a muted "Show more ⌄" / "Show less ⌃" toggle **only when the text is actually truncated** (measured via scrollHeight, kept accurate with a ResizeObserver). The toggle stops propagation so expanding a summary doesn't switch the viewed version.

| Collapsed | Expanded |
|---|---|
| 2 clamped lines + "Show more ⌄" | full text in place, selectable, "Show less ⌃" |

🤖 Generated with [Claude Code](https://claude.com/claude-code)