### PR TITLE
fix(console-backend): make scheduler_update_job schedule switches valid instead of 500ing

### DIFF
--- a/packages/console-backend/console_backend/routers/scheduler_router.py
+++ b/packages/console-backend/console_backend/routers/scheduler_router.py
@@ -9,6 +9,7 @@ import logging
 import re
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
+from sqlalchemy.exc import IntegrityError
 
 from ..db.session import DbSession
 from ..dependencies import require_auth, require_auth_or_bearer_token
@@ -222,6 +223,16 @@ async def update_job(
         )
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    except IntegrityError as e:
+        # Backstop: the service validates schedule combinations up front, but any
+        # constraint violation that still reaches the database must come back as an
+        # actionable client error, not an opaque 500 (MCP callers can self-correct
+        # on a message, not on "Internal Server Error").
+        detail = str(getattr(e, "orig", e)).splitlines()[0]
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Update rejected by a database constraint: {detail}",
+        ) from e
     if job is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
     return job

--- a/packages/console-backend/console_backend/services/scheduler_service.py
+++ b/packages/console-backend/console_backend/services/scheduler_service.py
@@ -14,6 +14,7 @@ from ..models.scheduled_job import (
     ScheduledJobCreate,
     ScheduledJobRun,
     ScheduledJobUpdate,
+    ScheduleKind,
 )
 from ..models.user import User
 from ..repositories.scheduled_job_repository import ScheduledJobRepository, compute_next_run
@@ -222,21 +223,40 @@ class SchedulerService:
             if not any(sa.id == fields["sub_agent_id"] for sa in accessible_agents):
                 raise ValueError(f"Access denied: You do not have permission to use sub-agent {fields['sub_agent_id']}")
 
-        # If schedule changed, recompute next_run_at
-        new_kind = data.schedule_kind or job.schedule_kind
-        new_cron = data.cron_expr if data.cron_expr is not None else job.cron_expr
-        new_interval = data.interval_seconds if data.interval_seconds is not None else job.interval_seconds
-        new_run_at = data.run_at if data.run_at is not None else job.run_at
+        # The DB enforces exactly one schedule config (scheduled_jobs_schedule_config):
+        # the column matching schedule_kind must be set and the other two NULL. A
+        # partial PATCH that switches kind must therefore clear the now-stale columns,
+        # and the effective combination must be validated here so callers get a clean
+        # 400 instead of a CheckViolationError surfacing as a 500.
+        if any(getattr(data, f) is not None for f in ("schedule_kind", "cron_expr", "interval_seconds", "run_at")):
+            new_kind = ScheduleKind(data.schedule_kind or job.schedule_kind)
+            new_cron = data.cron_expr if data.cron_expr is not None else job.cron_expr
+            new_interval = data.interval_seconds if data.interval_seconds is not None else job.interval_seconds
+            new_run_at = data.run_at if data.run_at is not None else job.run_at
 
-        if any(f in fields for f in ("schedule_kind", "cron_expr", "interval_seconds", "run_at")):
-            next_run_at = compute_next_run(new_kind, new_cron, new_interval, new_run_at)
-            if next_run_at is not None:
-                fields["next_run_at"] = next_run_at
+            if new_kind == ScheduleKind.CRON:
+                if not new_cron:
+                    raise ValueError("schedule_kind 'cron' requires cron_expr")
+                new_interval = None
+                new_run_at = None
+            elif new_kind == ScheduleKind.INTERVAL:
+                if new_interval is None:
+                    raise ValueError("schedule_kind 'interval' requires interval_seconds")
+                new_cron = None
+                new_run_at = None
+            else:  # ScheduleKind.ONCE
+                if new_run_at is None:
+                    raise ValueError("schedule_kind 'once' requires run_at")
+                new_cron = None
+                new_interval = None
 
-        for attr in ("schedule_kind", "cron_expr", "interval_seconds", "run_at"):
-            val = getattr(data, attr, None)
-            if val is not None:
-                fields[attr] = val.value if hasattr(val, "value") else val
+            fields["schedule_kind"] = new_kind.value
+            fields["cron_expr"] = new_cron
+            fields["interval_seconds"] = new_interval
+            fields["run_at"] = new_run_at
+            # compute_next_run returns None for 'once' (nothing to repeat after the
+            # run) — the single run happens at run_at itself, mirroring create_job.
+            fields["next_run_at"] = compute_next_run(new_kind, new_cron, new_interval, new_run_at) or new_run_at
 
         await self.repo.update_job(db=db, actor=actor, job_id=job_id, fields=fields)
         await db.commit()

--- a/packages/console-backend/tests/test_scheduler_service.py
+++ b/packages/console-backend/tests/test_scheduler_service.py
@@ -470,3 +470,121 @@ class TestUpdateJobUnsetSentinel:
 
         result = await service.update_job(db=db, job_id=1, data=ScheduledJobUpdate(), actor=actor)
         assert result is None
+
+
+class TestUpdateJobScheduleSwitch:
+    """Switching schedule_kind must clear the stale schedule columns and recompute next_run_at.
+
+    The DB check constraint scheduled_jobs_schedule_config requires exactly one
+    schedule config; leaving e.g. cron_expr set while switching to 'once' used to
+    surface as an IntegrityError 500 (prod incident 2026-08-03, job 4).
+    """
+
+    @pytest.mark.asyncio
+    async def test_cron_to_once_clears_cron_expr(
+        self, service: SchedulerService, mock_repo: AsyncMock, actor: User
+    ):
+        db = AsyncMock()
+        existing_job = _make_job(
+            user_id=actor.id, schedule_kind=ScheduleKind.CRON, interval_seconds=None
+        )
+        existing_job.cron_expr = "0 8 * * *"
+        mock_repo.get_job.side_effect = [existing_job, existing_job]
+        mock_repo.update_job.return_value = None
+
+        run_at = datetime.now(timezone.utc) + timedelta(minutes=1)
+        data = ScheduledJobUpdate(schedule_kind=ScheduleKind.ONCE, run_at=run_at)
+        await service.update_job(db=db, job_id=1, data=data, actor=actor)
+
+        fields = mock_repo.update_job.call_args[1]["fields"]
+        assert fields["schedule_kind"] == "once"
+        assert fields["run_at"] == run_at
+        assert fields["cron_expr"] is None
+        assert fields["interval_seconds"] is None
+        # once-jobs run at run_at itself
+        assert fields["next_run_at"] == run_at
+
+    @pytest.mark.asyncio
+    async def test_interval_to_cron_clears_interval(
+        self, service: SchedulerService, mock_repo: AsyncMock, actor: User
+    ):
+        db = AsyncMock()
+        existing_job = _make_job(user_id=actor.id)  # interval job
+        mock_repo.get_job.side_effect = [existing_job, existing_job]
+        mock_repo.update_job.return_value = None
+
+        data = ScheduledJobUpdate(schedule_kind=ScheduleKind.CRON, cron_expr="0 8 * * *")
+        await service.update_job(db=db, job_id=1, data=data, actor=actor)
+
+        fields = mock_repo.update_job.call_args[1]["fields"]
+        assert fields["schedule_kind"] == "cron"
+        assert fields["cron_expr"] == "0 8 * * *"
+        assert fields["interval_seconds"] is None
+        assert fields["run_at"] is None
+        assert fields["next_run_at"] > datetime.now(timezone.utc)
+
+    @pytest.mark.asyncio
+    async def test_switch_to_once_without_run_at_raises(
+        self, service: SchedulerService, mock_repo: AsyncMock, actor: User
+    ):
+        db = AsyncMock()
+        existing_job = _make_job(user_id=actor.id)  # interval job, run_at unset
+        mock_repo.get_job.return_value = existing_job
+
+        with pytest.raises(ValueError, match="'once' requires run_at"):
+            await service.update_job(
+                db=db, job_id=1, data=ScheduledJobUpdate(schedule_kind=ScheduleKind.ONCE), actor=actor
+            )
+        mock_repo.update_job.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_switch_to_cron_without_expr_raises(
+        self, service: SchedulerService, mock_repo: AsyncMock, actor: User
+    ):
+        db = AsyncMock()
+        existing_job = _make_job(user_id=actor.id)  # interval job, cron_expr unset
+        mock_repo.get_job.return_value = existing_job
+
+        with pytest.raises(ValueError, match="'cron' requires cron_expr"):
+            await service.update_job(
+                db=db, job_id=1, data=ScheduledJobUpdate(schedule_kind=ScheduleKind.CRON), actor=actor
+            )
+        mock_repo.update_job.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_schedule_only_patch_recomputes_next_run_at(
+        self, service: SchedulerService, mock_repo: AsyncMock, actor: User
+    ):
+        """Regression: the old code checked for schedule fields in the update payload
+        BEFORE adding them, so next_run_at was never recomputed on a schedule change."""
+        db = AsyncMock()
+        existing_job = _make_job(user_id=actor.id)  # interval 3600s
+        mock_repo.get_job.side_effect = [existing_job, existing_job]
+        mock_repo.update_job.return_value = None
+
+        before = datetime.now(timezone.utc)
+        await service.update_job(
+            db=db, job_id=1, data=ScheduledJobUpdate(interval_seconds=120), actor=actor
+        )
+
+        fields = mock_repo.update_job.call_args[1]["fields"]
+        assert fields["interval_seconds"] == 120
+        assert "next_run_at" in fields
+        assert timedelta(seconds=100) < fields["next_run_at"] - before < timedelta(seconds=140)
+
+    @pytest.mark.asyncio
+    async def test_non_schedule_patch_leaves_schedule_untouched(
+        self, service: SchedulerService, mock_repo: AsyncMock, actor: User
+    ):
+        db = AsyncMock()
+        existing_job = _make_job(user_id=actor.id)
+        mock_repo.get_job.side_effect = [existing_job, existing_job]
+        mock_repo.update_job.return_value = None
+
+        await service.update_job(
+            db=db, job_id=1, data=ScheduledJobUpdate(), actor=actor, name="renamed"
+        )
+
+        fields = mock_repo.update_job.call_args[1]["fields"]
+        for f in ("schedule_kind", "cron_expr", "interval_seconds", "run_at", "next_run_at"):
+            assert f not in fields


### PR DESCRIPTION
## Problem

During a prod run on 2026-08-03, an agent tried to reschedule a cron job to run once (`PATCH /api/v1/scheduler/jobs/4` with `schedule_kind='once', run_at=...`). The update left the job's `cron_expr` set, violating the `scheduled_jobs_schedule_config` check constraint (exactly one schedule config may be set). The resulting `IntegrityError` surfaced through fastapi-mcp as an opaque `500 {"detail":"Internal Server Error"}` — nothing an MCP agent can self-correct on.

## Changes

- **Clear stale schedule columns on kind switches**: when any schedule field is PATCHed, the two columns not matching the effective `schedule_kind` are explicitly nulled, and the effective combination is validated up front — a missing `cron_expr`/`interval_seconds`/`run_at` now returns **400** with an actionable message (same pattern as the existing delivery-channel validation).
- **Fix a latent `next_run_at` bug**: the recompute guard checked for schedule fields in the update payload *before* they were added to it, so `next_run_at` was never recomputed on schedule changes (confirmed by the incident's failing row: `run_at` was being set to 07:31Z while `next_run_at` stayed 08:00Z). It is now always recomputed, with `once` jobs getting `next_run_at = run_at`, mirroring `create_job`.
- **422 backstop**: any `IntegrityError` that still reaches the database comes back as a 422 carrying the constraint message instead of a bare 500.

## Tests

6 new unit tests in `test_scheduler_service.py`, including a regression test reproducing the incident (cron → once switch), kind-switch clearing in both directions, missing-config validation, `next_run_at` recompute on schedule-only PATCH, and no schedule side-effects on non-schedule PATCHes. Full console-backend suite: 1276 passed (1 pre-existing environment failure in `test_bulk_activation.py`, reproducible on origin/main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)