### PR TITLE
fix(litellm-proxy): strip cache_control before gemini-format deployments

### DIFF
--- a/packages/litellm-proxy/README.md
+++ b/packages/litellm-proxy/README.md
@@ -17,6 +17,36 @@ model registration, and proxy-side cost capture. Apps talk to it via
     ("`additionalProperties: object` is not supported. Please set to false"); LangChain's
     native `ProviderStrategy`/`AutoStrategy` path emits non-strict schemas that omit it.
     Fixing it here covers every structured-output path uniformly and is safe across providers.
+  - **Gemini cache_control stripping** (`async_pre_call_deployment_hook`): removes
+    Anthropic-style `cache_control` markers from requests routed to gemini-format models
+    (`_CACHE_CONTROL_STRIP_RULES`, keyed provider + model prefix — Claude-on-Vertex keeps its
+    markers). The app attaches the markers to every provider's messages (ADR-0001, one client);
+    on Gemini, LiteLLM silently reinterprets them as *explicit* Vertex context caching: a
+    `cachedContents` object is created before the first generate call, so the first call of a
+    conversation reports its whole prefix as cache-read. The create call bills full-price input
+    plus per-token-hour storage (default TTL ~1h) and emits no success event, so that cost was
+    invisible to cost capture. LiteLLM documents no off-switch. At ~$1/M-tokens/hour storage, a
+    15k-token conversation prefix costs more to store for the default hour than one cache-read
+    saves — a net loss for short conversations even before the unbilled create.
+
+    Worse for multi-turn traffic: **explicit caches are immutable — there is no incremental
+    write.** A `cachedContents` object cannot be appended to or updated; LiteLLM reuses one only
+    on an exact content-hash match of the marked block. The moment the marked block changes or
+    grows (and the app's Anthropic-oriented markers move with the conversation on some turns),
+    that turn silently creates a **new cache of the entire grown prefix**: full input tokens
+    billed again at the standard rate plus a fresh storage object, with the superseded cache
+    still accruing storage until its TTL expires — unlike Anthropic, where a moved breakpoint
+    writes only the delta. Explicit caching fits static assets (a large fixed system prompt, a
+    reference document), not growing chat logs.
+
+    With markers stripped, Gemini's built-in **implicit** caching applies instead: free (no
+    storage, no create), but **best-effort** — measured 2026-08-06 through the gateway
+    (`gemini-3.5-flash-lite`, growing ~31k-token conversation prefix): hits on ~50–60% of
+    turns, with misses interleaved; a burst of calls within seconds can see zero hits before
+    the prefix propagates. Partial cache-read coverage on the usage page is therefore expected
+    behavior, not a bug. Genuine implicit hits also never cover 100% of the prompt (a few
+    hundred tokens past the last chunk boundary stay uncached) — a first call reporting its
+    *entire* prompt as cache-read is the signature of the explicit-caching path leaking back.
 - `Dockerfile` — `FROM ghcr.io/berriai/litellm` + the callback only.
 
 The `config.yaml` (model_list, regions, `model_info` cost seeds, `store_model_in_db`)

--- a/packages/litellm-proxy/custom_logger.py
+++ b/packages/litellm-proxy/custom_logger.py
@@ -145,6 +145,79 @@ def _sanitize_response_format(data: dict) -> None:
         _force_additional_properties_false(schema)
 
 
+# --- Gemini cache_control stripping ------------------------------------------------------
+# The app attaches Anthropic-style `cache_control: {"type": "ephemeral"}` markers to every
+# model's messages (ADR-0001: one ChatOpenAI client for all providers). On gemini-format
+# models LiteLLM turns those markers into EXPLICIT Vertex context caching: it creates a
+# `cachedContents` object before generateContent, so even a conversation's first call reports
+# its whole prefix as cache-read. The cachedContents.create call bills full-price input tokens
+# plus per-token-hour storage (default TTL ~1h) and emits no success event — that cost is
+# invisible to this logger, so gemini conversations get under-billed. Gemini 2.5+ implicit
+# caching already gives the read discount for free, and LiteLLM documents no way to disable
+# the explicit path (docs/providers/gemini), so we strip the markers at the provider boundary.
+# Implicit caching is best-effort, not guaranteed: measured ~50-60% hit rate across turns of a
+# growing conversation prefix (2026-08-06) — partial cache-read coverage is expected, and at
+# ~$1/M-tok/hour cachedContents storage the guaranteed explicit hits still cost more than they
+# save for short conversations. Explicit caches are also immutable (no incremental write): any
+# turn that changes the marked block re-writes the ENTIRE prefix at full price into a new cache
+# object — unlike Anthropic, where a moved breakpoint writes only the delta. Trade-off details:
+# README "Gemini cache_control stripping".
+#
+# Keyed on (provider, model prefix), not provider alone: Claude models served via vertex_ai
+# support cache_control natively and must keep their markers. Runs in the post-routing
+# deployment hook — provider identity doesn't exist pre-routing — and copies-on-write so a
+# retry/fallback of the same request to another provider still sees the original markers.
+_CACHE_CONTROL_STRIP_RULES: dict[str, tuple[str, ...]] = {
+    # provider -> model-name prefixes to strip (empty tuple = every model of that provider)
+    "vertex_ai": ("gemini",),
+    "gemini": (),  # Google AI Studio serves only gemini-format models
+}
+
+
+def _should_strip_cache_control(provider: str | None, model: str) -> bool:
+    prefixes = _CACHE_CONTROL_STRIP_RULES.get(provider or "")
+    if prefixes is None:
+        return False
+    return not prefixes or model.startswith(prefixes)
+
+
+def _strip_cache_control_entries(items: list) -> list | None:
+    """Return a copy of ``items`` (messages or tools) with every ``cache_control`` removed,
+    or None if no marker was found.
+
+    Markers appear at the entry level (messages and tool definitions) and on structured
+    content parts (``content: [{"type": "text", ..., "cache_control": ...}]``). Copy-on-write:
+    untouched entries are reused and the input is never mutated — the router hands each
+    deployment attempt a shallow copy of the request, so mutating shared message dicts would
+    leak the strip into a fallback attempt on a provider that wants its markers.
+    """
+    changed = False
+    out = []
+    for item in items:
+        if not isinstance(item, dict):
+            out.append(item)
+            continue
+        new_item = item
+        if "cache_control" in item:
+            new_item = {k: v for k, v in item.items() if k != "cache_control"}
+        content = new_item.get("content")
+        if isinstance(content, list) and any(
+            isinstance(part, dict) and "cache_control" in part for part in content
+        ):
+            if new_item is item:
+                new_item = dict(item)
+            new_item["content"] = [
+                {k: v for k, v in part.items() if k != "cache_control"}
+                if isinstance(part, dict) and "cache_control" in part
+                else part
+                for part in content
+            ]
+        if new_item is not item:
+            changed = True
+        out.append(new_item)
+    return out if changed else None
+
+
 def _as_dict(obj) -> dict:
     if obj is None:
         return {}
@@ -448,6 +521,40 @@ class NannosCostLogger(CustomLogger):
                 "[schema] response_format sanitization failed: %s", e, exc_info=True
             )
         return data
+
+    async def async_pre_call_deployment_hook(self, kwargs, call_type):
+        """Strip cache_control markers from requests routed to gemini-format deployments.
+
+        Runs after the router picked a deployment (unlike ``async_pre_call_hook``), so the
+        provider/model are known. See ``_CACHE_CONTROL_STRIP_RULES`` for the why. Returning
+        the (mutated) kwargs replaces the request for this attempt only; returning None
+        leaves it unchanged. Never raise — stripping is an optimization, not a gate.
+        """
+        try:
+            model = kwargs.get("model") or ""
+            provider = kwargs.get("custom_llm_provider")
+            if not provider and "/" in model:
+                provider = model.split("/", 1)[0]
+            bare_model = model.split("/", 1)[1] if "/" in model else model
+            if not _should_strip_cache_control(provider, bare_model):
+                return None
+            changed = False
+            for key in ("messages", "tools"):
+                items = kwargs.get(key)
+                if isinstance(items, list):
+                    stripped = _strip_cache_control_entries(items)
+                    if stripped is not None:
+                        kwargs[key] = stripped
+                        changed = True
+            return kwargs if changed else None
+        except Exception as e:  # never break the call on a stripping failure
+            logger.warning(
+                "[cache-control] strip failed for model=%s: %s",
+                kwargs.get("model"),
+                e,
+                exc_info=True,
+            )
+            return None
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         try:

--- a/packages/litellm-proxy/tests/test_custom_logger.py
+++ b/packages/litellm-proxy/tests/test_custom_logger.py
@@ -330,7 +330,9 @@ def test_web_search_billed_one_unit_per_grounded_call():
             "prompt_tokens_details": {"text_tokens": 12, "web_search_requests": 2},
         }
     )
-    assert bd["web_search"] == 1  # NOT 2 — would over-bill the flat per-call grounding fee
+    assert (
+        bd["web_search"] == 1
+    )  # NOT 2 — would over-bill the flat per-call grounding fee
     assert bd["base_input_tokens"] == 12
     assert bd["base_output_tokens"] == 251
 
@@ -533,3 +535,121 @@ def test_pre_call_hook_passthrough_without_response_format():
         cl.proxy_handler_instance.async_pre_call_hook(None, None, data, "completion")
     )
     assert out == {"model": "claude-sonnet-4.6", "messages": []}
+
+
+# ---- cache_control stripping (gemini-format deployments) --------------------------------
+
+
+def _gemini_kwargs(**overrides):
+    """Deployment-hook kwargs as the router builds them: resolved deployment model id."""
+    kwargs = {
+        "model": "vertex_ai/gemini-3.5-flash",
+        "messages": [
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "sys",
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            },
+            {"role": "user", "content": "hi"},
+        ],
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+def _run_deployment_hook(kwargs):
+    return asyncio.run(
+        cl.proxy_handler_instance.async_pre_call_deployment_hook(kwargs, "acompletion")
+    )
+
+
+def test_strip_removes_part_level_marker_for_vertex_gemini():
+    kwargs = _gemini_kwargs()
+    out = _run_deployment_hook(kwargs)
+    assert out is kwargs
+    assert out["messages"][0]["content"][0] == {"type": "text", "text": "sys"}
+
+
+def test_strip_removes_message_and_tool_level_markers():
+    kwargs = _gemini_kwargs(
+        messages=[
+            {
+                "role": "system",
+                "content": "sys",
+                "cache_control": {"type": "ephemeral"},
+            },
+        ],
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "t", "parameters": {}},
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+    )
+    out = _run_deployment_hook(kwargs)
+    assert out["messages"][0] == {"role": "system", "content": "sys"}
+    assert out["tools"][0] == {
+        "type": "function",
+        "function": {"name": "t", "parameters": {}},
+    }
+
+
+def test_strip_is_copy_on_write():
+    """A fallback attempt to another provider must still see the original markers."""
+    original_messages = _gemini_kwargs()["messages"]
+    kwargs = {"model": "vertex_ai/gemini-3.5-flash", "messages": original_messages}
+    out = _run_deployment_hook(kwargs)
+    # the input list and its marked message dict are untouched
+    assert "cache_control" in original_messages[0]["content"][0]
+    # untouched entries are reused, not copied
+    assert out["messages"][1] is original_messages[1]
+
+
+def test_no_strip_for_bedrock_claude():
+    kwargs = _gemini_kwargs(model="bedrock/eu.anthropic.claude-sonnet-4-6")
+    out = _run_deployment_hook(kwargs)
+    assert out is None
+    assert "cache_control" in kwargs["messages"][0]["content"][0]
+
+
+def test_no_strip_for_claude_on_vertex():
+    """vertex_ai serves Claude too; its Anthropic transform honors cache_control natively."""
+    kwargs = _gemini_kwargs(model="vertex_ai/claude-sonnet-4-6")
+    assert _run_deployment_hook(kwargs) is None
+
+
+def test_strip_for_google_ai_studio_provider_any_model():
+    kwargs = _gemini_kwargs(model="gemini/gemini-3.5-flash")
+    out = _run_deployment_hook(kwargs)
+    assert out is not None
+    assert "cache_control" not in out["messages"][0]["content"][0]
+
+
+def test_explicit_custom_llm_provider_wins_over_prefix():
+    kwargs = _gemini_kwargs(model="gemini-3.5-flash", custom_llm_provider="vertex_ai")
+    out = _run_deployment_hook(kwargs)
+    assert out is not None
+
+
+def test_no_change_returns_none_for_gemini_without_markers():
+    kwargs = _gemini_kwargs(
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    assert _run_deployment_hook(kwargs) is None
+
+
+def test_strip_never_raises_on_odd_shapes():
+    for kwargs in (
+        {"model": "vertex_ai/gemini-3.5-flash", "messages": "not-a-list"},
+        {"model": "vertex_ai/gemini-3.5-flash", "messages": [None, "x", 42]},
+        {"model": "vertex_ai/gemini-3.5-flash"},
+        {"model": None},
+        {},
+    ):
+        assert _run_deployment_hook(kwargs) is None


### PR DESCRIPTION
## Problem

The very first call of a conversation to a Gemini model reported ~its entire prompt as **cache read** (e.g. 17,732 of 17,734 tokens) — before any prior call could have warmed a cache.

Root cause: the app attaches Anthropic-style `cache_control: {"type": "ephemeral"}` markers to every provider's messages (ADR-0001, single ChatOpenAI client). On gemini-format models LiteLLM silently reinterprets those markers as **explicit Vertex context caching**: it creates an immutable `cachedContents` object *before* the first generate call. Consequences:

- The generate call reports the whole prefix as discounted cache-read on first contact.
- The `cachedContents.create` call bills those same tokens at **full input price + per-token-hour storage** (default TTL ~1h) and emits **no success event** → invisible to cost capture → gemini conversations systematically under-billed.
- Explicit caches have **no incremental write**: any turn that changes the marked block (the app's Anthropic-oriented markers move with the conversation) re-writes the *entire grown prefix* into a new cache object, with the superseded one still accruing storage until TTL — pathological for multi-turn traffic, unlike Anthropic's delta-only breakpoint writes.
- At ~\$1/M-tokens/hour storage, a 15k-token prefix costs more to store for the default hour than one cache-read saves.
- LiteLLM documents no way to disable the explicit path ([docs](https://docs.litellm.ai/docs/providers/vertex)).

## Fix

Strip `cache_control` markers (message-, content-part-, and tool-level) in `async_pre_call_deployment_hook` — post-routing, since provider identity doesn't exist pre-routing. Keyed on **provider + model prefix** via `_CACHE_CONTROL_STRIP_RULES` (`vertex_ai: gemini*`, `gemini: *`): Claude-on-Vertex keeps its markers (`VertexAIAnthropicConfig` extends `AnthropicConfig`, native cache_control support). Copy-on-write so a retry/fallback of the same request to another provider still sees the original markers. Adding a provider is a one-line rule change.

Gemini 2.5+ **implicit** caching then applies instead: free (no create call, no storage), best-effort — measured ~50–60% hit rate across turns of a growing conversation prefix. Partial cache-read coverage on the usage page is expected behavior; a first call reporting its *entire* prompt as cache-read is the regression signature of the explicit path leaking back (genuine implicit hits leave a few-hundred-token uncached tail).

## Verification

- Prod probe, novel prompt **with** marker: first call reported `cached_tokens=31245/31247` — the reported anomaly's exact shape.
- Prod probe, same prompt **without** marker: first call zero cached; identical repeat hit implicitly (30,682 cached).
- Cross-model seeding (flash-lite → flash) experimentally refuted; retries/other-env seeding ruled out via prod access logs + spend logs of all three environments.
- 9 new unit tests (strip shapes, copy-on-write, Claude-on-Vertex exemption, provider resolution, odd-shape safety); 40/40 pass.

closes #

## Checklist
- [x] I have performed a self-review of my code
- [x] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨 — behavior change: gemini calls stop getting guaranteed (explicit) cache hits; billed base-input goes up because it was previously under-billed. See README "Gemini cache_control stripping" for the trade-off record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)