### PR TITLE
feat(clients): task-cancellation slash commands for Slack and Google Chat

### DIFF
--- a/packages/client-google-chat/src/handlers/commandHandler.ts
+++ b/packages/client-google-chat/src/handlers/commandHandler.ts
@@ -182,15 +182,15 @@ async function handleLoginCommand(
 }
 
 /**
- * Handle "cancel" command – aborts a running task via the same A2A cancel
+ * Handle "cancel" command – aborts running tasks via the same A2A cancel
  * protocol the web client's stop button uses.
  *
- * The task is resolved from the current thread when possible; otherwise from
- * the user's in-flight tasks (a task ID argument disambiguates).
+ * Task IDs are internal to the system, so the tasks to cancel are resolved
+ * from where the command is issued: the user's running tasks in the current
+ * thread (there is almost always exactly one).
  */
 export async function handleCancelCommand(
   appCommand: AppCommand,
-  args: string,
   chatService: GoogleChatService,
   inFlightTaskStore: IInFlightTaskStore,
   userAuthService: UserAuthService,
@@ -204,44 +204,14 @@ export async function handleCancelCommand(
   const reply = (text: string) => chatService.sendPrivateTextMessage(projectId, spaceId, userId, text, threadId);
 
   const tasks = await inFlightTaskStore.getByUser(projectId, userId);
+  const targets: InFlightTask[] = tasks.filter((t) => t.threadId === threadId);
 
-  if (tasks.length === 0) {
-    await reply('ℹ️ You have no running tasks to cancel.');
-    return;
-  }
-
-  const requestedTaskId = args.trim();
-  const threadTasks = tasks.filter((t) => t.threadId === threadId);
-  let task: InFlightTask | undefined;
-
-  if (requestedTaskId) {
-    task = tasks.find((t) => t.taskId === requestedTaskId || t.taskId.startsWith(requestedTaskId));
-    if (!task) {
-      await reply(
-        [
-          `❓ No running task matches \`${requestedTaskId}\`.`,
-          '',
-          '*Your running tasks:*',
-          ...tasks.map((t) => `• \`${t.taskId}\` — started ${formatTimestamp(t.createdAt)}`),
-        ].join('\n')
-      );
-      return;
-    }
-  } else if (threadTasks.length === 1) {
-    task = threadTasks[0];
-  } else if (threadTasks.length === 0 && tasks.length === 1) {
-    task = tasks[0];
-  } else {
-    const candidates = threadTasks.length > 0 ? threadTasks : tasks;
-    await reply(
-      [
-        `You have ${candidates.length} running tasks. Specify which one to cancel:`,
-        '',
-        ...candidates.map((t) => `• \`${t.taskId}\` — started ${formatTimestamp(t.createdAt)}`),
-        '',
-        'Use the *cancel* command followed by the task ID.',
-      ].join('\n')
-    );
+  if (targets.length === 0) {
+    const elsewhere =
+      tasks.length > 0
+        ? ` You have ${tasks.length} running task(s) in other threads — use the *cancel* command there to cancel them.`
+        : '';
+    await reply(`ℹ️ You have no running tasks in this thread.${elsewhere}`);
     return;
   }
 
@@ -251,20 +221,42 @@ export async function handleCancelCommand(
     return;
   }
 
-  const response = await a2aClientService.cancelTask(task.taskId, accessToken);
+  let cancelled = 0;
+  let alreadyFinished = 0;
+  const failures: string[] = [];
 
-  if ('error' in response && response.error) {
-    if (response.error.code === A2A_TASK_NOT_FOUND || response.error.code === A2A_TASK_NOT_CANCELABLE) {
-      // Stale record — the task already reached a terminal state.
-      await inFlightTaskStore.delete(task.taskId).catch(() => {});
-      await reply(`ℹ️ Task \`${task.taskId}\` has already finished — nothing to cancel.`);
+  for (const task of targets) {
+    const response = await a2aClientService.cancelTask(task.taskId, accessToken);
+
+    if ('error' in response && response.error) {
+      if (response.error.code === A2A_TASK_NOT_FOUND || response.error.code === A2A_TASK_NOT_CANCELABLE) {
+        // Stale record — the task already reached a terminal state.
+        await inFlightTaskStore.delete(task.taskId).catch(() => {});
+        alreadyFinished++;
+      } else {
+        failures.push(response.error.message);
+      }
     } else {
-      await reply(`❌ Failed to cancel task \`${task.taskId}\`: ${response.error.message}`);
+      cancelled++;
     }
-    return;
   }
 
-  await reply(`🛑 Cancellation requested for task \`${task.taskId}\`. The task will stop shortly.`);
+  const lines: string[] = [];
+  if (cancelled > 0) {
+    lines.push(
+      cancelled === 1
+        ? '🛑 Cancellation requested — the task will stop shortly.'
+        : `🛑 Cancellation requested for ${cancelled} running tasks — they will stop shortly.`
+    );
+  }
+  if (alreadyFinished > 0) {
+    lines.push(`ℹ️ ${alreadyFinished} task(s) had already finished — nothing to cancel.`);
+  }
+  for (const failure of failures) {
+    lines.push(`❌ Failed to cancel a task: ${failure}`);
+  }
+
+  await reply(lines.join('\n'));
 }
 
 /**
@@ -277,7 +269,7 @@ async function handleHelpCommand(
   const helpText = [
     '🤖 *Nannos Commands*\n',
     '• *login* - Log in to use Nannos services',
-    '• *cancel [task_id]* - Cancel a running task (alias: *stop*)',
+    '• *cancel* - Cancel your running task in this thread (alias: *stop*)',
     '• *debug* - Show debug info about your session and threads',
     '• *logout* - Log out from Nannos',
     '• *help* - Show this help message',
@@ -306,9 +298,8 @@ export async function handleAppCommand(
   const logger = Logger.getLogger('handleAppCommand');
   logger.info(`App command argument=${appCommand.commandArgument} from user ${appCommand.userId} in space ${appCommand.spaceId}`);
 
-  // Dispatch on the first token so commands can take arguments (e.g. "cancel <task_id>")
-  const [commandName, ...commandArgs] = appCommand.commandArgument.split(/\s+/);
-  const commandArgsText = commandArgs.join(' ');
+  // Dispatch on the first token so trailing text doesn't break command matching
+  const [commandName] = appCommand.commandArgument.split(/\s+/);
 
   switch (commandName) {
     case 'help':
@@ -319,14 +310,7 @@ export async function handleAppCommand(
 
     case 'cancel':
     case 'stop':
-      return handleCancelCommand(
-        appCommand,
-        commandArgsText,
-        chatService,
-        inFlightTaskStore,
-        userAuthService,
-        a2aClientService
-      );
+      return handleCancelCommand(appCommand, chatService, inFlightTaskStore, userAuthService, a2aClientService);
 
     case 'debug':
       return handleDebugCommand(

--- a/packages/client-google-chat/src/handlers/commandHandler.ts
+++ b/packages/client-google-chat/src/handlers/commandHandler.ts
@@ -1,9 +1,15 @@
 import { Logger } from '../utils/logger.js';
 
-import type { IContextStore, IInFlightTaskStore } from '../storage/types.js';
+import type { IContextStore, IInFlightTaskStore, InFlightTask } from '../storage/types.js';
 import { UserAuthService } from '../services/userAuthService.js';
 import { GoogleChatService } from '../services/googleChatService.js';
+import { A2AClientService } from '../services/a2aClientService.js';
 import { HandlerDependencies } from './types.js';
+
+// A2A JSON-RPC error codes signalling the task is already terminal (or gone),
+// i.e. the stored in-flight record is stale and can be dropped.
+const A2A_TASK_NOT_FOUND = -32001;
+const A2A_TASK_NOT_CANCELABLE = -32002;
 
 
 export interface AppCommand {
@@ -176,6 +182,92 @@ async function handleLoginCommand(
 }
 
 /**
+ * Handle "cancel" command – aborts a running task via the same A2A cancel
+ * protocol the web client's stop button uses.
+ *
+ * The task is resolved from the current thread when possible; otherwise from
+ * the user's in-flight tasks (a task ID argument disambiguates).
+ */
+export async function handleCancelCommand(
+  appCommand: AppCommand,
+  args: string,
+  chatService: GoogleChatService,
+  inFlightTaskStore: IInFlightTaskStore,
+  userAuthService: UserAuthService,
+  a2aClientService: A2AClientService
+): Promise<void> {
+  const logger = Logger.getLogger('handleCancelCommand');
+  const { projectId, spaceId, userId, threadId } = appCommand;
+
+  logger.info(`cancel command from user ${userId} in thread ${threadId}`);
+
+  const reply = (text: string) => chatService.sendPrivateTextMessage(projectId, spaceId, userId, text, threadId);
+
+  const tasks = await inFlightTaskStore.getByUser(projectId, userId);
+
+  if (tasks.length === 0) {
+    await reply('ℹ️ You have no running tasks to cancel.');
+    return;
+  }
+
+  const requestedTaskId = args.trim();
+  const threadTasks = tasks.filter((t) => t.threadId === threadId);
+  let task: InFlightTask | undefined;
+
+  if (requestedTaskId) {
+    task = tasks.find((t) => t.taskId === requestedTaskId || t.taskId.startsWith(requestedTaskId));
+    if (!task) {
+      await reply(
+        [
+          `❓ No running task matches \`${requestedTaskId}\`.`,
+          '',
+          '*Your running tasks:*',
+          ...tasks.map((t) => `• \`${t.taskId}\` — started ${formatTimestamp(t.createdAt)}`),
+        ].join('\n')
+      );
+      return;
+    }
+  } else if (threadTasks.length === 1) {
+    task = threadTasks[0];
+  } else if (threadTasks.length === 0 && tasks.length === 1) {
+    task = tasks[0];
+  } else {
+    const candidates = threadTasks.length > 0 ? threadTasks : tasks;
+    await reply(
+      [
+        `You have ${candidates.length} running tasks. Specify which one to cancel:`,
+        '',
+        ...candidates.map((t) => `• \`${t.taskId}\` — started ${formatTimestamp(t.createdAt)}`),
+        '',
+        'Use the *cancel* command followed by the task ID.',
+      ].join('\n')
+    );
+    return;
+  }
+
+  const accessToken = await userAuthService.getOrchestratorToken(userId, projectId);
+  if (!accessToken) {
+    await reply('🔐 You need to log in first. Use the *login* command.');
+    return;
+  }
+
+  const response = await a2aClientService.cancelTask(task.taskId, accessToken);
+
+  if ('error' in response && response.error) {
+    if (response.error.code === A2A_TASK_NOT_FOUND || response.error.code === A2A_TASK_NOT_CANCELABLE) {
+      // Stale record — the task already reached a terminal state.
+      await inFlightTaskStore.delete(task.taskId).catch(() => {});
+      await reply(`ℹ️ Task \`${task.taskId}\` has already finished — nothing to cancel.`);
+    } else {
+      await reply(`❌ Failed to cancel task \`${task.taskId}\`: ${response.error.message}`);
+    }
+    return;
+  }
+
+  await reply(`🛑 Cancellation requested for task \`${task.taskId}\`. The task will stop shortly.`);
+}
+
+/**
  * Handle "help" command – shows available commands.
  */
 async function handleHelpCommand(
@@ -185,6 +277,7 @@ async function handleHelpCommand(
   const helpText = [
     '🤖 *Nannos Commands*\n',
     '• *login* - Log in to use Nannos services',
+    '• *cancel [task_id]* - Cancel a running task (alias: *stop*)',
     '• *debug* - Show debug info about your session and threads',
     '• *logout* - Log out from Nannos',
     '• *help* - Show this help message',
@@ -208,17 +301,32 @@ export async function handleAppCommand(
   appCommand: AppCommand,
   deps: HandlerDependencies
 ): Promise<void> {
-  const { chatService, contextStore, inFlightTaskStore, userAuthService } = deps;
+  const { chatService, contextStore, inFlightTaskStore, userAuthService, a2aClientService } = deps;
 
   const logger = Logger.getLogger('handleAppCommand');
   logger.info(`App command argument=${appCommand.commandArgument} from user ${appCommand.userId} in space ${appCommand.spaceId}`);
 
-  switch (appCommand.commandArgument) {
+  // Dispatch on the first token so commands can take arguments (e.g. "cancel <task_id>")
+  const [commandName, ...commandArgs] = appCommand.commandArgument.split(/\s+/);
+  const commandArgsText = commandArgs.join(' ');
+
+  switch (commandName) {
     case 'help':
       return handleHelpCommand(appCommand, chatService);
 
     case 'login':
       return handleLoginCommand(appCommand, chatService, userAuthService);
+
+    case 'cancel':
+    case 'stop':
+      return handleCancelCommand(
+        appCommand,
+        commandArgsText,
+        chatService,
+        inFlightTaskStore,
+        userAuthService,
+        a2aClientService
+      );
 
     case 'debug':
       return handleDebugCommand(

--- a/packages/client-google-chat/src/services/a2aClientService.ts
+++ b/packages/client-google-chat/src/services/a2aClientService.ts
@@ -8,6 +8,7 @@ import {
   DataPart,
   FilePart,
   GetTaskResponse,
+  CancelTaskResponse,
   TaskStatusUpdateEvent,
   TaskArtifactUpdateEvent,
 } from '@a2a-js/sdk';
@@ -195,6 +196,31 @@ export class A2AClientService {
     const task = (response as { result: Task }).result;
     const state = task.status?.state || 'working';
     this.logger.debug(`Task status: id=${task.id}, state=${state}, artifacts=${task.artifacts?.length}`);
+    return response;
+  }
+
+  /**
+   * Request cancellation of a running task. This is the same A2A cancel
+   * protocol the web client's stop button uses; the orchestrator propagates
+   * the cancel to sub-agents and emits a terminal `canceled` status event.
+   */
+  async cancelTask(taskId: string, accessToken: string): Promise<CancelTaskResponse> {
+    this.logger.info(`Requesting cancellation of taskId: ${taskId}`);
+
+    // Create client with authenticated fetch
+    const client = await A2AClient.fromCardUrl(this.agentCardUrl, {
+      fetchImpl: createAuthenticatedFetch(accessToken),
+    });
+
+    const response: CancelTaskResponse = await client.cancelTask({ id: taskId });
+
+    if ('error' in response && response.error) {
+      this.logger.warn(`cancelTask error response for ${taskId}: ${response.error.message}`);
+      return response;
+    }
+
+    const task = (response as { result: Task }).result;
+    this.logger.info(`Cancellation accepted: id=${task.id}, state=${task.status?.state}`);
     return response;
   }
 }

--- a/packages/client-google-chat/test/handlers/commandHandlerCancel.test.ts
+++ b/packages/client-google-chat/test/handlers/commandHandlerCancel.test.ts
@@ -1,0 +1,190 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import { handleAppCommand, AppCommand } from '../../src/handlers/commandHandler.js';
+import type { HandlerDependencies } from '../../src/handlers/types.js';
+import type { InFlightTask } from '../../src/storage/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const THREAD = 'spaces/S1/threads/T1';
+
+function makeTask(overrides: Partial<InFlightTask> = {}): InFlightTask {
+  return {
+    taskId: 'task-abc-123',
+    visitorId: 'P1:users/U1',
+    userId: 'users/U1',
+    projectId: 'P1',
+    spaceId: 'spaces/S1',
+    threadId: THREAD,
+    messageId: 'spaces/S1/messages/M1',
+    contextKey: 'P1:spaces/S1:' + THREAD,
+    source: 'space_message',
+    createdAt: 1700000000000,
+    ttl: 1700003600,
+    ...overrides,
+  };
+}
+
+function makeAppCommand(commandArgument: string): AppCommand {
+  return {
+    commandArgument,
+    spaceId: 'spaces/S1',
+    userId: 'users/U1',
+    projectId: 'P1',
+    threadId: THREAD,
+    messageId: 'spaces/S1/messages/M2',
+  };
+}
+
+interface DepsOptions {
+  tasks?: InFlightTask[];
+  token?: string | null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  cancelResponse?: any;
+}
+
+function makeDeps({
+  tasks = [],
+  token = 'orch-token',
+  cancelResponse = { result: { id: 'task-abc-123', status: { state: 'canceled' } } },
+}: DepsOptions = {}) {
+  const sendPrivateTextMessage = jest
+    .fn<(projectId: string, spaceId: string, userId: string, text: string, threadId: string) => Promise<void>>()
+    .mockResolvedValue(undefined);
+  const cancelTask = jest
+    .fn<(taskId: string, accessToken: string) => Promise<unknown>>()
+    .mockResolvedValue(cancelResponse);
+  const deleteTask = jest.fn<(taskId: string) => Promise<void>>().mockResolvedValue(undefined);
+
+  const deps = {
+    chatService: { sendPrivateTextMessage },
+    contextStore: {},
+    inFlightTaskStore: {
+      getByUser: jest.fn<() => Promise<InFlightTask[]>>().mockResolvedValue(tasks),
+      delete: deleteTask,
+    },
+    userAuthService: {
+      getOrchestratorToken: jest.fn<() => Promise<string | null>>().mockResolvedValue(token),
+    },
+    a2aClientService: { cancelTask },
+  } as unknown as HandlerDependencies;
+
+  return { deps, sendPrivateTextMessage, cancelTask, deleteTask };
+}
+
+type SendPrivateTextMessageMock = jest.Mock<
+  (projectId: string, spaceId: string, userId: string, text: string, threadId: string) => Promise<void>
+>;
+
+function lastMessageText(sendPrivateTextMessage: SendPrivateTextMessageMock): string {
+  const call = sendPrivateTextMessage.mock.calls.at(-1);
+  return call ? call[3] : '';
+}
+
+// ---------------------------------------------------------------------------
+// handleAppCommand — cancel
+// ---------------------------------------------------------------------------
+
+describe('handleAppCommand cancel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('responds with info when the user has no running tasks', async () => {
+    const { deps, sendPrivateTextMessage, cancelTask } = makeDeps({ tasks: [] });
+
+    await handleAppCommand(makeAppCommand('cancel'), deps);
+
+    expect(cancelTask).not.toHaveBeenCalled();
+    expect(lastMessageText(sendPrivateTextMessage)).toContain('no running tasks');
+  });
+
+  test('cancels the single task in the current thread and confirms', async () => {
+    const { deps, sendPrivateTextMessage, cancelTask } = makeDeps({ tasks: [makeTask()] });
+
+    await handleAppCommand(makeAppCommand('cancel'), deps);
+
+    expect(cancelTask).toHaveBeenCalledWith('task-abc-123', 'orch-token');
+    expect(lastMessageText(sendPrivateTextMessage)).toContain('Cancellation requested');
+    // Reply goes to the thread the command was issued in
+    expect(sendPrivateTextMessage).toHaveBeenCalledWith('P1', 'spaces/S1', 'users/U1', expect.any(String), THREAD);
+  });
+
+  test('supports the stop alias', async () => {
+    const { deps, cancelTask } = makeDeps({ tasks: [makeTask()] });
+
+    await handleAppCommand(makeAppCommand('stop'), deps);
+
+    expect(cancelTask).toHaveBeenCalledWith('task-abc-123', 'orch-token');
+  });
+
+  test('falls back to the single task outside the thread', async () => {
+    const task = makeTask({ threadId: 'spaces/S1/threads/OTHER' });
+    const { deps, cancelTask } = makeDeps({ tasks: [task] });
+
+    await handleAppCommand(makeAppCommand('cancel'), deps);
+
+    expect(cancelTask).toHaveBeenCalledWith('task-abc-123', 'orch-token');
+  });
+
+  test('lists tasks when multiple candidates and no task ID given', async () => {
+    const tasks = [
+      makeTask({ threadId: 'spaces/S1/threads/A' }),
+      makeTask({ taskId: 'task-def-456', threadId: 'spaces/S1/threads/B' }),
+    ];
+    const { deps, sendPrivateTextMessage, cancelTask } = makeDeps({ tasks });
+
+    await handleAppCommand(makeAppCommand('cancel'), deps);
+
+    expect(cancelTask).not.toHaveBeenCalled();
+    const text = lastMessageText(sendPrivateTextMessage);
+    expect(text).toContain('task-abc-123');
+    expect(text).toContain('task-def-456');
+  });
+
+  test('cancels the task matching a task ID argument', async () => {
+    const tasks = [makeTask(), makeTask({ taskId: 'task-def-456', threadId: 'spaces/S1/threads/B' })];
+    const { deps, cancelTask } = makeDeps({
+      tasks,
+      cancelResponse: { result: { id: 'task-def-456', status: { state: 'canceled' } } },
+    });
+
+    await handleAppCommand(makeAppCommand('cancel task-def-456'), deps);
+
+    expect(cancelTask).toHaveBeenCalledWith('task-def-456', 'orch-token');
+  });
+
+  test('prompts login when the user has no orchestrator token', async () => {
+    const { deps, sendPrivateTextMessage, cancelTask } = makeDeps({ tasks: [makeTask()], token: null });
+
+    await handleAppCommand(makeAppCommand('cancel'), deps);
+
+    expect(cancelTask).not.toHaveBeenCalled();
+    expect(lastMessageText(sendPrivateTextMessage)).toContain('log in');
+  });
+
+  test('deletes the stale record when the task is no longer cancelable', async () => {
+    const { deps, sendPrivateTextMessage, deleteTask } = makeDeps({
+      tasks: [makeTask()],
+      cancelResponse: { error: { code: -32002, message: 'Task cannot be canceled' } },
+    });
+
+    await handleAppCommand(makeAppCommand('cancel'), deps);
+
+    expect(deleteTask).toHaveBeenCalledWith('task-abc-123');
+    expect(lastMessageText(sendPrivateTextMessage)).toContain('already finished');
+  });
+
+  test('reports other cancel errors without deleting the record', async () => {
+    const { deps, sendPrivateTextMessage, deleteTask } = makeDeps({
+      tasks: [makeTask()],
+      cancelResponse: { error: { code: -32603, message: 'Internal error' } },
+    });
+
+    await handleAppCommand(makeAppCommand('cancel'), deps);
+
+    expect(deleteTask).not.toHaveBeenCalled();
+    expect(lastMessageText(sendPrivateTextMessage)).toContain('Failed to cancel');
+  });
+});

--- a/packages/client-google-chat/test/handlers/commandHandlerCancel.test.ts
+++ b/packages/client-google-chat/test/handlers/commandHandlerCancel.test.ts
@@ -97,10 +97,10 @@ describe('handleAppCommand cancel', () => {
     await handleAppCommand(makeAppCommand('cancel'), deps);
 
     expect(cancelTask).not.toHaveBeenCalled();
-    expect(lastMessageText(sendPrivateTextMessage)).toContain('no running tasks');
+    expect(lastMessageText(sendPrivateTextMessage)).toContain('no running tasks in this thread');
   });
 
-  test('cancels the single task in the current thread and confirms', async () => {
+  test('cancels the running task in the current thread and confirms', async () => {
     const { deps, sendPrivateTextMessage, cancelTask } = makeDeps({ tasks: [makeTask()] });
 
     await handleAppCommand(makeAppCommand('cancel'), deps);
@@ -119,40 +119,24 @@ describe('handleAppCommand cancel', () => {
     expect(cancelTask).toHaveBeenCalledWith('task-abc-123', 'orch-token');
   });
 
-  test('falls back to the single task outside the thread', async () => {
-    const task = makeTask({ threadId: 'spaces/S1/threads/OTHER' });
-    const { deps, cancelTask } = makeDeps({ tasks: [task] });
+  test('only cancels tasks in the current thread', async () => {
+    const tasks = [makeTask(), makeTask({ taskId: 'task-other-thread', threadId: 'spaces/S1/threads/OTHER' })];
+    const { deps, cancelTask } = makeDeps({ tasks });
 
     await handleAppCommand(makeAppCommand('cancel'), deps);
 
+    expect(cancelTask).toHaveBeenCalledTimes(1);
     expect(cancelTask).toHaveBeenCalledWith('task-abc-123', 'orch-token');
   });
 
-  test('lists tasks when multiple candidates and no task ID given', async () => {
-    const tasks = [
-      makeTask({ threadId: 'spaces/S1/threads/A' }),
-      makeTask({ taskId: 'task-def-456', threadId: 'spaces/S1/threads/B' }),
-    ];
+  test('points the user at other threads when nothing runs here', async () => {
+    const tasks = [makeTask({ threadId: 'spaces/S1/threads/OTHER' })];
     const { deps, sendPrivateTextMessage, cancelTask } = makeDeps({ tasks });
 
     await handleAppCommand(makeAppCommand('cancel'), deps);
 
     expect(cancelTask).not.toHaveBeenCalled();
-    const text = lastMessageText(sendPrivateTextMessage);
-    expect(text).toContain('task-abc-123');
-    expect(text).toContain('task-def-456');
-  });
-
-  test('cancels the task matching a task ID argument', async () => {
-    const tasks = [makeTask(), makeTask({ taskId: 'task-def-456', threadId: 'spaces/S1/threads/B' })];
-    const { deps, cancelTask } = makeDeps({
-      tasks,
-      cancelResponse: { result: { id: 'task-def-456', status: { state: 'canceled' } } },
-    });
-
-    await handleAppCommand(makeAppCommand('cancel task-def-456'), deps);
-
-    expect(cancelTask).toHaveBeenCalledWith('task-def-456', 'orch-token');
+    expect(lastMessageText(sendPrivateTextMessage)).toContain('other threads');
   });
 
   test('prompts login when the user has no orchestrator token', async () => {

--- a/packages/client-slack/src/listeners/commands/nannos.ts
+++ b/packages/client-slack/src/listeners/commands/nannos.ts
@@ -252,65 +252,38 @@ async function handleDebugSubcommand(
 }
 
 /**
- * Handle /bot cancel subcommand — aborts a running task via the same A2A
+ * Handle /bot cancel subcommand — aborts running tasks via the same A2A
  * cancel protocol the web client's stop button uses.
  *
- * Slash commands don't carry thread context, so the task is resolved from the
- * user's in-flight tasks: a single task is cancelled directly, multiple tasks
- * require the task ID (shown in the list) as an argument.
+ * Task IDs are internal to the system, so the tasks to cancel are resolved
+ * from where the command is issued: the user's running tasks in the current
+ * channel (there is almost always exactly one). Slash command payloads carry
+ * no thread_ts, so channel scope is the finest granularity available.
  */
 export async function handleCancelSubcommand(
   { command, respond }: NannosCommand,
   userAuthService: UserAuthService,
   a2aClientService: A2AClientService,
-  inFlightTaskStore: IInFlightTaskStore,
-  args: string
+  inFlightTaskStore: IInFlightTaskStore
 ): Promise<void> {
   const logger = Logger.getLogger('handleCancelSubcommand');
   const userId = command.user_id;
   const teamId = command.team_id;
+  const channelId = command.channel_id;
 
-  logger.info(`${command.command} cancel from user ${userId} in team ${teamId}`);
+  logger.info(`${command.command} cancel from user ${userId} in channel ${channelId}`);
 
   const tasks = await inFlightTaskStore.getByUser(teamId, userId);
+  const targets: InFlightTask[] = tasks.filter((t) => t.channelId === channelId);
 
-  if (tasks.length === 0) {
+  if (targets.length === 0) {
+    const elsewhere =
+      tasks.length > 0
+        ? ` You have ${tasks.length} running task(s) in other channels — run \`${command.command} cancel\` there to cancel them.`
+        : '';
     await respond({
       response_type: 'ephemeral',
-      text: 'ℹ️ You have no running tasks to cancel.',
-    });
-    return;
-  }
-
-  const requestedTaskId = args.trim();
-  let task: InFlightTask | undefined;
-
-  if (requestedTaskId) {
-    task = tasks.find((t) => t.taskId === requestedTaskId || t.taskId.startsWith(requestedTaskId));
-    if (!task) {
-      await respond({
-        response_type: 'ephemeral',
-        text: [
-          `❓ No running task matches \`${requestedTaskId}\`.`,
-          '',
-          '*Your running tasks:*',
-          ...tasks.map((t) => `• \`${t.taskId}\` — started ${formatTimestamp(t.createdAt)} in <#${t.channelId}>`),
-        ].join('\n'),
-      });
-      return;
-    }
-  } else if (tasks.length === 1) {
-    task = tasks[0];
-  } else {
-    await respond({
-      response_type: 'ephemeral',
-      text: [
-        `You have ${tasks.length} running tasks. Specify which one to cancel:`,
-        '',
-        ...tasks.map((t) => `• \`${t.taskId}\` — started ${formatTimestamp(t.createdAt)} in <#${t.channelId}>`),
-        '',
-        `Run \`${command.command} cancel <task_id>\``,
-      ].join('\n'),
+      text: `ℹ️ You have no running tasks in this channel.${elsewhere}`,
     });
     return;
   }
@@ -324,28 +297,44 @@ export async function handleCancelSubcommand(
     return;
   }
 
-  const response = await a2aClientService.cancelTask(task.taskId, accessToken);
+  let cancelled = 0;
+  let alreadyFinished = 0;
+  const failures: string[] = [];
 
-  if ('error' in response && response.error) {
-    if (response.error.code === A2A_TASK_NOT_FOUND || response.error.code === A2A_TASK_NOT_CANCELABLE) {
-      // Stale record — the task already reached a terminal state.
-      await inFlightTaskStore.delete(task.taskId).catch(() => {});
-      await respond({
-        response_type: 'ephemeral',
-        text: `ℹ️ Task \`${task.taskId}\` has already finished — nothing to cancel.`,
-      });
+  for (const task of targets) {
+    const response = await a2aClientService.cancelTask(task.taskId, accessToken);
+
+    if ('error' in response && response.error) {
+      if (response.error.code === A2A_TASK_NOT_FOUND || response.error.code === A2A_TASK_NOT_CANCELABLE) {
+        // Stale record — the task already reached a terminal state.
+        await inFlightTaskStore.delete(task.taskId).catch(() => {});
+        alreadyFinished++;
+      } else {
+        failures.push(response.error.message);
+      }
     } else {
-      await respond({
-        response_type: 'ephemeral',
-        text: `❌ Failed to cancel task \`${task.taskId}\`: ${response.error.message}`,
-      });
+      cancelled++;
     }
-    return;
+  }
+
+  const lines: string[] = [];
+  if (cancelled > 0) {
+    lines.push(
+      cancelled === 1
+        ? '🛑 Cancellation requested — the task will stop shortly.'
+        : `🛑 Cancellation requested for ${cancelled} running tasks — they will stop shortly.`
+    );
+  }
+  if (alreadyFinished > 0) {
+    lines.push(`ℹ️ ${alreadyFinished} task(s) had already finished — nothing to cancel.`);
+  }
+  for (const failure of failures) {
+    lines.push(`❌ Failed to cancel a task: ${failure}`);
   }
 
   await respond({
     response_type: 'ephemeral',
-    text: `🛑 Cancellation requested for task \`${task.taskId}\`. The task will stop shortly.`,
+    text: lines.join('\n'),
   });
 }
 
@@ -357,7 +346,7 @@ async function handleHelpSubcommand({ command, respond }: NannosCommand, botName
   const helpText = [
     `🤖 *${botName} Commands*\n`,
     `\`${cmd} login\` - Log in to use ${botName} services`,
-    `\`${cmd} cancel [task_id]\` - Cancel a running task (alias: \`stop\`)`,
+    `\`${cmd} cancel\` - Cancel your running task in this channel (alias: \`stop\`)`,
     `\`${cmd} debug [thread_ts]\` - Show debug info about your session and threads`,
     `\`${cmd} help\` - Show this help message`,
   ].join('\n');
@@ -401,7 +390,7 @@ async function handleNannosCommand(
 
       case 'cancel':
       case 'stop':
-        await handleCancelSubcommand(args, userAuthService, a2aClientService, inFlightTaskStore, subArgsText);
+        await handleCancelSubcommand(args, userAuthService, a2aClientService, inFlightTaskStore);
         break;
 
       case 'debug':

--- a/packages/client-slack/src/listeners/commands/nannos.ts
+++ b/packages/client-slack/src/listeners/commands/nannos.ts
@@ -1,7 +1,19 @@
 import { App, SlackCommandMiddlewareArgs, AllMiddlewareArgs } from '@slack/bolt';
 import { UserAuthService } from '../../services/userAuthService.js';
-import type { IContextStore, IInFlightTaskStore, IPendingRequestStore, IOAuthStateStore } from '../../storage/types.js';
+import { A2AClientService } from '../../services/a2aClientService.js';
+import type {
+  IContextStore,
+  IInFlightTaskStore,
+  IPendingRequestStore,
+  IOAuthStateStore,
+  InFlightTask,
+} from '../../storage/types.js';
 import { Logger } from '../../utils/logger.js';
+
+// A2A JSON-RPC error codes signalling the task is already terminal (or gone),
+// i.e. the stored in-flight record is stale and can be dropped.
+const A2A_TASK_NOT_FOUND = -32001;
+const A2A_TASK_NOT_CANCELABLE = -32002;
 
 type NannosCommand = SlackCommandMiddlewareArgs & AllMiddlewareArgs;
 
@@ -240,6 +252,104 @@ async function handleDebugSubcommand(
 }
 
 /**
+ * Handle /bot cancel subcommand — aborts a running task via the same A2A
+ * cancel protocol the web client's stop button uses.
+ *
+ * Slash commands don't carry thread context, so the task is resolved from the
+ * user's in-flight tasks: a single task is cancelled directly, multiple tasks
+ * require the task ID (shown in the list) as an argument.
+ */
+export async function handleCancelSubcommand(
+  { command, respond }: NannosCommand,
+  userAuthService: UserAuthService,
+  a2aClientService: A2AClientService,
+  inFlightTaskStore: IInFlightTaskStore,
+  args: string
+): Promise<void> {
+  const logger = Logger.getLogger('handleCancelSubcommand');
+  const userId = command.user_id;
+  const teamId = command.team_id;
+
+  logger.info(`${command.command} cancel from user ${userId} in team ${teamId}`);
+
+  const tasks = await inFlightTaskStore.getByUser(teamId, userId);
+
+  if (tasks.length === 0) {
+    await respond({
+      response_type: 'ephemeral',
+      text: 'ℹ️ You have no running tasks to cancel.',
+    });
+    return;
+  }
+
+  const requestedTaskId = args.trim();
+  let task: InFlightTask | undefined;
+
+  if (requestedTaskId) {
+    task = tasks.find((t) => t.taskId === requestedTaskId || t.taskId.startsWith(requestedTaskId));
+    if (!task) {
+      await respond({
+        response_type: 'ephemeral',
+        text: [
+          `❓ No running task matches \`${requestedTaskId}\`.`,
+          '',
+          '*Your running tasks:*',
+          ...tasks.map((t) => `• \`${t.taskId}\` — started ${formatTimestamp(t.createdAt)} in <#${t.channelId}>`),
+        ].join('\n'),
+      });
+      return;
+    }
+  } else if (tasks.length === 1) {
+    task = tasks[0];
+  } else {
+    await respond({
+      response_type: 'ephemeral',
+      text: [
+        `You have ${tasks.length} running tasks. Specify which one to cancel:`,
+        '',
+        ...tasks.map((t) => `• \`${t.taskId}\` — started ${formatTimestamp(t.createdAt)} in <#${t.channelId}>`),
+        '',
+        `Run \`${command.command} cancel <task_id>\``,
+      ].join('\n'),
+    });
+    return;
+  }
+
+  const accessToken = await userAuthService.getOrchestratorToken(userId, teamId);
+  if (!accessToken) {
+    await respond({
+      response_type: 'ephemeral',
+      text: `🔐 You need to log in first. Use \`${command.command} login\`.`,
+    });
+    return;
+  }
+
+  const response = await a2aClientService.cancelTask(task.taskId, accessToken);
+
+  if ('error' in response && response.error) {
+    if (response.error.code === A2A_TASK_NOT_FOUND || response.error.code === A2A_TASK_NOT_CANCELABLE) {
+      // Stale record — the task already reached a terminal state.
+      await inFlightTaskStore.delete(task.taskId).catch(() => {});
+      await respond({
+        response_type: 'ephemeral',
+        text: `ℹ️ Task \`${task.taskId}\` has already finished — nothing to cancel.`,
+      });
+    } else {
+      await respond({
+        response_type: 'ephemeral',
+        text: `❌ Failed to cancel task \`${task.taskId}\`: ${response.error.message}`,
+      });
+    }
+    return;
+  }
+
+  await respond({
+    response_type: 'ephemeral',
+    text: `🛑 Cancellation requested for task \`${task.taskId}\`. The task will stop shortly.`,
+  });
+}
+
+/**
  * Show help for the bot command
  */
 async function handleHelpSubcommand({ command, respond }: NannosCommand, botName: string): Promise<void> {
@@ -247,6 +357,7 @@ async function handleHelpSubcommand({ command, respond }: NannosCommand, botName
   const helpText = [
     `🤖 *${botName} Commands*\n`,
     `\`${cmd} login\` - Log in to use ${botName} services`,
+    `\`${cmd} cancel [task_id]\` - Cancel a running task (alias: \`stop\`)`,
     `\`${cmd} debug [thread_ts]\` - Show debug info about your session and threads`,
     `\`${cmd} help\` - Show this help message`,
   ].join('\n');
@@ -264,6 +375,7 @@ async function handleHelpSubcommand({ command, respond }: NannosCommand, botName
 async function handleNannosCommand(
   args: NannosCommand,
   userAuthService: UserAuthService,
+  a2aClientService: A2AClientService,
   contextStore: IContextStore,
   inFlightTaskStore: IInFlightTaskStore,
   pendingRequestStore: IPendingRequestStore,
@@ -285,6 +397,11 @@ async function handleNannosCommand(
     switch (subcommand.toLowerCase()) {
       case 'login':
         await handleLoginSubcommand(args, userAuthService, botName);
+        break;
+
+      case 'cancel':
+      case 'stop':
+        await handleCancelSubcommand(args, userAuthService, a2aClientService, inFlightTaskStore, subArgsText);
         break;
 
       case 'debug':
@@ -330,6 +447,7 @@ export function registerNannosCommand(
   app: App,
   slashCommand: string,
   userAuthService: UserAuthService,
+  a2aClientService: A2AClientService,
   contextStore: IContextStore,
   inFlightTaskStore: IInFlightTaskStore,
   pendingRequestStore: IPendingRequestStore,
@@ -340,6 +458,14 @@ export function registerNannosCommand(
 
   app.command(slashCommand, async (args) => {
     const botName = ((args.context as any).botName as string | undefined) ?? 'Bot';
-    await handleNannosCommand(args, userAuthService, contextStore, inFlightTaskStore, pendingRequestStore, botName);
+    await handleNannosCommand(
+      args,
+      userAuthService,
+      a2aClientService,
+      contextStore,
+      inFlightTaskStore,
+      pendingRequestStore,
+      botName
+    );
   });
 }

--- a/packages/client-slack/src/listeners/index.ts
+++ b/packages/client-slack/src/listeners/index.ts
@@ -82,6 +82,7 @@ export async function registerListeners(
       app,
       bot.slashCommand,
       userAuthService,
+      a2aClientService,
       contextStore,
       inFlightTaskStore,
       pendingRequestStore,

--- a/packages/client-slack/src/services/a2aClientService.ts
+++ b/packages/client-slack/src/services/a2aClientService.ts
@@ -8,6 +8,7 @@ import {
   DataPart,
   FilePart,
   GetTaskResponse,
+  CancelTaskResponse,
   TaskStatusUpdateEvent,
   TaskArtifactUpdateEvent,
 } from '@a2a-js/sdk';
@@ -240,6 +241,31 @@ export class A2AClientService {
     const task = (response as { result: Task }).result;
     const state = task.status?.state || 'working';
     this.logger.debug(`Task status: id=${task.id}, state=${state}, artifacts=${task.artifacts?.length}`);
+    return response;
+  }
+
+  /**
+   * Request cancellation of a running task. This is the same A2A cancel
+   * protocol the web client's stop button uses; the orchestrator propagates
+   * the cancel to sub-agents and emits a terminal `canceled` status event.
+   */
+  async cancelTask(taskId: string, accessToken: string): Promise<CancelTaskResponse> {
+    this.logger.info(`Requesting cancellation of taskId: ${taskId}`);
+
+    // Create client with authenticated fetch
+    const client = await A2AClient.fromCardUrl(this.agentCardUrl, {
+      fetchImpl: createAuthenticatedFetch(accessToken),
+    });
+
+    const response: CancelTaskResponse = await client.cancelTask({ id: taskId });
+
+    if ('error' in response && response.error) {
+      this.logger.warn(`cancelTask error response for ${taskId}: ${response.error.message}`);
+      return response;
+    }
+
+    const task = (response as { result: Task }).result;
+    this.logger.info(`Cancellation accepted: id=${task.id}, state=${task.status?.state}`);
     return response;
   }
 }

--- a/packages/client-slack/test/listeners/nannosCancel.test.ts
+++ b/packages/client-slack/test/listeners/nannosCancel.test.ts
@@ -1,0 +1,150 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+import { handleCancelSubcommand } from '../../src/listeners/commands/nannos.js';
+import { UserAuthService } from '../../src/services/userAuthService.js';
+import { A2AClientService } from '../../src/services/a2aClientService.js';
+import type { IInFlightTaskStore, InFlightTask } from '../../src/storage/types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTask(overrides: Partial<InFlightTask> = {}): InFlightTask {
+  return {
+    taskId: 'task-abc-123',
+    visitorId: 'T1:U1',
+    userId: 'U1',
+    teamId: 'T1',
+    channelId: 'C1',
+    threadTs: '1700000000.000100',
+    messageTs: '1700000000.000100',
+    contextKey: 'T1:C1:1700000000.000100',
+    source: 'app_mention',
+    createdAt: 1700000000000,
+    ttl: 1700003600,
+    ...overrides,
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeArgs(respond: jest.Mock): any {
+  return {
+    command: { command: '/nannos', user_id: 'U1', team_id: 'T1', channel_id: 'C1', text: 'cancel' },
+    respond,
+  };
+}
+
+function makeStore(tasks: InFlightTask[]) {
+  return {
+    getByUser: jest.fn<() => Promise<InFlightTask[]>>().mockResolvedValue(tasks),
+    delete: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  } as unknown as IInFlightTaskStore;
+}
+
+function makeAuth(token: string | null = 'orch-token') {
+  return {
+    getOrchestratorToken: jest.fn<() => Promise<string | null>>().mockResolvedValue(token),
+  } as unknown as UserAuthService;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeA2A(response: any = { result: { id: 'task-abc-123', status: { state: 'canceled' } } }) {
+  return {
+    cancelTask: jest.fn<() => Promise<unknown>>().mockResolvedValue(response),
+  } as unknown as A2AClientService;
+}
+
+// ---------------------------------------------------------------------------
+// handleCancelSubcommand
+// ---------------------------------------------------------------------------
+
+describe('handleCancelSubcommand', () => {
+  let respond: jest.Mock;
+
+  beforeEach(() => {
+    respond = jest.fn<() => Promise<void>>().mockResolvedValue(undefined) as jest.Mock;
+  });
+
+  test('responds with info when the user has no running tasks', async () => {
+    const a2a = makeA2A();
+
+    await handleCancelSubcommand(makeArgs(respond), makeAuth(), a2a, makeStore([]), '');
+
+    expect(respond).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('no running tasks') }));
+    expect(a2a.cancelTask).not.toHaveBeenCalled();
+  });
+
+  test('cancels the single running task and confirms', async () => {
+    const a2a = makeA2A();
+    const store = makeStore([makeTask()]);
+
+    await handleCancelSubcommand(makeArgs(respond), makeAuth(), a2a, store, '');
+
+    expect(a2a.cancelTask).toHaveBeenCalledWith('task-abc-123', 'orch-token');
+    expect(respond).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining('Cancellation requested') })
+    );
+  });
+
+  test('lists tasks and does not cancel when multiple tasks and no task ID given', async () => {
+    const a2a = makeA2A();
+    const store = makeStore([makeTask(), makeTask({ taskId: 'task-def-456', threadTs: '1700000100.000200' })]);
+
+    await handleCancelSubcommand(makeArgs(respond), makeAuth(), a2a, store, '');
+
+    expect(a2a.cancelTask).not.toHaveBeenCalled();
+    const text = (respond.mock.calls[0][0] as { text: string }).text;
+    expect(text).toContain('task-abc-123');
+    expect(text).toContain('task-def-456');
+    expect(text).toContain('cancel <task_id>');
+  });
+
+  test('cancels the task matching a task ID prefix argument', async () => {
+    const a2a = makeA2A({ result: { id: 'task-def-456', status: { state: 'canceled' } } });
+    const store = makeStore([makeTask(), makeTask({ taskId: 'task-def-456' })]);
+
+    await handleCancelSubcommand(makeArgs(respond), makeAuth(), a2a, store, 'task-def');
+
+    expect(a2a.cancelTask).toHaveBeenCalledWith('task-def-456', 'orch-token');
+  });
+
+  test('responds with not-found when the task ID argument matches nothing', async () => {
+    const a2a = makeA2A();
+    const store = makeStore([makeTask()]);
+
+    await handleCancelSubcommand(makeArgs(respond), makeAuth(), a2a, store, 'nope');
+
+    expect(a2a.cancelTask).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining('No running task matches') })
+    );
+  });
+
+  test('prompts login when the user has no orchestrator token', async () => {
+    const a2a = makeA2A();
+
+    await handleCancelSubcommand(makeArgs(respond), makeAuth(null), a2a, makeStore([makeTask()]), '');
+
+    expect(a2a.cancelTask).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('log in') }));
+  });
+
+  test('deletes the stale record when the task is no longer cancelable', async () => {
+    const a2a = makeA2A({ error: { code: -32002, message: 'Task cannot be canceled' } });
+    const store = makeStore([makeTask()]);
+
+    await handleCancelSubcommand(makeArgs(respond), makeAuth(), a2a, store, '');
+
+    expect(store.delete).toHaveBeenCalledWith('task-abc-123');
+    expect(respond).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('already finished') }));
+  });
+
+  test('reports other cancel errors without deleting the record', async () => {
+    const a2a = makeA2A({ error: { code: -32603, message: 'Internal error' } });
+    const store = makeStore([makeTask()]);
+
+    await handleCancelSubcommand(makeArgs(respond), makeAuth(), a2a, store, '');
+
+    expect(store.delete).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Failed to cancel') }));
+  });
+});

--- a/packages/client-slack/test/listeners/nannosCancel.test.ts
+++ b/packages/client-slack/test/listeners/nannosCancel.test.ts
@@ -53,6 +53,11 @@ function makeA2A(response: any = { result: { id: 'task-abc-123', status: { state
   } as unknown as A2AClientService;
 }
 
+function respondedText(respond: jest.Mock): string {
+  const call = respond.mock.calls.at(-1);
+  return call ? (call[0] as { text: string }).text : '';
+}
+
 // ---------------------------------------------------------------------------
 // handleCancelSubcommand
 // ---------------------------------------------------------------------------
@@ -67,84 +72,78 @@ describe('handleCancelSubcommand', () => {
   test('responds with info when the user has no running tasks', async () => {
     const a2a = makeA2A();
 
-    await handleCancelSubcommand(makeArgs(respond), makeAuth(), a2a, makeStore([]), '');
+    await handleCancelSubcommand(makeArgs(respond), makeAuth(), a2a, makeStore([]));
 
-    expect(respond).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('no running tasks') }));
     expect(a2a.cancelTask).not.toHaveBeenCalled();
+    expect(respondedText(respond)).toContain('no running tasks in this channel');
   });
 
-  test('cancels the single running task and confirms', async () => {
+  test('cancels the running task in the current channel and confirms', async () => {
     const a2a = makeA2A();
     const store = makeStore([makeTask()]);
 
-    await handleCancelSubcommand(makeArgs(respond), makeAuth(), a2a, store, '');
+    await handleCancelSubcommand(makeArgs(respond), makeAuth(), a2a, store);
 
     expect(a2a.cancelTask).toHaveBeenCalledWith('task-abc-123', 'orch-token');
-    expect(respond).toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringContaining('Cancellation requested') })
-    );
+    expect(respondedText(respond)).toContain('Cancellation requested');
   });
 
-  test('lists tasks and does not cancel when multiple tasks and no task ID given', async () => {
+  test('only cancels tasks in the current channel', async () => {
+    const a2a = makeA2A();
+    const store = makeStore([makeTask(), makeTask({ taskId: 'task-other-channel', channelId: 'C2' })]);
+
+    await handleCancelSubcommand(makeArgs(respond), makeAuth(), a2a, store);
+
+    expect(a2a.cancelTask).toHaveBeenCalledTimes(1);
+    expect(a2a.cancelTask).toHaveBeenCalledWith('task-abc-123', 'orch-token');
+  });
+
+  test('cancels multiple running tasks in the current channel', async () => {
     const a2a = makeA2A();
     const store = makeStore([makeTask(), makeTask({ taskId: 'task-def-456', threadTs: '1700000100.000200' })]);
 
-    await handleCancelSubcommand(makeArgs(respond), makeAuth(), a2a, store, '');
+    await handleCancelSubcommand(makeArgs(respond), makeAuth(), a2a, store);
 
-    expect(a2a.cancelTask).not.toHaveBeenCalled();
-    const text = (respond.mock.calls[0][0] as { text: string }).text;
-    expect(text).toContain('task-abc-123');
-    expect(text).toContain('task-def-456');
-    expect(text).toContain('cancel <task_id>');
+    expect(a2a.cancelTask).toHaveBeenCalledTimes(2);
+    expect(respondedText(respond)).toContain('2 running tasks');
   });
 
-  test('cancels the task matching a task ID prefix argument', async () => {
-    const a2a = makeA2A({ result: { id: 'task-def-456', status: { state: 'canceled' } } });
-    const store = makeStore([makeTask(), makeTask({ taskId: 'task-def-456' })]);
-
-    await handleCancelSubcommand(makeArgs(respond), makeAuth(), a2a, store, 'task-def');
-
-    expect(a2a.cancelTask).toHaveBeenCalledWith('task-def-456', 'orch-token');
-  });
-
-  test('responds with not-found when the task ID argument matches nothing', async () => {
+  test('points the user at other channels when nothing runs here', async () => {
     const a2a = makeA2A();
-    const store = makeStore([makeTask()]);
+    const store = makeStore([makeTask({ channelId: 'C2' })]);
 
-    await handleCancelSubcommand(makeArgs(respond), makeAuth(), a2a, store, 'nope');
+    await handleCancelSubcommand(makeArgs(respond), makeAuth(), a2a, store);
 
     expect(a2a.cancelTask).not.toHaveBeenCalled();
-    expect(respond).toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringContaining('No running task matches') })
-    );
+    expect(respondedText(respond)).toContain('other channels');
   });
 
   test('prompts login when the user has no orchestrator token', async () => {
     const a2a = makeA2A();
 
-    await handleCancelSubcommand(makeArgs(respond), makeAuth(null), a2a, makeStore([makeTask()]), '');
+    await handleCancelSubcommand(makeArgs(respond), makeAuth(null), a2a, makeStore([makeTask()]));
 
     expect(a2a.cancelTask).not.toHaveBeenCalled();
-    expect(respond).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('log in') }));
+    expect(respondedText(respond)).toContain('log in');
   });
 
   test('deletes the stale record when the task is no longer cancelable', async () => {
     const a2a = makeA2A({ error: { code: -32002, message: 'Task cannot be canceled' } });
     const store = makeStore([makeTask()]);
 
-    await handleCancelSubcommand(makeArgs(respond), makeAuth(), a2a, store, '');
+    await handleCancelSubcommand(makeArgs(respond), makeAuth(), a2a, store);
 
     expect(store.delete).toHaveBeenCalledWith('task-abc-123');
-    expect(respond).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('already finished') }));
+    expect(respondedText(respond)).toContain('already finished');
   });
 
   test('reports other cancel errors without deleting the record', async () => {
     const a2a = makeA2A({ error: { code: -32603, message: 'Internal error' } });
     const store = makeStore([makeTask()]);
 
-    await handleCancelSubcommand(makeArgs(respond), makeAuth(), a2a, store, '');
+    await handleCancelSubcommand(makeArgs(respond), makeAuth(), a2a, store);
 
     expect(store.delete).not.toHaveBeenCalled();
-    expect(respond).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Failed to cancel') }));
+    expect(respondedText(respond)).toContain('Failed to cancel');
   });
 });


### PR DESCRIPTION
Closes https://github.com/alloy-ch/rcplus-alloy-infrastructure-agents/issues/224

## Checklist
- [x] I have performed a self-review of my code
- [x] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨

## What

Adds a `cancel` command (alias: `stop`) to both chat clients, giving them parity with the web client's stop button:

- **Slack**: `/nannos cancel` — new subcommand in the existing slash-command dispatcher.
- **Google Chat**: `cancel` app command — the command dispatcher now matches on the first token of `argumentText` so trailing text doesn't break matching.

Task IDs are internal and unknown to users, so the command takes no arguments. It cancels the user's running task(s) where it is issued: the current **thread** in Google Chat, the current **channel** in Slack (slash command payloads carry no `thread_ts`, so channel scope is the finest granularity available). Tasks running elsewhere are left alone and the reply points the user to where they can cancel them.

## How

- Both `A2AClientService`s gain a `cancelTask(taskId, accessToken)` method that calls the standard A2A `tasks/cancel` JSON-RPC method — the same protocol the console backend uses for the web stop button, so the orchestrator's existing `on_cancel_task` propagation (sub-agent cancels + terminal `canceled` status event) is reused unchanged.
- The tasks to cancel are resolved from the in-flight task store, filtered to the current thread (Google Chat) or channel (Slack).
- Auth uses the existing per-user orchestrator token exchange (`getOrchestratorToken`); unauthenticated users get a login prompt.
- If the orchestrator replies with `TaskNotFoundError`/`TaskNotCancelableError` (-32001/-32002), the stale in-flight record is deleted and the user is told the task already finished. On success the in-flight record is left alone — the active stream handler (or the recovery loop) observes the terminal `canceled` state and cleans up, exactly as it does for any other terminal state.

## Tests

- `packages/client-slack/test/listeners/nannosCancel.test.ts` (8 tests)
- `packages/client-google-chat/test/handlers/commandHandlerCancel.test.ts` (8 tests)

Both packages: `tsc --noEmit` clean, full jest suites green (slack 58, google-chat 25). `npm run lint` fails in both packages due to the missing private `@alloy-ch/eslint-config-alloy` package — pre-existing, reproduces on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)