### PR TITLE
feat(console-frontend): add copy prompt/response and export conversation

### DIFF
--- a/packages/console-frontend/src/components/chat/ChatApp.tsx
+++ b/packages/console-frontend/src/components/chat/ChatApp.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useEffect } from 'react';
-import { Settings, PanelRightOpen, ExternalLink } from 'lucide-react';
+import { Settings, PanelRightOpen, ExternalLink, Download } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { config } from '@/config';
 import { useAuth } from '@/contexts/AuthContext';
@@ -17,16 +17,24 @@ import {
 } from './components';
 import { WorkingBlock } from './components/WorkingBlock';
 import { InterruptConfirmCard } from './components/InterruptConfirmCard';
+import { downloadTextFile, formatConversationAsText, slugifyFilename } from './utils';
 
 export function ChatApp() {
   const { isAdmin } = useAuth();
   const { agentInfo } = useSocket();
-  const { messages, activeConversationId, liveWorkingSteps, isWaiting } = useChat();
+  const { messages, conversations, activeConversationId, liveWorkingSteps, isWaiting } = useChat();
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isTaskPanelCollapsed, setIsTaskPanelCollapsed] = useState(true);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
 
   const agentName = agentInfo?.name || agentInfo?.title || 'A2A Assistant';
+
+  const handleExportConversation = () => {
+    const activeConversation = conversations.find((c) => c.id === activeConversationId);
+    const title = activeConversation?.title || agentName;
+    const text = formatConversationAsText(title, messages);
+    downloadTextFile(`${slugifyFilename(title)}.txt`, text);
+  };
 
   // Auto-scroll to bottom when messages change or new content is generated
   useEffect(() => {
@@ -81,6 +89,25 @@ export function ChatApp() {
             <ConnectionStatus />
             {activeConversationId && (
               <>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7"
+                        onClick={handleExportConversation}
+                        data-testid="button-export-conversation"
+                        aria-label="Export conversation"
+                      >
+                        <Download className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Export conversation</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger asChild>

--- a/packages/console-frontend/src/components/chat/ChatApp.tsx
+++ b/packages/console-frontend/src/components/chat/ChatApp.tsx
@@ -19,6 +19,10 @@ import { WorkingBlock } from './components/WorkingBlock';
 import { InterruptConfirmCard } from './components/InterruptConfirmCard';
 import { downloadTextFile, formatConversationAsText, slugifyFilename } from './utils';
 
+// Matches the backend's hard cap in message_router.py (limit is validated to <= 100,
+// no offset/cursor pagination) — the console never loads more than this per conversation.
+const MESSAGE_FETCH_LIMIT = 100;
+
 export function ChatApp() {
   const { isAdmin } = useAuth();
   const { agentInfo } = useSocket();
@@ -32,7 +36,7 @@ export function ChatApp() {
   const handleExportConversation = () => {
     const activeConversation = conversations.find((c) => c.id === activeConversationId);
     const title = activeConversation?.title || agentName;
-    const text = formatConversationAsText(title, messages);
+    const text = formatConversationAsText(title, messages, messages.length >= MESSAGE_FETCH_LIMIT);
     downloadTextFile(`${slugifyFilename(title)}.txt`, text);
   };
 

--- a/packages/console-frontend/src/components/chat/components/MessageFeedback.tsx
+++ b/packages/console-frontend/src/components/chat/components/MessageFeedback.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ThumbsUp, ThumbsDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import {
   submitFeedbackApiV1ConversationsConversationIdMessagesMessageIdFeedbackPostMutation,
   deleteFeedbackApiV1ConversationsConversationIdMessagesMessageIdFeedbackDeleteMutation,
@@ -59,30 +60,44 @@ export function MessageFeedback({ conversationId, messageId, currentRating }: Me
 
   return (
     <div className="flex items-center gap-1">
-      <button
-        type="button"
-        onClick={() => handleFeedback('positive')}
-        disabled={isLoading}
-        className={cn(
-          'p-1 rounded hover:bg-accent transition-colors',
-          rating === 'positive' ? 'text-green-600 dark:text-green-400' : 'text-muted-foreground/50 hover:text-muted-foreground',
-        )}
-        aria-label="Thumbs up"
-      >
-        <ThumbsUp className="w-3.5 h-3.5" fill={rating === 'positive' ? 'currentColor' : 'none'} />
-      </button>
-      <button
-        type="button"
-        onClick={() => handleFeedback('negative')}
-        disabled={isLoading}
-        className={cn(
-          'p-1 rounded hover:bg-accent transition-colors',
-          rating === 'negative' ? 'text-red-600 dark:text-red-400' : 'text-muted-foreground/50 hover:text-muted-foreground',
-        )}
-        aria-label="Thumbs down"
-      >
-        <ThumbsDown className="w-3.5 h-3.5" fill={rating === 'negative' ? 'currentColor' : 'none'} />
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => handleFeedback('positive')}
+            disabled={isLoading}
+            className={cn(
+              'p-1 rounded hover:bg-accent transition-colors',
+              rating === 'positive' ? 'text-green-600 dark:text-green-400' : 'text-muted-foreground/50 hover:text-muted-foreground',
+            )}
+            aria-label="Thumbs up"
+          >
+            <ThumbsUp className="w-3.5 h-3.5" fill={rating === 'positive' ? 'currentColor' : 'none'} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={4}>
+          Helpful
+        </TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => handleFeedback('negative')}
+            disabled={isLoading}
+            className={cn(
+              'p-1 rounded hover:bg-accent transition-colors',
+              rating === 'negative' ? 'text-red-600 dark:text-red-400' : 'text-muted-foreground/50 hover:text-muted-foreground',
+            )}
+            aria-label="Thumbs down"
+          >
+            <ThumbsDown className="w-3.5 h-3.5" fill={rating === 'negative' ? 'currentColor' : 'none'} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={4}>
+          Not helpful
+        </TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/packages/console-frontend/src/components/chat/components/MessageFeedback.tsx
+++ b/packages/console-frontend/src/components/chat/components/MessageFeedback.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ThumbsUp, ThumbsDown } from 'lucide-react';
-import { cn } from '@/lib/utils';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { TooltipIconButton } from './TooltipIconButton';
 import {
   submitFeedbackApiV1ConversationsConversationIdMessagesMessageIdFeedbackPostMutation,
   deleteFeedbackApiV1ConversationsConversationIdMessagesMessageIdFeedbackDeleteMutation,
@@ -60,44 +59,20 @@ export function MessageFeedback({ conversationId, messageId, currentRating }: Me
 
   return (
     <div className="flex items-center gap-1">
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            onClick={() => handleFeedback('positive')}
-            disabled={isLoading}
-            className={cn(
-              'p-1 rounded hover:bg-accent transition-colors',
-              rating === 'positive' ? 'text-green-600 dark:text-green-400' : 'text-muted-foreground/50 hover:text-muted-foreground',
-            )}
-            aria-label="Thumbs up"
-          >
-            <ThumbsUp className="w-3.5 h-3.5" fill={rating === 'positive' ? 'currentColor' : 'none'} />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom" sideOffset={4}>
-          Helpful
-        </TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            onClick={() => handleFeedback('negative')}
-            disabled={isLoading}
-            className={cn(
-              'p-1 rounded hover:bg-accent transition-colors',
-              rating === 'negative' ? 'text-red-600 dark:text-red-400' : 'text-muted-foreground/50 hover:text-muted-foreground',
-            )}
-            aria-label="Thumbs down"
-          >
-            <ThumbsDown className="w-3.5 h-3.5" fill={rating === 'negative' ? 'currentColor' : 'none'} />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom" sideOffset={4}>
-          Not helpful
-        </TooltipContent>
-      </Tooltip>
+      <TooltipIconButton
+        icon={<ThumbsUp className="w-3.5 h-3.5" fill={rating === 'positive' ? 'currentColor' : 'none'} />}
+        label="Helpful"
+        onClick={() => handleFeedback('positive')}
+        disabled={isLoading}
+        className={rating === 'positive' ? 'text-green-600 dark:text-green-400' : undefined}
+      />
+      <TooltipIconButton
+        icon={<ThumbsDown className="w-3.5 h-3.5" fill={rating === 'negative' ? 'currentColor' : 'none'} />}
+        label="Not helpful"
+        onClick={() => handleFeedback('negative')}
+        disabled={isLoading}
+        className={rating === 'negative' ? 'text-red-600 dark:text-red-400' : undefined}
+      />
     </div>
   );
 }

--- a/packages/console-frontend/src/components/chat/components/MessageList.tsx
+++ b/packages/console-frontend/src/components/chat/components/MessageList.tsx
@@ -10,13 +10,13 @@ import {
   getConversationFeedbackApiV1ConversationsConversationIdFeedbackGetQueryKey,
 } from '@/api/generated/@tanstack/react-query.gen';
 import type { FeedbackRating } from '@/api/generated';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useChat } from '../contexts';
 import { copyToClipboard, formatTime, getFileInfo } from '../utils';
 import type { Message } from '../types';
 import { UnifiedTimelineBlock } from './UnifiedTimelineBlock';
 import { MessageFeedback } from './MessageFeedback';
 import { ReportIssueDialog } from './ReportIssueDialog';
+import { TooltipIconButton } from './TooltipIconButton';
 
 function CopyMessageButton({ content, label }: { content: string; label: string }) {
   const [copied, setCopied] = useState(false);
@@ -30,21 +30,11 @@ function CopyMessageButton({ content, label }: { content: string; label: string 
   };
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <button
-          type="button"
-          onClick={handleCopy}
-          className="p-1 rounded text-muted-foreground/50 hover:text-muted-foreground hover:bg-accent transition-colors"
-          aria-label={label}
-        >
-          {copied ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5" />}
-        </button>
-      </TooltipTrigger>
-      <TooltipContent side="bottom" sideOffset={4}>
-        {copied ? 'Copied!' : label}
-      </TooltipContent>
-    </Tooltip>
+    <TooltipIconButton
+      icon={copied ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5" />}
+      label={copied ? 'Copied!' : label}
+      onClick={handleCopy}
+    />
   );
 }
 
@@ -190,21 +180,11 @@ function MessageCard({ message, feedbackMap }: MessageCardProps) {
                       messageId={message.id}
                       currentRating={currentRating}
                     />
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          onClick={() => setReportOpen(true)}
-                          className="p-1 rounded text-muted-foreground/50 hover:text-muted-foreground hover:bg-accent transition-colors"
-                          aria-label="Report issue"
-                        >
-                          <Flag className="w-3.5 h-3.5" />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom" sideOffset={4}>
-                        Report issue
-                      </TooltipContent>
-                    </Tooltip>
+                    <TooltipIconButton
+                      icon={<Flag className="w-3.5 h-3.5" />}
+                      label="Report issue"
+                      onClick={() => setReportOpen(true)}
+                    />
                   </>
                 )}
               </>

--- a/packages/console-frontend/src/components/chat/components/MessageList.tsx
+++ b/packages/console-frontend/src/components/chat/components/MessageList.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { AlertTriangle, Bot, User, FileText, Download, Flag, ThumbsUp, ThumbsDown } from 'lucide-react';
+import { AlertTriangle, Bot, User, FileText, Download, Flag, ThumbsUp, ThumbsDown, Copy, Check } from 'lucide-react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { cn } from '@/lib/utils';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
@@ -10,12 +10,43 @@ import {
   getConversationFeedbackApiV1ConversationsConversationIdFeedbackGetQueryKey,
 } from '@/api/generated/@tanstack/react-query.gen';
 import type { FeedbackRating } from '@/api/generated';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useChat } from '../contexts';
-import { formatTime, getFileInfo } from '../utils';
+import { copyToClipboard, formatTime, getFileInfo } from '../utils';
 import type { Message } from '../types';
 import { UnifiedTimelineBlock } from './UnifiedTimelineBlock';
 import { MessageFeedback } from './MessageFeedback';
 import { ReportIssueDialog } from './ReportIssueDialog';
+
+function CopyMessageButton({ content, label }: { content: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    const success = await copyToClipboard(content);
+    if (success) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    }
+  };
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="p-1 rounded text-muted-foreground/50 hover:text-muted-foreground hover:bg-accent transition-colors"
+          aria-label={label}
+        >
+          {copied ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5" />}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={4}>
+        {copied ? 'Copied!' : label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
 
 interface MessageCardProps {
   message: Message;
@@ -146,23 +177,39 @@ function MessageCard({ message, feedbackMap }: MessageCardProps) {
         </div>
         <div className="flex items-center gap-2 px-1">
           <span className="text-xs text-muted-foreground">{formattedTime}</span>
-          {!isUser && activeConversationId && (
-            <div className="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-1">
-              <MessageFeedback
-                conversationId={activeConversationId}
-                messageId={message.id}
-                currentRating={currentRating}
-              />
-              <button
-                type="button"
-                onClick={() => setReportOpen(true)}
-                className="p-1 rounded text-muted-foreground/50 hover:text-muted-foreground hover:bg-accent transition-colors"
-                aria-label="Report issue"
-              >
-                <Flag className="w-3.5 h-3.5" />
-              </button>
-            </div>
-          )}
+          <div className="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-1">
+            {isUser ? (
+              <CopyMessageButton content={message.content} label="Copy prompt" />
+            ) : (
+              <>
+                <CopyMessageButton content={message.content} label="Copy response" />
+                {activeConversationId && (
+                  <>
+                    <MessageFeedback
+                      conversationId={activeConversationId}
+                      messageId={message.id}
+                      currentRating={currentRating}
+                    />
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          onClick={() => setReportOpen(true)}
+                          className="p-1 rounded text-muted-foreground/50 hover:text-muted-foreground hover:bg-accent transition-colors"
+                          aria-label="Report issue"
+                        >
+                          <Flag className="w-3.5 h-3.5" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom" sideOffset={4}>
+                        Report issue
+                      </TooltipContent>
+                    </Tooltip>
+                  </>
+                )}
+              </>
+            )}
+          </div>
         </div>
         {reportOpen && activeConversationId && (
           <ReportIssueDialog

--- a/packages/console-frontend/src/components/chat/components/TooltipIconButton.tsx
+++ b/packages/console-frontend/src/components/chat/components/TooltipIconButton.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+
+interface TooltipIconButtonProps {
+  icon: ReactNode;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  className?: string;
+  side?: 'top' | 'bottom' | 'left' | 'right';
+}
+
+/**
+ * Small icon-only action button (message-row actions: copy, feedback, report)
+ * with a tooltip carrying its label. Defaults to side="bottom" since these
+ * buttons typically sit just below a message bubble.
+ */
+export function TooltipIconButton({ icon, label, onClick, disabled, className, side = 'bottom' }: TooltipIconButtonProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={onClick}
+          disabled={disabled}
+          className={cn(
+            'p-1 rounded text-muted-foreground/50 hover:text-muted-foreground hover:bg-accent transition-colors',
+            className
+          )}
+          aria-label={label}
+        >
+          {icon}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side={side} sideOffset={4}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/packages/console-frontend/src/components/chat/utils.ts
+++ b/packages/console-frontend/src/components/chat/utils.ts
@@ -414,10 +414,20 @@ export function downloadTextFile(filename: string, content: string, mimeType = '
 }
 
 /**
- * Render a conversation's messages as a plain-text transcript for export
+ * Render a conversation's messages as a plain-text transcript for export.
+ *
+ * `truncated` should be set when `messages` may not be the full history (the
+ * console only ever loads the most recent MESSAGE_FETCH_LIMIT messages, with
+ * no pagination) so the export doesn't silently look complete when it isn't.
  */
-export function formatConversationAsText(title: string, messages: Message[]): string {
+export function formatConversationAsText(title: string, messages: Message[], truncated = false): string {
   const lines = [title, '='.repeat(title.length), ''];
+  if (truncated) {
+    lines.push(
+      '⚠ This export may be incomplete: only the most recently loaded messages are included; earlier history was not fetched.',
+      ''
+    );
+  }
   for (const message of messages) {
     if (message.showMessageCard === false) continue;
     const speaker = message.type === 'user' ? 'User' : 'Assistant';

--- a/packages/console-frontend/src/components/chat/utils.ts
+++ b/packages/console-frontend/src/components/chat/utils.ts
@@ -1,6 +1,7 @@
 // Utility functions for the chat application
 
 import { v7 as uuidv7 } from 'uuid';
+import type { Message } from './types';
 
 /**
  * Generate a UUID v7
@@ -395,4 +396,46 @@ export async function copyToClipboard(text: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+/**
+ * Trigger a browser download of text content as a file
+ */
+export function downloadTextFile(filename: string, content: string, mimeType = 'text/plain'): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Render a conversation's messages as a plain-text transcript for export
+ */
+export function formatConversationAsText(title: string, messages: Message[]): string {
+  const lines = [title, '='.repeat(title.length), ''];
+  for (const message of messages) {
+    if (message.showMessageCard === false) continue;
+    const speaker = message.type === 'user' ? 'User' : 'Assistant';
+    lines.push(`[${formatTimestamp(message.timestamp)}] ${speaker}:`);
+    lines.push(message.content);
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Build a filesystem-safe filename from a conversation title
+ */
+export function slugifyFilename(title: string): string {
+  const slug = title
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || 'conversation';
 }


### PR DESCRIPTION
closes #132

## Summary
- Copy Prompt / Copy Response hover actions on chat message bubbles (`MessageList.tsx`)
- Export Conversation header button, downloads the active conversation as a `.txt` transcript (`ChatApp.tsx`)
- Tooltips on the message action icons (Copy, thumbs up/down, report issue), placed with `side="bottom"` so they open below the icon and never cover the bubble text above (`MessageList.tsx`, `MessageFeedback.tsx`)
- New shared helpers in `utils.ts`: `downloadTextFile`, `formatConversationAsText`, `slugifyFilename`

## Checklist
- [x] I have performed a self-review of my code
- [ ] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨 — No