### PR TITLE
fix(agent-common): degrade gracefully on Gatana MCP gateway errors

### DIFF
--- a/packages/agent-common/AGENTS.md
+++ b/packages/agent-common/AGENTS.md
@@ -36,7 +36,7 @@ The primary agent implementation for all user-configured sub-agents. Wraps a Lan
 
 **Key design decisions:**
 
-1. **Lazy initialization via `_ensure_agent()`**: Tools, skills, prompt, and graph are resolved only on first invocation (guarded by `_cached_tools` sentinel). After first call, it's a no-op.
+1. **Lazy initialization via `_ensure_agent()`**: Tools, skills, prompt, and graph are resolved only on first invocation (guarded by `_cached_tools` sentinel). A call that resolves cleanly makes every later call a no-op; a call that degrades due to an MCP gateway/transport failure (`_mcp_discovery_error` set) does not — the next call retries discovery instead of permanently pinning the instance at zero MCP tools.
 
 2. **Console self-improvement tools are always injected** — independent of the agent's `mcp_tools` whitelist. Every sub-agent can create/update/remove skills and update playbooks via console-backend MCP. These are discovered via a separate `_discover_console_self_improvement_tools()` call.
 

--- a/packages/agent-common/agent_common/agents/dynamic_agent.py
+++ b/packages/agent-common/agent_common/agents/dynamic_agent.py
@@ -129,6 +129,22 @@ def is_console_backend_tool(name: str) -> bool:
     return name.startswith(CONSOLE_BACKEND_TOOL_PREFIXES)
 
 
+class _TokenExchangeError(Exception):
+    """Marks a failure from exchange_token() as a distinct type, not a string flag.
+
+    _discover_mcp_tools must never degrade a failure exchanging the user's own
+    token into the gateway's "temporarily unavailable" path (their credentials,
+    not the gateway being down). Routing every exchange_token() call through
+    _exchange_token_for (the only place that raises this) makes that invariant
+    structural: a future third exchange call site that skips the helper is a
+    visible bug (unclassified as auth), not a silently-forgotten flag.
+
+    Always raised as ``raise _TokenExchangeError(...) from original_exc`` —
+    callers recover the original via ``__cause__`` for logging/classification,
+    then re-raise it bare (not ``from None``) so its own chain stays intact.
+    """
+
+
 def _validate_tool_schema(tool: BaseTool) -> BaseTool:
     """Validate and fix MCP tool schema for OpenAI API compatibility.
 
@@ -601,6 +617,21 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
             "</self_improvement>"
         )
 
+    async def _exchange_token_for(self, target_client_id: str) -> str:
+        """Exchange self.user_token for a token scoped to target_client_id.
+
+        The only place that calls self.oauth2_client.exchange_token() during
+        MCP discovery — see _TokenExchangeError for why that matters.
+        """
+        try:
+            return await self.oauth2_client.exchange_token(
+                subject_token=self.user_token,
+                target_client_id=target_client_id,
+                requested_scopes=["openid", "profile", "offline_access"],
+            )
+        except Exception as e:
+            raise _TokenExchangeError(f"Exchanging token for {target_client_id} failed") from e
+
     async def _discover_mcp_tools(self) -> List[BaseTool]:
         """Discover tools from MCP servers with authentication.
 
@@ -638,7 +669,6 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         """
         import asyncio
 
-        self._mcp_discovery_error = None
         mcp_gateway_url = self.mcp_gateway_url
         mcp_gateway_client_id = self.mcp_gateway_client_id
         mcp_tool_names = set(self.config.mcp_tools or [])
@@ -657,14 +687,6 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         delay = 1.0
 
         for attempt in range(max_retries):
-            # Set when a failure below came from exchange_token() rather than
-            # the MCP gateway/transport itself — a different failure class
-            # (the user's own credentials, not the gateway being down) that
-            # must not be degraded to []. Reused as-is by is_retryable_mcp_error
-            # for the retry decision, so a transient OIDC hiccup still gets
-            # retried the same as a transient gateway one; only a non-retryable
-            # or exhausted-retries auth failure skips the degrade and raises.
-            is_auth_exchange_error = False
             try:
                 # Build connections dict for MultiServerMCPClient
                 connections: dict[str, StreamableHttpConnection] = {}
@@ -675,15 +697,7 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                     headers: dict[str, str] = {}
                     if self.oauth2_client and self.user_token:
                         logger.debug(f"Exchanging token for MCP gateway access for {self.name}")
-                        try:
-                            mcp_gateway_token = await self.oauth2_client.exchange_token(
-                                subject_token=self.user_token,
-                                target_client_id=mcp_gateway_client_id,
-                                requested_scopes=["openid", "profile", "offline_access"],
-                            )
-                        except Exception:
-                            is_auth_exchange_error = True
-                            raise
+                        mcp_gateway_token = await self._exchange_token_for(mcp_gateway_client_id)
                         headers["Authorization"] = f"Bearer {mcp_gateway_token}"
                         logger.info(f"Successfully exchanged token for MCP gateway ({self.name})")
                     else:
@@ -703,15 +717,7 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                     console_headers: dict[str, str] = {}
                     if self.oauth2_client and self.user_token:
                         logger.debug(f"Exchanging token for console backend access for {self.name}")
-                        try:
-                            console_token = await self.oauth2_client.exchange_token(
-                                subject_token=self.user_token,
-                                target_client_id=self.console_backend_client_id,
-                                requested_scopes=["openid", "profile", "offline_access"],
-                            )
-                        except Exception:
-                            is_auth_exchange_error = True
-                            raise
+                        console_token = await self._exchange_token_for(self.console_backend_client_id)
                         console_headers["Authorization"] = f"Bearer {console_token}"
                         logger.info(f"Successfully exchanged token for console backend ({self.name})")
                     elif self.user_token:
@@ -746,24 +752,41 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
 
                 if attempt > 0:
                     logger.info(f"Successfully discovered MCP tools for {self.name} on attempt {attempt + 1}")
+                # Only cleared on an actual successful resolution — not
+                # unconditionally at the top of the method — so a call that
+                # raises (auth failure, non-transport error) before reaching
+                # here leaves a prior degrade's error in place. Otherwise the
+                # _ensure_agent guard below would see a cleared error next to
+                # still-cached degraded tools and wrongly treat that as
+                # "resolved," permanently skipping the retry it's meant to allow.
+                self._mcp_discovery_error = None
                 return validated_tools
 
             except Exception as e:
+                # A _TokenExchangeError wraps the real failure (from exchange_token
+                # via _exchange_token_for) purely to route it through this one
+                # except clause structurally — classify/log/retry on the
+                # original cause, never the wrapper's own generic message.
+                is_auth_exchange_error = isinstance(e, _TokenExchangeError)
+                classify_target = e.__cause__ if is_auth_exchange_error else e
+
                 # Check if this is a retryable error
-                is_retryable = is_retryable_mcp_error(e)
+                is_retryable = is_retryable_mcp_error(classify_target)
 
                 if not is_retryable or attempt >= max_retries - 1:
                     if is_auth_exchange_error:
-                        # Don't degrade — propagate so the turn fails loudly,
-                        # same as before this degrade path existed for
-                        # gateway/transport errors (see docstring).
+                        # Don't degrade — propagate the original cause (not the
+                        # wrapper) so the turn fails loudly, same as before this
+                        # degrade path existed for gateway/transport errors (see
+                        # docstring). Bare raise, not "from None": preserves
+                        # classify_target's own __cause__/__context__ chain intact.
                         logger.error(
                             f"Token exchange failed while discovering MCP tools for {self.name} "
-                            f"(attempt {attempt + 1}): {e}"
+                            f"(attempt {attempt + 1}): {classify_target}"
                         )
-                        raise
+                        raise classify_target
 
-                    if not is_mcp_transport_error(e):
+                    if not is_mcp_transport_error(classify_target):
                         # Not a gateway/network failure at all — a bug in our own
                         # code (e.g. a tool-schema validation error) raised from
                         # inside this try block. Must not be silently reported to
@@ -775,17 +798,15 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                         raise
 
                     # Non-retryable error or exhausted retries — degrade gracefully
-                    # instead of crashing the whole turn (see docstring). This is
-                    # always the loop's last possible outcome: every path either
-                    # returns here or above, so there is no unreachable tail after it.
-                    error_msg = format_mcp_error(e)
+                    # instead of crashing the whole turn (see docstring).
+                    error_msg = format_mcp_error(classify_target)
                     if is_retryable:
                         logger.error(
                             f"Failed to discover MCP tools for {self.name} after {attempt + 1} attempts: {error_msg}"
                         )
                     else:
-                        logger.error(f"Non-retryable error discovering MCP tools for {self.name}: {e}")
-                    log_mcp_gateway_error(logger, e, context=f"for {self.name} ")
+                        logger.error(f"Non-retryable error discovering MCP tools for {self.name}: {classify_target}")
+                    log_mcp_gateway_error(logger, classify_target, context=f"for {self.name} ")
                     # Recorded so _ensure_agent can warn the LLM (and, through it,
                     # the user) that some tools are missing — otherwise the agent
                     # just looks silently less capable with no way to explain why.
@@ -794,11 +815,18 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
 
                 # Retryable error - wait and retry
                 logger.warning(
-                    f"Transient error discovering MCP tools for {self.name} (attempt {attempt + 1}/{max_retries}): {e}. "
-                    f"Retrying in {delay:.1f}s..."
+                    f"Transient error discovering MCP tools for {self.name} (attempt {attempt + 1}/{max_retries}): "
+                    f"{classify_target}. Retrying in {delay:.1f}s..."
                 )
                 await asyncio.sleep(delay)
                 delay *= 2  # Exponential backoff
+
+        # Unreachable today (every branch above returns or raises on the last
+        # attempt) — kept as an executable invariant rather than only a
+        # comment, so a future change to the loop structure (e.g. a stray
+        # `continue`) fails loudly instead of silently returning None into
+        # _discovered_tools with _mcp_discovery_error left unset.
+        raise AssertionError("unreachable: MCP discovery retry loop exited without returning or raising")
 
     # Tools that sub-agents always get from console-backend MCP for self-improvement
     _CONSOLE_SELF_IMPROVEMENT_TOOLS = frozenset(

--- a/packages/agent-common/agent_common/agents/dynamic_agent.py
+++ b/packages/agent-common/agent_common/agents/dynamic_agent.py
@@ -128,17 +128,6 @@ def is_console_backend_tool(name: str) -> bool:
     return name.startswith(CONSOLE_BACKEND_TOOL_PREFIXES)
 
 
-class _McpTokenExchangeError(Exception):
-    """Marks a failure from exchange_token(), not from the MCP server itself.
-
-    _discover_mcp_tools degrades gracefully on MCP transport/gateway errors —
-    but a failure exchanging the user's own token is a different failure class
-    (their credentials, not the gateway being down) and must not be caught by
-    that same degrade path silently. Raised with the original exception as
-    __cause__ and unwrapped back to it before propagating past this module.
-    """
-
-
 def _validate_tool_schema(tool: BaseTool) -> BaseTool:
     """Validate and fix MCP tool schema for OpenAI API compatibility.
 
@@ -625,15 +614,18 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         If config.mcp_tools is set, only those tools are returned (whitelist filtering).
         The discovered tools override orchestrator tools entirely when whitelist is specified.
 
-        Implements retry logic with exponential backoff for transient errors (502, 503, 504).
-        Non-retryable MCP transport/gateway errors (4xx, exhausted retries) degrade
-        gracefully to an empty tool list rather than failing the turn — a dead/
-        misconfigured gateway (e.g. Gatana) shouldn't crash embedded execute-only
-        sub-agents that depend on this as their only tool source, mirroring
-        ToolDiscoveryService.fetch_available_servers. Failures exchanging the
-        user's own token are a different failure class (their credentials, not
-        the gateway being down) and are NOT degraded — they propagate so the turn
-        fails loudly, same as before this degrade path existed.
+        Implements retry logic with exponential backoff for transient errors (502, 503, 504),
+        applied uniformly to MCP transport/gateway errors and to exchange_token()
+        failures alike (a transient OIDC hiccup gets retried the same as a transient
+        gateway one). Once non-retryable or retries are exhausted, the two failure
+        classes diverge: a dead/misconfigured MCP transport/gateway (4xx, e.g. a
+        disabled Gatana account) degrades gracefully to an empty tool list rather
+        than failing the turn — it shouldn't crash embedded execute-only sub-agents
+        that depend on this as their only tool source, mirroring
+        ToolDiscoveryService.fetch_available_servers. A failure exchanging the
+        user's own token is a different failure class (their credentials, not the
+        gateway being down) and is NOT degraded — it propagates so the turn fails
+        loudly, same as before this degrade path existed.
 
         Returns:
             List of discovered BaseTool instances (filtered by whitelist if specified),
@@ -664,6 +656,14 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         delay = 1.0
 
         for attempt in range(max_retries):
+            # Set when a failure below came from exchange_token() rather than
+            # the MCP gateway/transport itself — a different failure class
+            # (the user's own credentials, not the gateway being down) that
+            # must not be degraded to []. Reused as-is by is_retryable_mcp_error
+            # for the retry decision, so a transient OIDC hiccup still gets
+            # retried the same as a transient gateway one; only a non-retryable
+            # or exhausted-retries auth failure skips the degrade and raises.
+            is_auth_exchange_error = False
             try:
                 # Build connections dict for MultiServerMCPClient
                 connections: dict[str, StreamableHttpConnection] = {}
@@ -680,8 +680,9 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                                 target_client_id=mcp_gateway_client_id,
                                 requested_scopes=["openid", "profile", "offline_access"],
                             )
-                        except Exception as auth_exc:
-                            raise _McpTokenExchangeError(str(auth_exc)) from auth_exc
+                        except Exception:
+                            is_auth_exchange_error = True
+                            raise
                         headers["Authorization"] = f"Bearer {mcp_gateway_token}"
                         logger.info(f"Successfully exchanged token for MCP gateway ({self.name})")
                     else:
@@ -707,8 +708,9 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                                 target_client_id=self.console_backend_client_id,
                                 requested_scopes=["openid", "profile", "offline_access"],
                             )
-                        except Exception as auth_exc:
-                            raise _McpTokenExchangeError(str(auth_exc)) from auth_exc
+                        except Exception:
+                            is_auth_exchange_error = True
+                            raise
                         console_headers["Authorization"] = f"Bearer {console_token}"
                         logger.info(f"Successfully exchanged token for console backend ({self.name})")
                     elif self.user_token:
@@ -745,18 +747,21 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                     logger.info(f"Successfully discovered MCP tools for {self.name} on attempt {attempt + 1}")
                 return validated_tools
 
-            except _McpTokenExchangeError as auth_exc:
-                # A different failure class from the gateway/transport errors below
-                # (the user's own credentials, not the gateway being down) — don't
-                # degrade, propagate the original exception as before this path existed.
-                logger.error(f"Token exchange failed while discovering MCP tools for {self.name}: {auth_exc}")
-                raise auth_exc.__cause__ from None
-
             except Exception as e:
                 # Check if this is a retryable error
                 is_retryable = is_retryable_mcp_error(e)
 
                 if not is_retryable or attempt >= max_retries - 1:
+                    if is_auth_exchange_error:
+                        # Don't degrade — propagate so the turn fails loudly,
+                        # same as before this degrade path existed for
+                        # gateway/transport errors (see docstring).
+                        logger.error(
+                            f"Token exchange failed while discovering MCP tools for {self.name} "
+                            f"(attempt {attempt + 1}): {e}"
+                        )
+                        raise
+
                     # Non-retryable error or exhausted retries — degrade gracefully
                     # instead of crashing the whole turn (see docstring). This is
                     # always the loop's last possible outcome: every path either
@@ -1002,10 +1007,14 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         6. Build self._agent ONLY if sandbox is not active (sandbox agents build
            a fresh graph per invocation in _astream_impl)
 
-        After first call, this is a no-op (guarded by _cached_tools sentinel).
+        After a call that resolved cleanly, this is a no-op (guarded by
+        _cached_tools). A call that degraded (_mcp_discovery_error set) is
+        NOT treated as resolved — the guard lets the next call retry
+        discovery instead of permanently pinning this instance at zero MCP
+        tools because of one transient gateway blip.
         """
-        # Already resolved — skip
-        if self._cached_tools is not None:
+        # Already resolved — skip, unless the last attempt degraded.
+        if self._cached_tools is not None and self._mcp_discovery_error is None:
             return
 
         # Discover MCP tools if whitelist is configured AND no injected tools
@@ -1013,6 +1022,14 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         if self.inject_all_tools is None:
             if self.config.mcp_tools and len(self.config.mcp_tools) > 0 and self._discovered_tools is None:
                 self._discovered_tools = await self._discover_mcp_tools()
+                if self._mcp_discovery_error:
+                    # Degraded, not resolved — leave _discovered_tools unset (not
+                    # cached as "[]", the same as a real empty whitelist match)
+                    # so the next call's guard above re-triggers discovery instead
+                    # of treating this instance as permanently tool-less.
+                    # _get_effective_tools() below still sees `[]` for *this*
+                    # call via `self._discovered_tools or []`.
+                    self._discovered_tools = None
 
         tools = self._get_effective_tools()
 

--- a/packages/agent-common/agent_common/agents/dynamic_agent.py
+++ b/packages/agent-common/agent_common/agents/dynamic_agent.py
@@ -49,6 +49,7 @@ from langgraph.store.postgres.aio import AsyncPostgresStore
 from ringier_a2a_sdk.oauth import OidcOAuth2Client
 from ringier_a2a_sdk.utils.mcp_errors import (
     format_mcp_error,
+    is_mcp_transport_error,
     is_retryable_mcp_error,
     log_mcp_gateway_error,
 )
@@ -759,6 +760,17 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                         logger.error(
                             f"Token exchange failed while discovering MCP tools for {self.name} "
                             f"(attempt {attempt + 1}): {e}"
+                        )
+                        raise
+
+                    if not is_mcp_transport_error(e):
+                        # Not a gateway/network failure at all — a bug in our own
+                        # code (e.g. a tool-schema validation error) raised from
+                        # inside this try block. Must not be silently reported to
+                        # the user as "temporarily unavailable" forever; crash
+                        # loudly like any other programming error.
+                        logger.error(
+                            f"Unexpected (non-MCP-transport) error discovering MCP tools for {self.name}: {e}"
                         )
                         raise
 

--- a/packages/agent-common/agent_common/agents/dynamic_agent.py
+++ b/packages/agent-common/agent_common/agents/dynamic_agent.py
@@ -49,9 +49,8 @@ from langgraph.store.postgres.aio import AsyncPostgresStore
 from ringier_a2a_sdk.oauth import OidcOAuth2Client
 from ringier_a2a_sdk.utils.mcp_errors import (
     format_mcp_error,
-    get_mcp_error_body,
-    get_mcp_http_status_error,
     is_retryable_mcp_error,
+    log_mcp_gateway_error,
 )
 from ringier_a2a_sdk.utils.mcp_progress import on_mcp_progress
 from ringier_a2a_sdk.utils.streaming import (
@@ -127,6 +126,17 @@ CONSOLE_BACKEND_TOOL_PREFIXES = ("console_", "scheduler_")
 def is_console_backend_tool(name: str) -> bool:
     """Return True if ``name`` is served by the console-backend MCP, not the gateway."""
     return name.startswith(CONSOLE_BACKEND_TOOL_PREFIXES)
+
+
+class _McpTokenExchangeError(Exception):
+    """Marks a failure from exchange_token(), not from the MCP server itself.
+
+    _discover_mcp_tools degrades gracefully on MCP transport/gateway errors —
+    but a failure exchanging the user's own token is a different failure class
+    (their credentials, not the gateway being down) and must not be caught by
+    that same degrade path silently. Raised with the original exception as
+    __cause__ and unwrapped back to it before propagating past this module.
+    """
 
 
 def _validate_tool_schema(tool: BaseTool) -> BaseTool:
@@ -494,6 +504,36 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
 
         return "\n\n" + "\n".join(parts)
 
+    def _build_tool_availability_addendum(self) -> str:
+        """Build the tool-availability warning for the system prompt.
+
+        Set when _discover_mcp_tools degraded to zero tools rather than failing
+        the turn (see its docstring) — without this, the agent just looks
+        silently less capable, with no way to tell the user a gateway is down
+        instead of the capability never having existed.
+
+        Deliberately a fixed, parameter-free sentence rather than interpolating
+        self._mcp_discovery_error: that text is gateway/exception-controlled
+        (a prompt-injection surface at system-prompt privilege), can embed
+        internal URLs the model would otherwise be told to relay to the user,
+        and varies turn to turn during a flapping gateway — which would
+        invalidate the prompt-cache prefix on every degraded turn. The detailed
+        message is already logged server-side, in _discover_mcp_tools.
+
+        Returns:
+            Formatted string to append to the system prompt, or empty string
+        """
+        if not self._mcp_discovery_error:
+            return ""
+        return (
+            "\n\n<tool_availability_warning>\n"
+            "Some of your integration tools failed to load. "
+            "If the user asks for something that would need those tools, tell them the "
+            "integration is temporarily unavailable due to a backend error (don't guess, "
+            "improvise, or silently refuse as if the capability never existed).\n"
+            "</tool_availability_warning>"
+        )
+
     def _build_self_improvement_addendum(self) -> str:
         """Build the self-improvement decision tree for the system prompt.
 
@@ -586,17 +626,26 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         The discovered tools override orchestrator tools entirely when whitelist is specified.
 
         Implements retry logic with exponential backoff for transient errors (502, 503, 504).
-        Non-retryable errors (4xx, exhausted retries) degrade gracefully to an empty
-        tool list rather than failing the turn — a dead/misconfigured gateway (e.g.
-        Gatana) shouldn't crash embedded execute-only sub-agents that depend on this
-        as their only tool source, mirroring ToolDiscoveryService.fetch_available_servers.
+        Non-retryable MCP transport/gateway errors (4xx, exhausted retries) degrade
+        gracefully to an empty tool list rather than failing the turn — a dead/
+        misconfigured gateway (e.g. Gatana) shouldn't crash embedded execute-only
+        sub-agents that depend on this as their only tool source, mirroring
+        ToolDiscoveryService.fetch_available_servers. Failures exchanging the
+        user's own token are a different failure class (their credentials, not
+        the gateway being down) and are NOT degraded — they propagate so the turn
+        fails loudly, same as before this degrade path existed.
 
         Returns:
             List of discovered BaseTool instances (filtered by whitelist if specified),
-            or an empty list if discovery fails after retries.
+            or an empty list if MCP transport/gateway discovery fails after retries.
+
+        Raises:
+            Exception: If exchanging the user's token fails (the original
+                exception, not wrapped) — this is not a gateway/transport error.
         """
         import asyncio
 
+        self._mcp_discovery_error = None
         mcp_gateway_url = self.mcp_gateway_url
         mcp_gateway_client_id = self.mcp_gateway_client_id
         mcp_tool_names = set(self.config.mcp_tools or [])
@@ -612,9 +661,7 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
 
         # Retry parameters
         max_retries = 3
-        initial_delay = 1.0
-        last_error = None
-        delay = initial_delay
+        delay = 1.0
 
         for attempt in range(max_retries):
             try:
@@ -627,11 +674,14 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                     headers: dict[str, str] = {}
                     if self.oauth2_client and self.user_token:
                         logger.debug(f"Exchanging token for MCP gateway access for {self.name}")
-                        mcp_gateway_token = await self.oauth2_client.exchange_token(
-                            subject_token=self.user_token,
-                            target_client_id=mcp_gateway_client_id,
-                            requested_scopes=["openid", "profile", "offline_access"],
-                        )
+                        try:
+                            mcp_gateway_token = await self.oauth2_client.exchange_token(
+                                subject_token=self.user_token,
+                                target_client_id=mcp_gateway_client_id,
+                                requested_scopes=["openid", "profile", "offline_access"],
+                            )
+                        except Exception as auth_exc:
+                            raise _McpTokenExchangeError(str(auth_exc)) from auth_exc
                         headers["Authorization"] = f"Bearer {mcp_gateway_token}"
                         logger.info(f"Successfully exchanged token for MCP gateway ({self.name})")
                     else:
@@ -651,11 +701,14 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                     console_headers: dict[str, str] = {}
                     if self.oauth2_client and self.user_token:
                         logger.debug(f"Exchanging token for console backend access for {self.name}")
-                        console_token = await self.oauth2_client.exchange_token(
-                            subject_token=self.user_token,
-                            target_client_id=self.console_backend_client_id,
-                            requested_scopes=["openid", "profile", "offline_access"],
-                        )
+                        try:
+                            console_token = await self.oauth2_client.exchange_token(
+                                subject_token=self.user_token,
+                                target_client_id=self.console_backend_client_id,
+                                requested_scopes=["openid", "profile", "offline_access"],
+                            )
+                        except Exception as auth_exc:
+                            raise _McpTokenExchangeError(str(auth_exc)) from auth_exc
                         console_headers["Authorization"] = f"Bearer {console_token}"
                         logger.info(f"Successfully exchanged token for console backend ({self.name})")
                     elif self.user_token:
@@ -692,15 +745,22 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                     logger.info(f"Successfully discovered MCP tools for {self.name} on attempt {attempt + 1}")
                 return validated_tools
 
-            except Exception as e:
-                last_error = e
+            except _McpTokenExchangeError as auth_exc:
+                # A different failure class from the gateway/transport errors below
+                # (the user's own credentials, not the gateway being down) — don't
+                # degrade, propagate the original exception as before this path existed.
+                logger.error(f"Token exchange failed while discovering MCP tools for {self.name}: {auth_exc}")
+                raise auth_exc.__cause__ from None
 
+            except Exception as e:
                 # Check if this is a retryable error
                 is_retryable = is_retryable_mcp_error(e)
 
                 if not is_retryable or attempt >= max_retries - 1:
                     # Non-retryable error or exhausted retries — degrade gracefully
-                    # instead of crashing the whole turn (see docstring).
+                    # instead of crashing the whole turn (see docstring). This is
+                    # always the loop's last possible outcome: every path either
+                    # returns here or above, so there is no unreachable tail after it.
                     error_msg = format_mcp_error(e)
                     if is_retryable:
                         logger.error(
@@ -708,12 +768,7 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                         )
                     else:
                         logger.error(f"Non-retryable error discovering MCP tools for {self.name}: {e}")
-                    http_err = get_mcp_http_status_error(e)
-                    if http_err is not None:
-                        logger.error(
-                            f"MCP gateway response for {self.name} ({http_err.request.url}): "
-                            f"{http_err.response.status_code} body={get_mcp_error_body(http_err)!r}"
-                        )
+                    log_mcp_gateway_error(logger, e, context=f"for {self.name} ")
                     # Recorded so _ensure_agent can warn the LLM (and, through it,
                     # the user) that some tools are missing — otherwise the agent
                     # just looks silently less capable with no way to explain why.
@@ -727,11 +782,6 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                 )
                 await asyncio.sleep(delay)
                 delay *= 2  # Exponential backoff
-
-        # Should never reach here, but just in case
-        logger.error(f"Failed to discover MCP tools for {self.name}: {last_error}")
-        self._mcp_discovery_error = format_mcp_error(last_error) if last_error else "unknown error"
-        return []
 
     # Tools that sub-agents always get from console-backend MCP for self-improvement
     _CONSOLE_SELF_IMPROVEMENT_TOOLS = frozenset(
@@ -1060,19 +1110,9 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
             system_prompt += TOOL_CATALOG_PROMPT_ADDENDUM
             logger.debug(f"Added tool-catalog addendum to {self.name} system prompt")
 
-        # MCP gateway discovery degraded to zero tools rather than failing the turn
-        # (see _discover_mcp_tools) — without this, the agent just looks silently
-        # less capable, and the user/operator has no way to tell a broken gateway
-        # apart from the agent simply refusing to help.
-        if self._mcp_discovery_error:
-            system_prompt += (
-                "\n\n<tool_availability_warning>\n"
-                f"Some of your integration tools failed to load: {self._mcp_discovery_error}\n"
-                "If the user asks for something that would need those tools, tell them the "
-                "integration is temporarily unavailable due to a backend error (don't guess, "
-                "improvise, or silently refuse as if the capability never existed).\n"
-                "</tool_availability_warning>"
-            )
+        tool_availability_addendum = self._build_tool_availability_addendum()
+        if tool_availability_addendum:
+            system_prompt += tool_availability_addendum
             logger.debug(f"Added MCP tool-availability warning to {self.name} system prompt")
 
         # Get provider-specific response_format strategy (may mutate tools list for Bedrock/Anthropic+thinking)

--- a/packages/agent-common/agent_common/agents/dynamic_agent.py
+++ b/packages/agent-common/agent_common/agents/dynamic_agent.py
@@ -47,7 +47,12 @@ from langgraph.errors import GraphInterrupt
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.store.postgres.aio import AsyncPostgresStore
 from ringier_a2a_sdk.oauth import OidcOAuth2Client
-from ringier_a2a_sdk.utils.mcp_errors import format_mcp_error, is_retryable_mcp_error
+from ringier_a2a_sdk.utils.mcp_errors import (
+    format_mcp_error,
+    get_mcp_error_body,
+    get_mcp_http_status_error,
+    is_retryable_mcp_error,
+)
 from ringier_a2a_sdk.utils.mcp_progress import on_mcp_progress
 from ringier_a2a_sdk.utils.streaming import (
     StreamBuffer,
@@ -580,12 +585,14 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         The discovered tools override orchestrator tools entirely when whitelist is specified.
 
         Implements retry logic with exponential backoff for transient errors (502, 503, 504).
+        Non-retryable errors (4xx, exhausted retries) degrade gracefully to an empty
+        tool list rather than failing the turn — a dead/misconfigured gateway (e.g.
+        Gatana) shouldn't crash embedded execute-only sub-agents that depend on this
+        as their only tool source, mirroring ToolDiscoveryService.fetch_available_servers.
 
         Returns:
-            List of discovered BaseTool instances (filtered by whitelist if specified)
-
-        Raises:
-            Exception: If MCP discovery fails (will result in failed state)
+            List of discovered BaseTool instances (filtered by whitelist if specified),
+            or an empty list if discovery fails after retries.
         """
         import asyncio
 
@@ -691,7 +698,8 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                 is_retryable = is_retryable_mcp_error(e)
 
                 if not is_retryable or attempt >= max_retries - 1:
-                    # Non-retryable error or exhausted retries
+                    # Non-retryable error or exhausted retries — degrade gracefully
+                    # instead of crashing the whole turn (see docstring).
                     if is_retryable:
                         error_msg = format_mcp_error(e)
                         logger.error(
@@ -699,7 +707,13 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                         )
                     else:
                         logger.error(f"Non-retryable error discovering MCP tools for {self.name}: {e}")
-                    raise
+                    http_err = get_mcp_http_status_error(e)
+                    if http_err is not None:
+                        logger.error(
+                            f"MCP gateway response for {self.name} ({http_err.request.url}): "
+                            f"{http_err.response.status_code} body={get_mcp_error_body(http_err)!r}"
+                        )
+                    return []
 
                 # Retryable error - wait and retry
                 logger.warning(
@@ -710,7 +724,8 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                 delay *= 2  # Exponential backoff
 
         # Should never reach here, but just in case
-        raise last_error or Exception(f"Failed to discover MCP tools for {self.name}")
+        logger.error(f"Failed to discover MCP tools for {self.name}: {last_error}")
+        return []
 
     # Tools that sub-agents always get from console-backend MCP for self-improvement
     _CONSOLE_SELF_IMPROVEMENT_TOOLS = frozenset(

--- a/packages/agent-common/agent_common/agents/dynamic_agent.py
+++ b/packages/agent-common/agent_common/agents/dynamic_agent.py
@@ -307,6 +307,7 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         )
         self._agent: CompiledStateGraph | None = None
         self._discovered_tools: Optional[List[BaseTool]] = None
+        self._mcp_discovery_error: Optional[str] = None
         self._resolved_skills: dict = {}
         # Cached intermediate state for per-invocation sandbox graph rebuild
         self._cached_tools: list[BaseTool] | None = None
@@ -700,8 +701,8 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                 if not is_retryable or attempt >= max_retries - 1:
                     # Non-retryable error or exhausted retries — degrade gracefully
                     # instead of crashing the whole turn (see docstring).
+                    error_msg = format_mcp_error(e)
                     if is_retryable:
-                        error_msg = format_mcp_error(e)
                         logger.error(
                             f"Failed to discover MCP tools for {self.name} after {attempt + 1} attempts: {error_msg}"
                         )
@@ -713,6 +714,10 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                             f"MCP gateway response for {self.name} ({http_err.request.url}): "
                             f"{http_err.response.status_code} body={get_mcp_error_body(http_err)!r}"
                         )
+                    # Recorded so _ensure_agent can warn the LLM (and, through it,
+                    # the user) that some tools are missing — otherwise the agent
+                    # just looks silently less capable with no way to explain why.
+                    self._mcp_discovery_error = error_msg
                     return []
 
                 # Retryable error - wait and retry
@@ -725,6 +730,7 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
 
         # Should never reach here, but just in case
         logger.error(f"Failed to discover MCP tools for {self.name}: {last_error}")
+        self._mcp_discovery_error = format_mcp_error(last_error) if last_error else "unknown error"
         return []
 
     # Tools that sub-agents always get from console-backend MCP for self-improvement
@@ -1053,6 +1059,21 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         if self.tool_catalog is not None and not code_interpreter_ptc_enabled():
             system_prompt += TOOL_CATALOG_PROMPT_ADDENDUM
             logger.debug(f"Added tool-catalog addendum to {self.name} system prompt")
+
+        # MCP gateway discovery degraded to zero tools rather than failing the turn
+        # (see _discover_mcp_tools) — without this, the agent just looks silently
+        # less capable, and the user/operator has no way to tell a broken gateway
+        # apart from the agent simply refusing to help.
+        if self._mcp_discovery_error:
+            system_prompt += (
+                "\n\n<tool_availability_warning>\n"
+                f"Some of your integration tools failed to load: {self._mcp_discovery_error}\n"
+                "If the user asks for something that would need those tools, tell them the "
+                "integration is temporarily unavailable due to a backend error (don't guess, "
+                "improvise, or silently refuse as if the capability never existed).\n"
+                "</tool_availability_warning>"
+            )
+            logger.debug(f"Added MCP tool-availability warning to {self.name} system prompt")
 
         # Get provider-specific response_format strategy (may mutate tools list for Bedrock/Anthropic+thinking)
         response_format = get_response_format(

--- a/packages/agent-common/tests/test_dynamic_agent.py
+++ b/packages/agent-common/tests/test_dynamic_agent.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from a2a.types import TaskState
 from langchain_core.messages import HumanMessage
@@ -456,8 +457,6 @@ class TestAttachmentMounting:
 
 
 def _http_error(status: int) -> Exception:
-    import httpx
-
     request = httpx.Request("POST", "https://gateway.example/mcp")
     response = httpx.Response(status, request=request, text="boom")
     return httpx.HTTPStatusError(f"{status} error", request=request, response=response)
@@ -532,6 +531,25 @@ class TestDiscoverMcpTools:
         assert runnable._mcp_discovery_error is None
 
     @pytest.mark.asyncio
+    async def test_retryable_token_exchange_error_is_retried_then_raised(self, runnable):
+        """A transient OIDC hiccup exchanging the user's token gets the same
+        retry-with-backoff treatment as a transient gateway error — it must
+        not raise on attempt 1 just because it's an auth failure. Once
+        retries are exhausted it still raises (not degrades): this is a
+        different failure class from the gateway being down."""
+        transient_error = _http_error(503)
+        runnable.oauth2_client.exchange_token = AsyncMock(side_effect=transient_error)
+
+        with patch("asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            with pytest.raises(httpx.HTTPStatusError):
+                await runnable._discover_mcp_tools()
+
+        assert runnable.oauth2_client.exchange_token.await_count == 3  # max_retries
+        assert mock_sleep.await_count == 2  # slept between attempts, not after the last
+        # Never reached the degrade path, so no warning was recorded.
+        assert runnable._mcp_discovery_error is None
+
+    @pytest.mark.asyncio
     async def test_stale_discovery_error_cleared_on_next_call(self, runnable):
         with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
             mock_client_cls.return_value.get_tools = AsyncMock(
@@ -544,6 +562,36 @@ class TestDiscoverMcpTools:
             mock_client_cls.return_value.get_tools = AsyncMock(return_value=[])
             await runnable._discover_mcp_tools()
         assert runnable._mcp_discovery_error is None
+
+    @pytest.mark.asyncio
+    async def test_ensure_agent_retries_discovery_after_degraded_call(self, runnable):
+        """A degraded _ensure_agent() call must not permanently pin the instance
+        at zero MCP tools: the next call should retry discovery, not treat the
+        degraded state as resolved."""
+        mock_graph = MagicMock()
+
+        def fake_tool(name):
+            return Tool(name=name, description="A fake gateway tool", func=lambda x: x)
+
+        with (
+            patch("agent_common.agents.dynamic_agent.build_sub_agent_graph", return_value=mock_graph),
+            patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls,
+        ):
+            mock_client_cls.return_value.get_tools = AsyncMock(
+                side_effect=ExceptionGroup("boom", [_http_error(400)])
+            )
+            await runnable._ensure_agent()
+            assert runnable._mcp_discovery_error is not None
+            assert runnable._discovered_tools is None  # not cached as "[]"
+
+            # Second call must retry discovery (not short-circuit on the
+            # _cached_tools guard) and, on success, actually resolve.
+            mock_client_cls.return_value.get_tools = AsyncMock(return_value=[fake_tool("some_gateway_tool")])
+            await runnable._ensure_agent()
+
+        assert runnable._mcp_discovery_error is None
+        assert [t.name for t in runnable._discovered_tools] == ["some_gateway_tool"]
+        assert "tool_availability_warning" not in runnable._cached_system_prompt
 
     def test_tool_availability_addendum_empty_when_no_error(self, runnable):
         assert runnable._build_tool_availability_addendum() == ""

--- a/packages/agent-common/tests/test_dynamic_agent.py
+++ b/packages/agent-common/tests/test_dynamic_agent.py
@@ -495,6 +495,19 @@ class TestDiscoverMcpTools:
         )
 
     @pytest.mark.asyncio
+    async def test_non_mcp_error_is_not_degraded(self, runnable):
+        """A bug in our own code (not an httpx/gateway error) raised from
+        inside the discovery try block must propagate, not be silently
+        reported to the user as "temporarily unavailable" forever."""
+        with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
+            mock_client_cls.return_value.get_tools = AsyncMock(side_effect=ValueError("schema bug"))
+
+            with pytest.raises(ValueError, match="schema bug"):
+                await runnable._discover_mcp_tools()
+
+        assert runnable._mcp_discovery_error is None
+
+    @pytest.mark.asyncio
     async def test_non_retryable_gateway_error_degrades_to_empty_list(self, runnable):
         with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
             mock_client_cls.return_value.get_tools = AsyncMock(

--- a/packages/agent-common/tests/test_dynamic_agent.py
+++ b/packages/agent-common/tests/test_dynamic_agent.py
@@ -577,6 +577,29 @@ class TestDiscoverMcpTools:
         assert runnable._mcp_discovery_error is None
 
     @pytest.mark.asyncio
+    async def test_discovery_error_survives_a_later_raising_call(self, runnable):
+        """A degraded call followed by a *raising* call (auth failure, or any
+        non-transport error) must NOT clear the error — only an actual
+        successful resolution should. Otherwise _ensure_agent's guard would
+        see a cleared error next to still-cached degraded tools and wrongly
+        treat the instance as resolved, permanently skipping the retry it's
+        meant to allow (this is the within-turn "stale pin" the reset-at-entry
+        version of this method was vulnerable to)."""
+        with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
+            mock_client_cls.return_value.get_tools = AsyncMock(
+                side_effect=ExceptionGroup("boom", [_http_error(400)])
+            )
+            await runnable._discover_mcp_tools()
+        assert runnable._mcp_discovery_error is not None
+
+        runnable.oauth2_client.exchange_token = AsyncMock(side_effect=RuntimeError("token exchange failed"))
+        with pytest.raises(RuntimeError, match="token exchange failed"):
+            await runnable._discover_mcp_tools()
+
+        # The raise must not have cleared the still-outstanding degrade.
+        assert runnable._mcp_discovery_error is not None
+
+    @pytest.mark.asyncio
     async def test_ensure_agent_retries_discovery_after_degraded_call(self, runnable):
         """A degraded _ensure_agent() call must not permanently pin the instance
         at zero MCP tools: the next call should retry discovery, not treat the

--- a/packages/agent-common/tests/test_dynamic_agent.py
+++ b/packages/agent-common/tests/test_dynamic_agent.py
@@ -453,3 +453,108 @@ class TestAttachmentMounting:
         composed = runnable._compose_backend_with_attachments(StateBackend(), att_backend)
         assert isinstance(composed, CompositeBackend)
         assert "/attachments/" in composed.routes
+
+
+def _http_error(status: int) -> Exception:
+    import httpx
+
+    request = httpx.Request("POST", "https://gateway.example/mcp")
+    response = httpx.Response(status, request=request, text="boom")
+    return httpx.HTTPStatusError(f"{status} error", request=request, response=response)
+
+
+class TestDiscoverMcpTools:
+    """Tests for DynamicLocalAgentRunnable._discover_mcp_tools' error handling:
+    graceful degradation on gateway/transport errors, no degradation for
+    token-exchange (auth) failures, and stale-error cleanup on retry."""
+
+    @pytest.fixture
+    def mock_model(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def gateway_config(self):
+        return LocalLangGraphSubAgentConfig(
+            type="langgraph",
+            name="gateway-agent",
+            description="Agent with gateway MCP tools",
+            system_prompt="You are an expert with tools.",
+            mcp_tools=["some_gateway_tool"],
+        )
+
+    @pytest.fixture
+    def runnable(self, gateway_config, mock_model):
+        oauth2_client = MagicMock()
+        oauth2_client.exchange_token = AsyncMock(return_value="gateway-token")
+        return DynamicLocalAgentRunnable(
+            config=gateway_config,
+            model=mock_model,
+            oauth2_client=oauth2_client,
+            user_token="user-token",
+            mcp_gateway_url="https://gateway.example/mcp",
+            mcp_gateway_client_id="gatana",
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_retryable_gateway_error_degrades_to_empty_list(self, runnable):
+        with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
+            mock_client_cls.return_value.get_tools = AsyncMock(
+                side_effect=ExceptionGroup("boom", [_http_error(400)])
+            )
+            tools = await runnable._discover_mcp_tools()
+
+        assert tools == []
+        assert runnable._mcp_discovery_error is not None
+        assert "400" in runnable._mcp_discovery_error or "MCP" in runnable._mcp_discovery_error
+
+    @pytest.mark.asyncio
+    async def test_nested_exception_group_also_degrades(self, runnable):
+        # The exact shape the pre-fix single-level unwrap missed.
+        nested = ExceptionGroup("outer", [ExceptionGroup("inner", [_http_error(403)])])
+        with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
+            mock_client_cls.return_value.get_tools = AsyncMock(side_effect=nested)
+            tools = await runnable._discover_mcp_tools()
+
+        assert tools == []
+        assert runnable._mcp_discovery_error is not None
+
+    @pytest.mark.asyncio
+    async def test_token_exchange_failure_is_not_degraded(self, runnable):
+        """An auth failure exchanging the user's own token is a different
+        failure class from the gateway being down — it must propagate, not
+        be swallowed into the same empty-list degrade path."""
+        runnable.oauth2_client.exchange_token = AsyncMock(side_effect=RuntimeError("token exchange failed"))
+
+        with pytest.raises(RuntimeError, match="token exchange failed"):
+            await runnable._discover_mcp_tools()
+
+        # Never reached the degrade path, so no warning was recorded.
+        assert runnable._mcp_discovery_error is None
+
+    @pytest.mark.asyncio
+    async def test_stale_discovery_error_cleared_on_next_call(self, runnable):
+        with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
+            mock_client_cls.return_value.get_tools = AsyncMock(
+                side_effect=ExceptionGroup("boom", [_http_error(400)])
+            )
+            await runnable._discover_mcp_tools()
+        assert runnable._mcp_discovery_error is not None
+
+        with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
+            mock_client_cls.return_value.get_tools = AsyncMock(return_value=[])
+            await runnable._discover_mcp_tools()
+        assert runnable._mcp_discovery_error is None
+
+    def test_tool_availability_addendum_empty_when_no_error(self, runnable):
+        assert runnable._build_tool_availability_addendum() == ""
+
+    def test_tool_availability_addendum_is_fixed_and_url_free(self, runnable):
+        runnable._mcp_discovery_error = "MCP server returned HTTP 403 for https://internal-gateway.example/mcp"
+        addendum = runnable._build_tool_availability_addendum()
+
+        assert "tool_availability_warning" in addendum
+        assert "temporarily unavailable" in addendum
+        # The raw, gateway-controlled error text (and any URL in it) must never
+        # be interpolated into the prompt — see the addendum's own docstring.
+        assert "internal-gateway.example" not in addendum
+        assert "403" not in addendum

--- a/packages/console-backend/console_backend/routers/mcp_router.py
+++ b/packages/console-backend/console_backend/routers/mcp_router.py
@@ -466,8 +466,11 @@ async def list_mcp_servers(
 
     try:
         # Call the Gatana gateway's /api/v1/mcp-servers endpoint to get the server list
-        # Extract base URL from mcp_gateway.url (remove /mcp suffix if present)
-        base_url = config.mcp_gateway.url.rstrip("/mcp").rstrip("/")
+        # Extract base URL from mcp_gateway.url (remove /mcp suffix if present). Strip
+        # the trailing slash first: rstrip("/mcp") strips a character *set* (/,m,c,p),
+        # not the literal suffix, so a host ending in one of those letters gets
+        # corrupted, and removesuffix("/mcp") alone is a no-op on ".../mcp/".
+        base_url = config.mcp_gateway.url.rstrip("/").removesuffix("/mcp")
         servers_url = f"{base_url}/api/v1/mcp-servers"
 
         async with httpx.AsyncClient(timeout=30.0) as client:

--- a/packages/orchestrator-agent/app/core/discovery.py
+++ b/packages/orchestrator-agent/app/core/discovery.py
@@ -22,6 +22,7 @@ from ringier_a2a_sdk.cost_tracking.attribution import context_header
 from ringier_a2a_sdk.oauth import OidcOAuth2Client
 from ringier_a2a_sdk.utils.mcp_errors import (
     format_mcp_error,
+    get_mcp_http_status_error,
     is_retryable_mcp_error,
     log_mcp_gateway_error,
 )
@@ -246,8 +247,14 @@ class ToolDiscoveryService:
                 return servers
 
         except Exception as e:
-            logger.error(f"Failed to fetch MCP servers: {e}", exc_info=True)
-            log_mcp_gateway_error(logger, e)
+            # A traceback (exc_info) and the gateway response body are both
+            # only logged once between them: the body line already restates
+            # the status/URL that exc_info's own str(e) would repeat, so pick
+            # whichever one actually adds information for this error.
+            if get_mcp_http_status_error(e) is not None:
+                log_mcp_gateway_error(logger, e, context="Failed to fetch MCP servers ")
+            else:
+                logger.error(f"Failed to fetch MCP servers: {e}", exc_info=True)
             return []
 
     async def _get_tools_with_retry(

--- a/packages/orchestrator-agent/app/core/discovery.py
+++ b/packages/orchestrator-agent/app/core/discovery.py
@@ -226,8 +226,9 @@ class ToolDiscoveryService:
         logger.debug("Fetching available MCP servers from gateway")
         try:
             # Call the MCP gateway API to get server list
-            # Extract base URL from MCP_GATEWAY_URL (remove /mcp path)
-            base_url = self.config.MCP_GATEWAY_URL.removesuffix("/mcp").rstrip("/")
+            # Extract base URL from MCP_GATEWAY_URL (remove /mcp path). Strip the
+            # trailing slash first: removesuffix("/mcp") is a no-op on ".../mcp/".
+            base_url = self.config.MCP_GATEWAY_URL.rstrip("/").removesuffix("/mcp")
             servers_url = f"{base_url}/api/v1/mcp-servers"
 
             logger.debug(f"Fetching servers from: {servers_url}")

--- a/packages/orchestrator-agent/app/core/discovery.py
+++ b/packages/orchestrator-agent/app/core/discovery.py
@@ -22,9 +22,8 @@ from ringier_a2a_sdk.cost_tracking.attribution import context_header
 from ringier_a2a_sdk.oauth import OidcOAuth2Client
 from ringier_a2a_sdk.utils.mcp_errors import (
     format_mcp_error,
-    get_mcp_error_body,
-    get_mcp_http_status_error,
     is_retryable_mcp_error,
+    log_mcp_gateway_error,
 )
 from ringier_a2a_sdk.utils.mcp_progress import on_mcp_progress
 
@@ -228,7 +227,7 @@ class ToolDiscoveryService:
         try:
             # Call the MCP gateway API to get server list
             # Extract base URL from MCP_GATEWAY_URL (remove /mcp path)
-            base_url = self.config.MCP_GATEWAY_URL.rstrip("/mcp").rstrip("/")
+            base_url = self.config.MCP_GATEWAY_URL.removesuffix("/mcp").rstrip("/")
             servers_url = f"{base_url}/api/v1/mcp-servers"
 
             logger.debug(f"Fetching servers from: {servers_url}")
@@ -247,12 +246,7 @@ class ToolDiscoveryService:
 
         except Exception as e:
             logger.error(f"Failed to fetch MCP servers: {e}", exc_info=True)
-            http_err = get_mcp_http_status_error(e)
-            if http_err is not None:
-                logger.error(
-                    f"MCP gateway response for {http_err.request.url}: "
-                    f"{http_err.response.status_code} body={get_mcp_error_body(http_err)!r}"
-                )
+            log_mcp_gateway_error(logger, e)
             return []
 
     async def _get_tools_with_retry(

--- a/packages/orchestrator-agent/app/core/discovery.py
+++ b/packages/orchestrator-agent/app/core/discovery.py
@@ -20,7 +20,12 @@ from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_mcp_adapters.sessions import StreamableHttpConnection
 from ringier_a2a_sdk.cost_tracking.attribution import context_header
 from ringier_a2a_sdk.oauth import OidcOAuth2Client
-from ringier_a2a_sdk.utils.mcp_errors import format_mcp_error, is_retryable_mcp_error
+from ringier_a2a_sdk.utils.mcp_errors import (
+    format_mcp_error,
+    get_mcp_error_body,
+    get_mcp_http_status_error,
+    is_retryable_mcp_error,
+)
 from ringier_a2a_sdk.utils.mcp_progress import on_mcp_progress
 
 from ..models.config import AgentSettings
@@ -242,6 +247,12 @@ class ToolDiscoveryService:
 
         except Exception as e:
             logger.error(f"Failed to fetch MCP servers: {e}", exc_info=True)
+            http_err = get_mcp_http_status_error(e)
+            if http_err is not None:
+                logger.error(
+                    f"MCP gateway response for {http_err.request.url}: "
+                    f"{http_err.response.status_code} body={get_mcp_error_body(http_err)!r}"
+                )
             return []
 
     async def _get_tools_with_retry(

--- a/packages/orchestrator-agent/tests/test_discovery.py
+++ b/packages/orchestrator-agent/tests/test_discovery.py
@@ -133,6 +133,38 @@ class TestToolDiscoveryService:
         assert service.oauth2_client == oauth2_client
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("gateway_url", "expected_servers_url"),
+        [
+            # A host ending in one of the stripped characters (m/c/p) is exactly
+            # the case rstrip("/mcp") used to corrupt — regression coverage.
+            ("https://alloych.gatana.ai/mcp", "https://alloych.gatana.ai/api/v1/mcp-servers"),
+            # A trailing slash is a no-op for removesuffix("/mcp") unless the
+            # slash is stripped first — regression coverage for that fix.
+            ("https://gw.example/mcp/", "https://gw.example/api/v1/mcp-servers"),
+            ("https://gw.example/mcp", "https://gw.example/api/v1/mcp-servers"),
+        ],
+    )
+    async def test_fetch_available_servers_builds_correct_url(self, gateway_url, expected_servers_url):
+        config = Mock(spec=AgentSettings)
+        config.MCP_GATEWAY_URL = gateway_url
+        service = ToolDiscoveryService(config, oauth2_client=Mock())
+
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"servers": []}
+
+        mock_http_client = AsyncMock()
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value = mock_http_client
+            await service.fetch_available_servers("test_token")
+
+        called_url = mock_http_client.get.call_args[0][0]
+        assert called_url == expected_servers_url
+
+    @pytest.mark.asyncio
     async def test_discover_tools_basic(self):
         """Test basic tool discovery functionality."""
         config = Mock(spec=AgentSettings)

--- a/packages/orchestrator-agent/tests/test_discovery.py
+++ b/packages/orchestrator-agent/tests/test_discovery.py
@@ -137,7 +137,13 @@ class TestToolDiscoveryService:
         ("gateway_url", "expected_servers_url"),
         [
             # A host ending in one of the stripped characters (m/c/p) is exactly
-            # the case rstrip("/mcp") used to corrupt — regression coverage.
+            # the case the old rstrip("/mcp") corrupted — most commonly any
+            # ".com" host (verified against the old code: it produces
+            # "https://gateway.example.co", dropping the "m"). This is the one
+            # case that actually fails without the fix; the others below don't
+            # (alloych.gatana.ai ends in "i", not m/c/p — accidentally correct
+            # either way — and are kept for the trailing-slash-only regression).
+            ("https://gateway.example.com/mcp", "https://gateway.example.com/api/v1/mcp-servers"),
             ("https://alloych.gatana.ai/mcp", "https://alloych.gatana.ai/api/v1/mcp-servers"),
             # A trailing slash is a no-op for removesuffix("/mcp") unless the
             # slash is stripped first — regression coverage for that fix.

--- a/packages/ringier-a2a-sdk/ringier_a2a_sdk/utils/mcp_errors.py
+++ b/packages/ringier-a2a-sdk/ringier_a2a_sdk/utils/mcp_errors.py
@@ -47,6 +47,54 @@ def is_retryable_mcp_error(error: Exception) -> bool:
     return False
 
 
+def get_mcp_http_status_error(error: Exception) -> httpx.HTTPStatusError | None:
+    """Extract the underlying httpx.HTTPStatusError from an MCP connection error.
+
+    Unwraps ExceptionGroup (from anyio task groups used by the streamable HTTP
+    client) the same way is_retryable_mcp_error/format_mcp_error do, so callers
+    can log the server's actual response body instead of just the status code —
+    raise_for_status() alone discards it.
+
+    Args:
+        error: Exception raised during MCP connection
+
+    Returns:
+        The httpx.HTTPStatusError if one is found, else None
+    """
+    if hasattr(error, "__class__") and error.__class__.__name__ == "ExceptionGroup":
+        exceptions = getattr(error, "exceptions", [error])
+        for exc in exceptions:
+            if isinstance(exc, httpx.HTTPStatusError):
+                return exc
+
+    if isinstance(error, httpx.HTTPStatusError):
+        return error
+
+    return None
+
+
+def get_mcp_error_body(http_err: httpx.HTTPStatusError, max_len: int = 2000) -> str:
+    """Safely read the response body text off an HTTPStatusError for logging.
+
+    The MCP streamable HTTP client streams responses and never calls read()
+    before raise_for_status(), so response.text raises httpx.ResponseNotRead
+    for MCP gateway errors (though not for a plain, non-streaming request like
+    ToolDiscoveryService's httpx.AsyncClient.get()). Callers just want a string
+    to log either way, so this never raises.
+
+    Args:
+        http_err: The HTTPStatusError to read the body from
+        max_len: Truncate the body to this many characters
+
+    Returns:
+        The response body text (truncated), or a placeholder if it can't be read
+    """
+    try:
+        return http_err.response.text[:max_len]
+    except Exception as e:
+        return f"<body unavailable: {type(e).__name__}: {e}>"
+
+
 def format_mcp_error(error: Exception) -> str:
     """Format MCP connection errors into user-friendly messages.
 

--- a/packages/ringier-a2a-sdk/ringier_a2a_sdk/utils/mcp_errors.py
+++ b/packages/ringier-a2a-sdk/ringier_a2a_sdk/utils/mcp_errors.py
@@ -76,21 +76,27 @@ def get_mcp_http_status_error(error: Exception) -> httpx.HTTPStatusError | None:
 def get_mcp_error_body(http_err: httpx.HTTPStatusError, max_len: int = 2000) -> str:
     """Safely read the response body text off an HTTPStatusError for logging.
 
-    The MCP streamable HTTP client streams responses and never calls read()
-    before raise_for_status(), so response.text raises httpx.ResponseNotRead
-    for MCP gateway errors (though not for a plain, non-streaming request like
-    ToolDiscoveryService's httpx.AsyncClient.get()). Callers just want a string
-    to log either way, so this never raises.
+    The MCP streamable HTTP client (mcp.client.streamable_http) calls
+    raise_for_status() from inside its `async with client.stream(...)` block;
+    by the time the error reaches us here, several `__aexit__` frames up, the
+    stream has already been torn down and the body can never be read. This is
+    expected for that transport (not for a plain, non-streaming request like
+    ToolDiscoveryService's httpx.AsyncClient.get(), where the body is already
+    buffered) — so it's reported as a known limitation rather than a second
+    error. Callers just want a string to log either way, so this never raises.
 
     Args:
         http_err: The HTTPStatusError to read the body from
         max_len: Truncate the body to this many characters
 
     Returns:
-        The response body text (truncated), or a placeholder if it can't be read
+        The response body text (truncated), or an explanatory placeholder if
+        it can't be read
     """
     try:
         return http_err.response.text[:max_len]
+    except httpx.ResponseNotRead:
+        return "<not captured: MCP streaming transport closes the response before it can be read>"
     except Exception as e:
         return f"<body unavailable: {type(e).__name__}: {e}>"
 

--- a/packages/ringier-a2a-sdk/ringier_a2a_sdk/utils/mcp_errors.py
+++ b/packages/ringier-a2a-sdk/ringier_a2a_sdk/utils/mcp_errors.py
@@ -4,6 +4,11 @@ import logging
 
 import httpx
 
+try:
+    from mcp.shared.exceptions import McpError
+except ImportError:  # pragma: no cover - mcp SDK not installed in this environment
+    McpError = ()  # isinstance() against an empty tuple never matches; nested tuples flatten fine
+
 
 def flatten_exceptions(error: BaseException) -> list[BaseException]:
     """Recursively flatten ExceptionGroups into their leaf exceptions.
@@ -23,22 +28,30 @@ def flatten_exceptions(error: BaseException) -> list[BaseException]:
 
 
 def is_mcp_transport_error(error: Exception) -> bool:
-    """True if `error` is (or wraps) an httpx-raised HTTP/network error.
+    """True if `error` is (or wraps) a genuine MCP gateway/transport failure.
 
-    Distinguishes a genuine gateway/transport failure — worth retrying or
-    degrading gracefully — from an unrelated programming error (e.g. a bug in
-    our own tool-schema validation code) that happens to be raised from the
-    same try block. The latter must never be silently reported to the user as
+    Distinguishes that from an unrelated programming error (e.g. a bug in our
+    own tool-schema validation code) that happens to be raised from the same
+    try block. The latter must never be silently reported to the user as
     "temporarily unavailable" forever; it should crash loudly like any other bug.
+
+    Covers two shapes a gateway failure actually arrives as:
+    - httpx.HTTPError (HTTPStatusError, or the RequestError family: timeouts,
+      connect errors) — raised for a plain failed HTTP request.
+    - mcp.shared.exceptions.McpError — the MCP SDK's own error, raised for a
+      JSON-RPC-level failure the gateway returns *without* an HTTP error status
+      (e.g. streamable_http.py synthesizes one for a 404 rather than raising
+      HTTPStatusError, and any JSON-RPC error during initialize/tools/list —
+      gateway up, downstream MCP server down, the canonical way an MCP
+      *gateway* specifically degrades — surfaces this way too).
 
     Args:
         error: Exception raised during MCP connection/discovery
 
     Returns:
-        True if any leaf is an httpx.HTTPError (covers HTTPStatusError and the
-        RequestError family: timeouts, connect errors, etc.)
+        True if any leaf is one of the above
     """
-    return any(isinstance(leaf, httpx.HTTPError) for leaf in flatten_exceptions(error))
+    return any(isinstance(leaf, (httpx.HTTPError, McpError)) for leaf in flatten_exceptions(error))
 
 
 def is_retryable_mcp_error(error: Exception) -> bool:

--- a/packages/ringier-a2a-sdk/ringier_a2a_sdk/utils/mcp_errors.py
+++ b/packages/ringier-a2a-sdk/ringier_a2a_sdk/utils/mcp_errors.py
@@ -1,6 +1,24 @@
 """MCP error handling utilities for retry logic and user-friendly error messages."""
 
+import logging
+
 import httpx
+
+
+def _flatten_exceptions(error: BaseException) -> list[BaseException]:
+    """Recursively flatten ExceptionGroups into their leaf exceptions.
+
+    anyio's task groups (used by the MCP streamable-HTTP client) commonly nest
+    ExceptionGroups, and mixed-cancellation groups surface as BaseExceptionGroup
+    — a single-level unwrap misses both. Mirrors the existing helper in
+    packages/voice-agent/voice_agent/agent.py.
+    """
+    if isinstance(error, BaseExceptionGroup):
+        leaves: list[BaseException] = []
+        for sub in error.exceptions:
+            leaves.extend(_flatten_exceptions(sub))
+        return leaves
+    return [error]
 
 
 def is_retryable_mcp_error(error: Exception) -> bool:
@@ -23,24 +41,11 @@ def is_retryable_mcp_error(error: Exception) -> bool:
     Returns:
         True if the error is transient and should be retried
     """
-    # Handle ExceptionGroup (Python 3.11+) from anyio/MCP client
-    if hasattr(error, "__class__") and error.__class__.__name__ == "ExceptionGroup":
-        exceptions = getattr(error, "exceptions", [error])
-        for exc in exceptions:
-            if isinstance(exc, httpx.HTTPStatusError):
-                status_code = exc.response.status_code
-                # Retry 502, 503, 504 (gateway/service issues)
-                return status_code in (502, 503, 504)
-            elif isinstance(exc, httpx.TimeoutException):
-                # Retry timeouts
-                return True
-
-    # Handle direct httpx exceptions
-    if isinstance(error, httpx.HTTPStatusError):
-        status_code = error.response.status_code
-        return status_code in (502, 503, 504)
-    elif isinstance(error, httpx.TimeoutException):
-        return True
+    for leaf in _flatten_exceptions(error):
+        if isinstance(leaf, httpx.HTTPStatusError):
+            return leaf.response.status_code in (502, 503, 504)
+        elif isinstance(leaf, httpx.TimeoutException):
+            return True
 
     # Don't retry connection errors (service not running)
     # Don't retry other errors (likely permanent)
@@ -50,10 +55,9 @@ def is_retryable_mcp_error(error: Exception) -> bool:
 def get_mcp_http_status_error(error: Exception) -> httpx.HTTPStatusError | None:
     """Extract the underlying httpx.HTTPStatusError from an MCP connection error.
 
-    Unwraps ExceptionGroup (from anyio task groups used by the streamable HTTP
-    client) the same way is_retryable_mcp_error/format_mcp_error do, so callers
-    can log the server's actual response body instead of just the status code —
-    raise_for_status() alone discards it.
+    Recursively unwraps ExceptionGroups (from anyio task groups used by the
+    streamable HTTP client) so callers can log the server's actual response
+    body instead of just the status code — raise_for_status() alone discards it.
 
     Args:
         error: Exception raised during MCP connection
@@ -61,15 +65,9 @@ def get_mcp_http_status_error(error: Exception) -> httpx.HTTPStatusError | None:
     Returns:
         The httpx.HTTPStatusError if one is found, else None
     """
-    if hasattr(error, "__class__") and error.__class__.__name__ == "ExceptionGroup":
-        exceptions = getattr(error, "exceptions", [error])
-        for exc in exceptions:
-            if isinstance(exc, httpx.HTTPStatusError):
-                return exc
-
-    if isinstance(error, httpx.HTTPStatusError):
-        return error
-
+    for leaf in _flatten_exceptions(error):
+        if isinstance(leaf, httpx.HTTPStatusError):
+            return leaf
     return None
 
 
@@ -101,6 +99,29 @@ def get_mcp_error_body(http_err: httpx.HTTPStatusError, max_len: int = 2000) -> 
         return f"<body unavailable: {type(e).__name__}: {e}>"
 
 
+def log_mcp_gateway_error(logger: logging.Logger, error: Exception, context: str = "") -> None:
+    """Log an MCP gateway's actual HTTP response (status + body) for a connection error.
+
+    No-op if `error` doesn't wrap an httpx.HTTPStatusError — there's nothing to
+    add beyond what the caller already logged. Redacts the body for 401/403:
+    an auth-rejection body can echo back token/session details that shouldn't
+    land in log storage (unlike other 4xx/5xx bodies, which are safe to log —
+    see get_mcp_error_body).
+
+    Args:
+        logger: The caller's module logger
+        error: Exception raised during MCP connection
+        context: Optional short prefix identifying the caller (e.g. "for my-agent "),
+            included verbatim before the URL in the log line
+    """
+    http_err = get_mcp_http_status_error(error)
+    if http_err is None:
+        return
+    status = http_err.response.status_code
+    body = "<redacted: auth error body withheld from logs>" if status in (401, 403) else get_mcp_error_body(http_err)
+    logger.error(f"MCP gateway response {context}({http_err.request.url}): {status} body={body!r}")
+
+
 def format_mcp_error(error: Exception) -> str:
     """Format MCP connection errors into user-friendly messages.
 
@@ -110,51 +131,31 @@ def format_mcp_error(error: Exception) -> str:
     Returns:
         User-friendly error message
     """
-    # Handle ExceptionGroup (Python 3.11+) from anyio/MCP client
-    if hasattr(error, "__class__") and error.__class__.__name__ == "ExceptionGroup":
-        # Extract the first HTTPStatusError from the exception group
-        exceptions = getattr(error, "exceptions", [error])
-        for exc in exceptions:
-            if isinstance(exc, httpx.HTTPStatusError):
-                status_code = exc.response.status_code
-                url = exc.request.url
+    for leaf in _flatten_exceptions(error):
+        if isinstance(leaf, httpx.HTTPStatusError):
+            status_code = leaf.response.status_code
+            url = leaf.request.url
 
-                if status_code == 502:
-                    return f"MCP server gateway is unavailable (502 Bad Gateway for {url}). The backend service may be down or unreachable."
-                elif status_code == 503:
-                    return f"MCP server is temporarily unavailable (503 Service Unavailable for {url}). Please try again in a moment."
-                elif status_code == 504:
-                    return f"MCP server gateway timeout (504 Gateway Timeout for {url}). The backend service is not responding."
-                elif 500 <= status_code < 600:
-                    return f"MCP server error ({status_code} for {url}). The backend service encountered an error."
-                elif status_code == 401:
-                    return (
-                        f"Authentication failed when connecting to MCP server ({url}). Please check your credentials."
-                    )
-                elif status_code == 403:
-                    return f"Access denied to MCP server ({url}). You may not have permission to access this service."
-                else:
-                    return f"MCP server returned HTTP {status_code} for {url}."
-            elif isinstance(exc, (httpx.ConnectError, httpx.ConnectTimeout)):
-                return "Could not connect to MCP server. The service may be offline or network is unavailable."
-            elif isinstance(exc, httpx.TimeoutException):
-                return "MCP server connection timed out. The service may be slow or overloaded."
-
-    # Handle direct httpx exceptions
-    if isinstance(error, httpx.HTTPStatusError):
-        status_code = error.response.status_code
-        url = error.request.url
-
-        if status_code == 502:
-            return f"MCP server gateway is unavailable (502 Bad Gateway for {url}). The backend service may be down or unreachable."
-        elif status_code >= 500:
-            return f"MCP server error ({status_code} for {url})."
-        else:
-            return f"MCP server returned HTTP {status_code} for {url}."
-    elif isinstance(error, (httpx.ConnectError, httpx.ConnectTimeout)):
-        return "Could not connect to MCP server. The service may be offline or network is unavailable."
-    elif isinstance(error, httpx.TimeoutException):
-        return "MCP server connection timed out. The service may be slow or overloaded."
+            if status_code == 502:
+                return f"MCP server gateway is unavailable (502 Bad Gateway for {url}). The backend service may be down or unreachable."
+            elif status_code == 503:
+                return f"MCP server is temporarily unavailable (503 Service Unavailable for {url}). Please try again in a moment."
+            elif status_code == 504:
+                return f"MCP server gateway timeout (504 Gateway Timeout for {url}). The backend service is not responding."
+            elif 500 <= status_code < 600:
+                return f"MCP server error ({status_code} for {url}). The backend service encountered an error."
+            elif status_code == 401:
+                return (
+                    f"Authentication failed when connecting to MCP server ({url}). Please check your credentials."
+                )
+            elif status_code == 403:
+                return f"Access denied to MCP server ({url}). You may not have permission to access this service."
+            else:
+                return f"MCP server returned HTTP {status_code} for {url}."
+        elif isinstance(leaf, (httpx.ConnectError, httpx.ConnectTimeout)):
+            return "Could not connect to MCP server. The service may be offline or network is unavailable."
+        elif isinstance(leaf, httpx.TimeoutException):
+            return "MCP server connection timed out. The service may be slow or overloaded."
 
     # Fallback for other errors
     return f"Failed to connect to MCP server: {type(error).__name__}: {str(error)}"

--- a/packages/ringier-a2a-sdk/ringier_a2a_sdk/utils/mcp_errors.py
+++ b/packages/ringier-a2a-sdk/ringier_a2a_sdk/utils/mcp_errors.py
@@ -22,6 +22,25 @@ def flatten_exceptions(error: BaseException) -> list[BaseException]:
     return [error]
 
 
+def is_mcp_transport_error(error: Exception) -> bool:
+    """True if `error` is (or wraps) an httpx-raised HTTP/network error.
+
+    Distinguishes a genuine gateway/transport failure — worth retrying or
+    degrading gracefully — from an unrelated programming error (e.g. a bug in
+    our own tool-schema validation code) that happens to be raised from the
+    same try block. The latter must never be silently reported to the user as
+    "temporarily unavailable" forever; it should crash loudly like any other bug.
+
+    Args:
+        error: Exception raised during MCP connection/discovery
+
+    Returns:
+        True if any leaf is an httpx.HTTPError (covers HTTPStatusError and the
+        RequestError family: timeouts, connect errors, etc.)
+    """
+    return any(isinstance(leaf, httpx.HTTPError) for leaf in flatten_exceptions(error))
+
+
 def is_retryable_mcp_error(error: Exception) -> bool:
     """Determine if an MCP error is retryable (transient).
 
@@ -112,6 +131,13 @@ def log_mcp_gateway_error(logger: logging.Logger, error: Exception, context: str
     an auth-rejection body can echo back token/session details that shouldn't
     land in log storage (unlike other 4xx/5xx bodies, which are safe to log —
     see get_mcp_error_body).
+
+    Deliberately does NOT also redact 400: this module's whole motivating case
+    — a disabled Gatana account — arrives as a plain 400 with a genuinely safe,
+    actionable body ("Your account has been disabled..."). Blanket-redacting
+    400 would hide the exact diagnostic this was built to surface, to guard
+    against a more speculative case (some other 400 that happens to echo
+    credentials) with no way to distinguish the two by status code alone.
 
     Args:
         logger: The caller's module logger

--- a/packages/ringier-a2a-sdk/ringier_a2a_sdk/utils/mcp_errors.py
+++ b/packages/ringier-a2a-sdk/ringier_a2a_sdk/utils/mcp_errors.py
@@ -5,18 +5,19 @@ import logging
 import httpx
 
 
-def _flatten_exceptions(error: BaseException) -> list[BaseException]:
+def flatten_exceptions(error: BaseException) -> list[BaseException]:
     """Recursively flatten ExceptionGroups into their leaf exceptions.
 
     anyio's task groups (used by the MCP streamable-HTTP client) commonly nest
     ExceptionGroups, and mixed-cancellation groups surface as BaseExceptionGroup
-    — a single-level unwrap misses both. Mirrors the existing helper in
-    packages/voice-agent/voice_agent/agent.py.
+    — a single-level unwrap misses both. Public so other packages needing the
+    same unwrap (e.g. voice-agent's MCP gateway warm-up) share one copy instead
+    of drifting independently.
     """
     if isinstance(error, BaseExceptionGroup):
         leaves: list[BaseException] = []
         for sub in error.exceptions:
-            leaves.extend(_flatten_exceptions(sub))
+            leaves.extend(flatten_exceptions(sub))
         return leaves
     return [error]
 
@@ -39,11 +40,15 @@ def is_retryable_mcp_error(error: Exception) -> bool:
         error: Exception raised during MCP connection
 
     Returns:
-        True if the error is transient and should be retried
+        True if the error is transient and should be retried. A group counts
+        as retryable if *any* leaf is — e.g. a gateway + console connection
+        failing together as [HTTPStatusError(400), ConnectTimeout()] must not
+        let the non-retryable leaf mask the genuinely transient one.
     """
-    for leaf in _flatten_exceptions(error):
+    for leaf in flatten_exceptions(error):
         if isinstance(leaf, httpx.HTTPStatusError):
-            return leaf.response.status_code in (502, 503, 504)
+            if leaf.response.status_code in (502, 503, 504):
+                return True
         elif isinstance(leaf, httpx.TimeoutException):
             return True
 
@@ -65,7 +70,7 @@ def get_mcp_http_status_error(error: Exception) -> httpx.HTTPStatusError | None:
     Returns:
         The httpx.HTTPStatusError if one is found, else None
     """
-    for leaf in _flatten_exceptions(error):
+    for leaf in flatten_exceptions(error):
         if isinstance(leaf, httpx.HTTPStatusError):
             return leaf
     return None
@@ -131,7 +136,7 @@ def format_mcp_error(error: Exception) -> str:
     Returns:
         User-friendly error message
     """
-    for leaf in _flatten_exceptions(error):
+    for leaf in flatten_exceptions(error):
         if isinstance(leaf, httpx.HTTPStatusError):
             status_code = leaf.response.status_code
             url = leaf.request.url

--- a/packages/ringier-a2a-sdk/tests/test_mcp_errors.py
+++ b/packages/ringier-a2a-sdk/tests/test_mcp_errors.py
@@ -1,0 +1,134 @@
+"""Tests for MCP error handling utilities: retry classification, status/body
+extraction (including nested ExceptionGroups from anyio task groups), gateway
+response logging, and user-facing message formatting."""
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from ringier_a2a_sdk.utils.mcp_errors import (
+    format_mcp_error,
+    get_mcp_error_body,
+    get_mcp_http_status_error,
+    is_retryable_mcp_error,
+    log_mcp_gateway_error,
+)
+
+
+def _http_error(status: int, text: str = "") -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://gateway.example/mcp")
+    response = httpx.Response(status, request=request, text=text)
+    return httpx.HTTPStatusError(f"{status} error", request=request, response=response)
+
+
+def _nested_group(leaf: BaseException, depth: int = 2) -> BaseException:
+    """Wrap `leaf` in `depth` levels of ExceptionGroup — the shape anyio's nested
+    task groups actually produce for the MCP streamable-HTTP client, and the
+    exact case the pre-fix single-level unwrap missed."""
+    exc: BaseException = leaf
+    for _ in range(depth):
+        exc = ExceptionGroup("nested", [exc])
+    return exc
+
+
+class TestIsRetryableMcpError:
+    def test_5xx_direct(self):
+        assert is_retryable_mcp_error(_http_error(503)) is True
+        assert is_retryable_mcp_error(_http_error(400)) is False
+
+    def test_timeout_direct(self):
+        assert is_retryable_mcp_error(httpx.ConnectTimeout("boom")) is True
+
+    def test_nested_exception_group(self):
+        assert is_retryable_mcp_error(_nested_group(_http_error(503))) is True
+
+    def test_nested_non_retryable_status(self):
+        assert is_retryable_mcp_error(_nested_group(_http_error(400))) is False
+
+    def test_base_exception_group(self):
+        # Mixed-cancellation groups surface as BaseExceptionGroup, not ExceptionGroup.
+        err = BaseExceptionGroup("mixed", [_http_error(502)])
+        assert is_retryable_mcp_error(err) is True
+
+    def test_unrelated_error_is_not_retryable(self):
+        assert is_retryable_mcp_error(RuntimeError("boom")) is False
+
+
+class TestGetMcpHttpStatusError:
+    def test_finds_nested_status_error(self):
+        original = _http_error(400)
+        assert get_mcp_http_status_error(_nested_group(original)) is original
+
+    def test_none_when_absent(self):
+        assert get_mcp_http_status_error(_nested_group(ConnectionError("boom"))) is None
+
+    def test_direct(self):
+        original = _http_error(400)
+        assert get_mcp_http_status_error(original) is original
+
+
+class TestGetMcpErrorBody:
+    def test_reads_buffered_body(self):
+        err = _http_error(400, text='{"message": "nope"}')
+        assert get_mcp_error_body(err) == '{"message": "nope"}'
+
+    def test_truncates(self):
+        err = _http_error(400, text="x" * 10)
+        assert get_mcp_error_body(err, max_len=3) == "xxx"
+
+    def test_unread_streaming_response_is_reported_not_raised(self):
+        request = httpx.Request("POST", "https://gateway.example/mcp")
+        response = httpx.Response(400, request=request, stream=httpx.SyncByteStream())
+        err = httpx.HTTPStatusError("boom", request=request, response=response)
+        assert "not captured" in get_mcp_error_body(err)
+
+
+class TestLogMcpGatewayError:
+    def test_noop_when_no_status_error(self):
+        logger = MagicMock()
+        log_mcp_gateway_error(logger, ConnectionError("boom"))
+        logger.error.assert_not_called()
+
+    def test_logs_body_for_non_auth_status(self):
+        logger = MagicMock()
+        log_mcp_gateway_error(logger, _http_error(400, text='{"message": "disabled"}'))
+        logger.error.assert_called_once()
+        message = logger.error.call_args[0][0]
+        assert "disabled" in message
+        assert "400" in message
+
+    @pytest.mark.parametrize("status", [401, 403])
+    def test_redacts_body_for_auth_status(self, status):
+        logger = MagicMock()
+        log_mcp_gateway_error(logger, _http_error(status, text='{"message": "token abc123 invalid"}'))
+        message = logger.error.call_args[0][0]
+        assert "abc123" not in message
+        assert "redacted" in message
+
+    def test_context_prefix_included_verbatim(self):
+        logger = MagicMock()
+        log_mcp_gateway_error(logger, _http_error(400), context="for my-agent ")
+        assert "for my-agent (" in logger.error.call_args[0][0]
+
+    def test_finds_status_error_nested_in_nested_group(self):
+        # The exact regression this helper exists to fix: a body-log line that
+        # silently never fired for the streamable-HTTP client's real nesting.
+        logger = MagicMock()
+        log_mcp_gateway_error(logger, _nested_group(_http_error(400, text="oops")))
+        logger.error.assert_called_once()
+
+
+class TestFormatMcpError:
+    def test_direct_401_gets_specific_message(self):
+        assert "Authentication failed" in format_mcp_error(_http_error(401))
+
+    def test_direct_403_gets_specific_message(self):
+        assert "Access denied" in format_mcp_error(_http_error(403))
+
+    def test_nested_group_message(self):
+        assert "temporarily unavailable" in format_mcp_error(_nested_group(_http_error(503)))
+
+    def test_fallback_for_unrelated_error(self):
+        msg = format_mcp_error(RuntimeError("weird"))
+        assert "RuntimeError" in msg

--- a/packages/ringier-a2a-sdk/tests/test_mcp_errors.py
+++ b/packages/ringier-a2a-sdk/tests/test_mcp_errors.py
@@ -51,6 +51,16 @@ class TestIsRetryableMcpError:
         err = BaseExceptionGroup("mixed", [_http_error(502)])
         assert is_retryable_mcp_error(err) is True
 
+    def test_retryable_leaf_not_masked_by_earlier_non_retryable_leaf(self):
+        # Plausible when a gateway + console connection fail together: the
+        # non-retryable leaf must not mask the genuinely transient one.
+        err = ExceptionGroup("boom", [_http_error(400), httpx.ConnectTimeout("boom")])
+        assert is_retryable_mcp_error(err) is True
+
+    def test_all_non_retryable_leaves_stay_non_retryable(self):
+        err = ExceptionGroup("boom", [_http_error(400), _http_error(404)])
+        assert is_retryable_mcp_error(err) is False
+
     def test_unrelated_error_is_not_retryable(self):
         assert is_retryable_mcp_error(RuntimeError("boom")) is False
 

--- a/packages/ringier-a2a-sdk/tests/test_mcp_errors.py
+++ b/packages/ringier-a2a-sdk/tests/test_mcp_errors.py
@@ -11,6 +11,7 @@ from ringier_a2a_sdk.utils.mcp_errors import (
     format_mcp_error,
     get_mcp_error_body,
     get_mcp_http_status_error,
+    is_mcp_transport_error,
     is_retryable_mcp_error,
     log_mcp_gateway_error,
 )
@@ -30,6 +31,35 @@ def _nested_group(leaf: BaseException, depth: int = 2) -> BaseException:
     for _ in range(depth):
         exc = ExceptionGroup("nested", [exc])
     return exc
+
+
+class TestIsMcpTransportError:
+    def test_httpx_error_is_transport_error(self):
+        assert is_mcp_transport_error(_http_error(400)) is True
+        assert is_mcp_transport_error(httpx.ConnectTimeout("boom")) is True
+
+    def test_mcp_sdk_error_is_transport_error(self):
+        # The MCP SDK's own error for JSON-RPC-level failures (e.g. a
+        # synthesized "Session terminated" on a 404, or any JSON-RPC error
+        # during initialize/tools/list) — never an httpx exception, but
+        # unambiguously a remote-side gateway failure.
+        from mcp.shared.exceptions import McpError
+        from mcp.types import ErrorData
+
+        err = McpError(ErrorData(code=-32000, message="Session terminated"))
+        assert is_mcp_transport_error(err) is True
+
+    def test_nested_mcp_sdk_error_is_transport_error(self):
+        from mcp.shared.exceptions import McpError
+        from mcp.types import ErrorData
+
+        err = McpError(ErrorData(code=-32000, message="Session terminated"))
+        assert is_mcp_transport_error(_nested_group(err)) is True
+
+    def test_unrelated_error_is_not_transport_error(self):
+        # A bug in our own code (e.g. a schema-validation ValueError) raised
+        # from the same try block must not be classified as a gateway failure.
+        assert is_mcp_transport_error(ValueError("schema bug")) is False
 
 
 class TestIsRetryableMcpError:

--- a/packages/voice-agent/voice_agent/agent.py
+++ b/packages/voice-agent/voice_agent/agent.py
@@ -390,11 +390,13 @@ async def warm_up_mcp_gateway() -> None:
                     await mcp_session.list_tools()
         logger.info("MCP gateway warm-up complete (url=%s, authenticated=%s)", gateway_url, token is not None)
     except Exception as exc:
+        from ringier_a2a_sdk.utils.mcp_errors import flatten_exceptions  # noqa: PLC0415
+
         # MCP's streamablehttp_client runs inside an anyio TaskGroup, so failures arrive
         # wrapped in an ExceptionGroup whose str() only says "N sub-exception(s)" and hides
         # the real cause. Unwrap every leaf so the actual error (e.g. the gateway 500 body)
         # is visible, and include the full traceback.
-        leaves = _flatten_exceptions(exc)
+        leaves = flatten_exceptions(exc)
         detail = "; ".join(f"{type(e).__name__}: {e}" for e in leaves)
         logger.warning(
             "MCP gateway warm-up failed (url=%s): %s — ignoring",
@@ -402,16 +404,6 @@ async def warm_up_mcp_gateway() -> None:
             detail,
             exc_info=True,
         )
-
-
-def _flatten_exceptions(exc: BaseException) -> list[BaseException]:
-    """Recursively flatten ExceptionGroups into their leaf exceptions."""
-    if isinstance(exc, BaseExceptionGroup):
-        leaves: list[BaseException] = []
-        for sub in exc.exceptions:
-            leaves.extend(_flatten_exceptions(sub))
-        return leaves
-    return [exc]
 
 
 # ── Agent ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
closes #134

## Summary
- `_discover_mcp_tools` degrades to `[]` for genuine MCP gateway/transport failures — now covering both `httpx.HTTPError` **and** `mcp.shared.exceptions.McpError` (the MCP SDK's own error for JSON-RPC-level failures, e.g. a synthesized 404 or `initialize`/`tools/list` errors when the gateway is up but a downstream MCP server is down — the canonical way a *gateway* specifically degrades). Arbitrary bugs in our own code still crash loudly, as they should.
- A failure exchanging the **user's own token** is retried like a transient gateway error but never degraded — routed through a typed `_TokenExchangeError` (via a single `_exchange_token_for()` helper) rather than a boolean flag, so the "never degrade" invariant is structural.
- Fixed a stale-pin bug: `_mcp_discovery_error` is now only cleared on an actual successful resolution, not unconditionally at the top of every attempt — a degrade followed by a later raising call no longer gets silently treated as "resolved."
- `flatten_exceptions` is public and shared with `voice-agent`. `log_mcp_gateway_error()` consolidates gateway-response logging and redacts 401/403 bodies (deliberately not 400 — this PR's own motivating case is a safe, actionable 400).
- The sub-agent's system prompt gets a fixed, parameter-free `<tool_availability_warning>` when degraded — never the raw gateway error text.
- Fixed the same `rstrip("/mcp")` character-set bug in two places, and found (by actually running the old code) that my own regression test didn't cover the bug it claimed to — fixed the test too.

## Checklist
- [x] I have performed a self-review of my code
- [x] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨 No

## Test plan
- [x] `ringier-a2a-sdk`: `uv run pytest -q` — 359 passed, 2 skipped
- [x] `agent-common`: `uv run pytest -q` (excl. 2 pre-existing environment-credential gaps, unrelated) — 703 passed
- [x] `orchestrator-agent`: `uv run pytest -q` — 625 passed
- [x] `voice-agent`: `uv run pytest -q` — 8 passed
- [x] `console-backend`: `uv run pytest -q tests/test_mcp_router.py` — 14 passed

## Follow-ups filed (not blocking this PR)
- nannos#136 — pre-existing `combined_middlewares`/`None` crash in the tool-catalog + client-action path (`feature/nannos-embedded` only, doesn't exist on `main`)
- nannos#137 — design: surface discovery-time auth failures as a distinct signal instead of a generic `InternalError`
- nannos#138 — design: scope degraded-instance retries to the gateway step only (currently re-runs the whole lazy init every call while degraded); consolidate the MCP gateway URL derivation duplicated across 3 files

## Discarded review findings (with reasoning, not silently dropped)
- Widening 401/403 body redaction to include 400: **rejected** — this PR's own motivating case (disabled Gatana account) arrives as a 400 with a safe, actionable body.
- `console_gateway_server_access_service.py`'s `api_base_url`: flagged as a third buggy copy of the URL-derivation logic — checked, it's actually already correct (different but valid implementation). No fix needed there; the duplication itself is tracked in nannos#138.
- Redundant OIDC round-trips on retry; "no cooldown during a sustained outage" (now tracked concretely in nannos#138 with a design sketch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)