### PR TITLE
fix(orchestrator): bound concurrent MCP tool discovery

### DIFF
--- a/example-k8s-deployment/base/orchestrator.yaml
+++ b/example-k8s-deployment/base/orchestrator.yaml
@@ -63,6 +63,12 @@ spec:
           value: "https://YOUR_ORG_ID.gatana.ai/mcp"
         - name: MCP_GATEWAY_CLIENT_ID
           value: "gatana"
+        # Max MCP servers queried for their tool catalogue at once, process-wide.
+        # Cold discovery opens one connection per server, so an unbounded fan-out
+        # makes the memory peak scale with the gateway catalogue rather than with
+        # anything the deployment controls.
+        - name: MCP_DISCOVERY_CONCURRENCY
+          value: "5"
         - name: A2A_TIMEOUT_CONNECT
           value: "10.0"
         - name: A2A_TIMEOUT_READ

--- a/packages/orchestrator-agent/.env.template
+++ b/packages/orchestrator-agent/.env.template
@@ -64,6 +64,11 @@ ORCHESTRATOR_THINKING_LEVEL=low
 # ===================================
 MCP_GATEWAY_URL=https://alloych.gatana.ai/mcp
 MCP_GATEWAY_CLIENT_ID=gatana
+# Max MCP servers queried for their tool catalogue at once, process-wide.
+# Cold discovery opens one connection per server; an unbounded fan-out makes the
+# memory peak scale with the size of the gateway catalogue. Lower this if the
+# pod is memory-constrained, raise it to trade memory for cold-start latency.
+MCP_DISCOVERY_CONCURRENCY=5
 
 # ===================================
 # A2A Client Timeout Configuration

--- a/packages/orchestrator-agent/app/core/discovery.py
+++ b/packages/orchestrator-agent/app/core/discovery.py
@@ -32,6 +32,12 @@ from ..models.config import AgentSettings
 
 logger = logging.getLogger(__name__)
 
+# Process-wide bound on concurrent MCP tool-catalogue fetches; see
+# ToolDiscoveryService._discovery_semaphore for why this is not per-call.
+# Created lazily so the configured limit is read at first use rather than import.
+_DISCOVERY_SEMAPHORE: asyncio.Semaphore | None = None
+_DISCOVERY_SEMAPHORE_LIMIT: int | None = None
+
 
 async def _console_attribution_interceptor(request, handler):
     """Stamp the caller's cost-attribution (user_sub, conversation_id, sub_agent_id, …) on every
@@ -257,6 +263,25 @@ class ToolDiscoveryService:
                 logger.error(f"Failed to fetch MCP servers: {e}", exc_info=True)
             return []
 
+    def _discovery_semaphore(self) -> asyncio.Semaphore:
+        """Process-wide bound on concurrent MCP catalogue fetches.
+
+        Deliberately module-level, NOT per-call: discovery runs per user on cache
+        miss, so a per-invocation semaphore would still allow limit x N concurrent
+        fetches when N users hit a cold cache together — with a limit of 5, seven
+        simultaneous users already exceed the ~31 that OOMKilled the pod. What has
+        to be capped is what the *process* holds open at once.
+
+        The cost is that unrelated users' cold discoveries queue behind each other.
+        That is the intended trade: bounded memory over parallel cold starts.
+        """
+        global _DISCOVERY_SEMAPHORE, _DISCOVERY_SEMAPHORE_LIMIT
+        limit = self.config.MCP_DISCOVERY_CONCURRENCY
+        if _DISCOVERY_SEMAPHORE is None or _DISCOVERY_SEMAPHORE_LIMIT != limit:
+            _DISCOVERY_SEMAPHORE = asyncio.Semaphore(limit)
+            _DISCOVERY_SEMAPHORE_LIMIT = limit
+        return _DISCOVERY_SEMAPHORE
+
     async def _get_tools_with_retry(
         self,
         client: MultiServerMCPClient,
@@ -286,7 +311,11 @@ class ToolDiscoveryService:
 
         for attempt in range(max_retries):
             try:
-                server_tools = await client.get_tools(server_name=server_name)
+                # Hold a slot only for the fetch itself. Keeping it across the
+                # backoff sleep below would let a few flaky servers idle away the
+                # whole budget while healthy ones wait on a user-facing path.
+                async with self._discovery_semaphore():
+                    server_tools = await client.get_tools(server_name=server_name)
                 # Tag tools with server_name metadata
                 for tool in server_tools:
                     if tool.metadata is None:
@@ -433,24 +462,23 @@ class ToolDiscoveryService:
             # Gather tools from all servers with retry logic.
             # Use asyncio.gather with return_exceptions=True to handle partial failures gracefully.
             #
-            # Bounded by a semaphore: an unbounded fan-out keeps every server's session,
-            # response body, parsed schema and tool objects alive at once, so the memory
-            # peak scales with the number of servers on the gateway rather than with
-            # anything we control. On prod that reached ~31 concurrent fetches and
-            # OOMKilled the pod (2026-08-15). Results stay positionally aligned with
-            # `connections` below, so the zip() that follows is unaffected.
-            discovery_semaphore = asyncio.Semaphore(self.config.MCP_DISCOVERY_CONCURRENCY)
-
-            async def _bounded_get_tools(slug: str) -> list:
-                async with discovery_semaphore:
-                    return await self._get_tools_with_retry(client, slug)
-
+            # Each fetch takes a slot from a process-wide semaphore (see
+            # _get_tools_with_retry), so the number of MCP sessions and response
+            # bodies held open AT ONCE no longer scales with the size of the
+            # gateway catalogue. On prod an unbounded fan-out reached ~31
+            # concurrent fetches and OOMKilled the pod (2026-08-15).
+            #
+            # Note this bounds only what is IN FLIGHT. The tools that have already
+            # been fetched are retained for the whole call, so total retained
+            # memory still scales with the catalogue; it is the concurrent peak
+            # that is capped. Results stay positionally aligned with `connections`
+            # below, so the zip() that follows is unaffected.
             logger.debug(
                 f"Discovering tools from {len(connections)} MCP servers "
-                f"(max {self.config.MCP_DISCOVERY_CONCURRENCY} concurrent)"
+                f"(max {self.config.MCP_DISCOVERY_CONCURRENCY} concurrent, process-wide)"
             )
             results = await asyncio.gather(
-                *[_bounded_get_tools(slug) for slug in connections], return_exceptions=True
+                *[self._get_tools_with_retry(client, slug) for slug in connections], return_exceptions=True
             )
 
             # Process results - filter out exceptions and log failures

--- a/packages/orchestrator-agent/app/core/discovery.py
+++ b/packages/orchestrator-agent/app/core/discovery.py
@@ -430,10 +430,27 @@ class ToolDiscoveryService:
                 tool_interceptors=[_console_attribution_interceptor],
             )
 
-            # Gather tools from all servers with retry logic
-            # Use asyncio.gather with return_exceptions=True to handle partial failures gracefully
+            # Gather tools from all servers with retry logic.
+            # Use asyncio.gather with return_exceptions=True to handle partial failures gracefully.
+            #
+            # Bounded by a semaphore: an unbounded fan-out keeps every server's session,
+            # response body, parsed schema and tool objects alive at once, so the memory
+            # peak scales with the number of servers on the gateway rather than with
+            # anything we control. On prod that reached ~31 concurrent fetches and
+            # OOMKilled the pod (2026-08-15). Results stay positionally aligned with
+            # `connections` below, so the zip() that follows is unaffected.
+            discovery_semaphore = asyncio.Semaphore(self.config.MCP_DISCOVERY_CONCURRENCY)
+
+            async def _bounded_get_tools(slug: str) -> list:
+                async with discovery_semaphore:
+                    return await self._get_tools_with_retry(client, slug)
+
+            logger.debug(
+                f"Discovering tools from {len(connections)} MCP servers "
+                f"(max {self.config.MCP_DISCOVERY_CONCURRENCY} concurrent)"
+            )
             results = await asyncio.gather(
-                *[self._get_tools_with_retry(client, slug) for slug in connections], return_exceptions=True
+                *[_bounded_get_tools(slug) for slug in connections], return_exceptions=True
             )
 
             # Process results - filter out exceptions and log failures

--- a/packages/orchestrator-agent/app/models/config.py
+++ b/packages/orchestrator-agent/app/models/config.py
@@ -346,6 +346,15 @@ class AgentSettings:
     MCP_GATEWAY_URL = os.getenv("MCP_GATEWAY_URL", "https://alloych.gatana.ai/mcp")
     MCP_GATEWAY_CLIENT_ID = os.getenv("MCP_GATEWAY_CLIENT_ID", "gatana")
 
+    # How many MCP servers may be queried for their tool catalogue at the same time
+    # during a cold discovery.  Discovery opens one connection per server, so an
+    # unbounded fan-out holds every server's session, response body, parsed schema
+    # and resulting tool objects in memory simultaneously — with ~31 servers on prod
+    # that spike OOMKilled the pod twice on 2026-08-15, each time within seconds of a
+    # single request.  Bounding it trades a little cold-start latency for a peak that
+    # no longer scales with the size of the gateway catalogue.
+    MCP_DISCOVERY_CONCURRENCY = max(1, int(os.getenv("MCP_DISCOVERY_CONCURRENCY", "5")))
+
     # Gatana compression: slug of the MCP server that provides compression utilities.
     # When tools from compression-enabled servers are in use, all tools from this
     # server are automatically included so agents can access compressed outputs.

--- a/packages/orchestrator-agent/app/models/config.py
+++ b/packages/orchestrator-agent/app/models/config.py
@@ -353,7 +353,7 @@ class AgentSettings:
     # that spike OOMKilled the pod twice on 2026-08-15, each time within seconds of a
     # single request.  Bounding it trades a little cold-start latency for a peak that
     # no longer scales with the size of the gateway catalogue.
-    MCP_DISCOVERY_CONCURRENCY = max(1, int(os.getenv("MCP_DISCOVERY_CONCURRENCY", "5")))
+    MCP_DISCOVERY_CONCURRENCY = max(1, _int_env("MCP_DISCOVERY_CONCURRENCY", 5))
 
     # Gatana compression: slug of the MCP server that provides compression utilities.
     # When tools from compression-enabled servers are in use, all tools from this

--- a/packages/orchestrator-agent/tests/test_discovery.py
+++ b/packages/orchestrator-agent/tests/test_discovery.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import httpx
 import pytest
 
+import app.core.discovery as discovery_module
 from app.core.discovery import AgentDiscoveryService, ToolDiscoveryService
 from app.models.config import AgentSettings
 
@@ -266,6 +267,11 @@ class TestToolDiscoveryService:
         oauth2_client.exchange_token = AsyncMock(return_value="mcp_token")
         service = ToolDiscoveryService(config, oauth2_client)
 
+        # The semaphore is process-wide and lazily built; clear it so this test's
+        # limit applies rather than one cached by an earlier test.
+        discovery_module._DISCOVERY_SEMAPHORE = None
+        discovery_module._DISCOVERY_SEMAPHORE_LIMIT = None
+
         servers = [{"slug": f"server-{i}"} for i in range(20)]
         in_flight = 0
         max_in_flight = 0
@@ -294,7 +300,9 @@ class TestToolDiscoveryService:
 
             result = await service.discover_tools("test_token")
 
-        assert max_in_flight <= 3, f"expected at most 3 concurrent fetches, saw {max_in_flight}"
+        # Exactly 3: `<= 3` would also pass under full serialisation, which would
+        # hide a bound that throttles far harder than configured.
+        assert max_in_flight == 3, f"expected exactly 3 concurrent fetches, saw {max_in_flight}"
         assert sorted(visited) == sorted(s["slug"] for s in servers)
         assert len(result) == 20
 

--- a/packages/orchestrator-agent/tests/test_discovery.py
+++ b/packages/orchestrator-agent/tests/test_discovery.py
@@ -1,5 +1,7 @@
 """Unit tests for discovery services."""
 
+import asyncio
+
 from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
@@ -206,6 +208,7 @@ class TestToolDiscoveryService:
         config.get_oidc_issuer.return_value = "https://test.oidc.com"
         config.MCP_GATEWAY_URL = "https://mock-gateway/mcp"
         config.CONSOLE_BACKEND_URL = None
+        config.MCP_DISCOVERY_CONCURRENCY = 5
 
         oauth2_client = AsyncMock()
         oauth2_client.exchange_token = AsyncMock(return_value="mcp_token")
@@ -238,6 +241,62 @@ class TestToolDiscoveryService:
             assert len(result) == 1
             assert result[0].name == "allowed_tool"
             oauth2_client.exchange_token.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_discover_tools_bounds_concurrent_server_fetches(self):
+        """Cold discovery must not query every MCP server at once.
+
+        An unbounded fan-out holds every server's session, response body, parsed
+        schema and tool objects in memory simultaneously, so the memory peak scales
+        with the size of the gateway catalogue. That spike OOMKilled the prod pod
+        (2026-08-15). This pins the bound: with 20 servers and a limit of 3, no more
+        than 3 fetches may ever be in flight together, and every server is still
+        visited exactly once.
+        """
+        config = Mock(spec=AgentSettings)
+        config.get_oidc_client_id.return_value = "test_client_id"
+        config.get_oidc_client_secret.return_value = Mock()
+        config.get_oidc_client_secret.return_value.get_secret_value.return_value = "test_secret"
+        config.get_oidc_issuer.return_value = "https://test.oidc.com"
+        config.MCP_GATEWAY_URL = "https://mock-gateway/mcp"
+        config.CONSOLE_BACKEND_URL = None
+        config.MCP_DISCOVERY_CONCURRENCY = 3
+
+        oauth2_client = AsyncMock()
+        oauth2_client.exchange_token = AsyncMock(return_value="mcp_token")
+        service = ToolDiscoveryService(config, oauth2_client)
+
+        servers = [{"slug": f"server-{i}"} for i in range(20)]
+        in_flight = 0
+        max_in_flight = 0
+        visited: list[str] = []
+
+        async def fake_get_tools(server_name: str):
+            nonlocal in_flight, max_in_flight
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+            visited.append(server_name)
+            # Yield control so overlapping fetches actually interleave; without this
+            # the coroutines would run to completion one after another and the test
+            # would pass even with an unbounded gather.
+            await asyncio.sleep(0)
+            in_flight -= 1
+            tool = Mock()
+            tool.name = f"tool_{server_name}"
+            tool.metadata = None
+            return [tool]
+
+        with patch("app.core.discovery.MultiServerMCPClient") as mock_client:
+            mock_client_instance = Mock()
+            mock_client_instance.get_tools = AsyncMock(side_effect=fake_get_tools)
+            mock_client.return_value = mock_client_instance
+            service.fetch_available_servers = AsyncMock(return_value=servers)
+
+            result = await service.discover_tools("test_token")
+
+        assert max_in_flight <= 3, f"expected at most 3 concurrent fetches, saw {max_in_flight}"
+        assert sorted(visited) == sorted(s["slug"] for s in servers)
+        assert len(result) == 20
 
     @pytest.mark.asyncio
     async def test_discover_tools_error_handling(self):


### PR DESCRIPTION
## Problem

Cold discovery opens one connection per MCP server and awaits them all in a single **unbounded** `asyncio.gather`. Every server's session, response body, parsed schema and resulting tool objects are therefore alive at the same moment, so the memory peak scales with the size of the gateway catalogue rather than with anything we control.

In one deployment this reached **31 concurrent fetches** (30 gateway servers plus console) and OOMKilled the pod twice on 2026-08-15, each time within 5–6 s of a single request arriving. The container's own cgroup showed a **424 MiB idle floor of a 1 GiB limit** on a pod that had served zero requests, so the burst had roughly 600 MiB of headroom available — and consumed all of it. All 31 sessions were established inside a ~1 second window.

The connection-per-server design is deliberate (`langchain_mcp_adapters` doesn't record `server_name` in tool metadata, so one connection per server is how tool→server attribution is preserved). The missing concurrency bound is the defect.

## Change

Bound the fan-out with an `asyncio.Semaphore`, defaulting to 5 and overridable via `MCP_DISCOVERY_CONCURRENCY`.

Results stay positionally aligned with the `connections` dict, so the `zip()` that maps results back to server slugs is unaffected, as is the partial-failure handling (`return_exceptions=True`).

## Trade-off

A little cold-start latency on the first request of a conversation (discovery is cached for 300 s, so this is paid per cold request, not per turn), in exchange for a peak that no longer grows every time a server is added to the gateway.

## Verification

- New test drives 20 servers with a limit of 3 and asserts at most 3 fetches are ever in flight, and that every server is still visited exactly once. **Verified to fail against the unfixed code** (`expected at most 3 concurrent fetches, saw 20`).
- Full orchestrator unit suite: 626 tests pass.
- `ruff check` clean on the changed files. (`ruff format` reports these files as unformatted, but it does so on `origin/main` too — the repo's lint gate runs `ruff check` only, and reformatting whole files would balloon the diff.)
- One existing test fixture needed `MCP_DISCOVERY_CONCURRENCY` set: it uses `Mock(spec=AgentSettings)`, so the new setting otherwise arrives as a `Mock`. Fixed in the fixture rather than by adding defensive coercion to production code.

Refs alloy-ch/rcplus-alloy-infrastructure-agents#241