### PR TITLE
fix(orchestrator): guard inbound MCP SSE events against unbounded parsing

### DIFF
--- a/example-k8s-deployment/base/orchestrator.yaml
+++ b/example-k8s-deployment/base/orchestrator.yaml
@@ -69,6 +69,13 @@ spec:
         # anything the deployment controls.
         - name: MCP_DISCOVERY_CONCURRENCY
           value: "5"
+        # Reject any single inbound MCP SSE event larger than this, before the
+        # parse whose memory amplification can OOM the pod. Warn level logs the
+        # offending server slug so catalogue growth is visible early.
+        - name: MCP_SSE_MAX_EVENT_BYTES
+          value: "10485760"
+        - name: MCP_SSE_WARN_EVENT_BYTES
+          value: "1048576"
         - name: A2A_TIMEOUT_CONNECT
           value: "10.0"
         - name: A2A_TIMEOUT_READ

--- a/example-k8s-deployment/base/orchestrator.yaml
+++ b/example-k8s-deployment/base/orchestrator.yaml
@@ -76,6 +76,10 @@ spec:
           value: "10485760"
         - name: MCP_SSE_WARN_EVENT_BYTES
           value: "1048576"
+        # Hard per-server timeout (s) for a discovery tools/list fetch; the
+        # backstop that releases the discovery slot if a server stalls.
+        - name: MCP_DISCOVERY_TIMEOUT_S
+          value: "120"
         - name: A2A_TIMEOUT_CONNECT
           value: "10.0"
         - name: A2A_TIMEOUT_READ

--- a/packages/orchestrator-agent/.env.template
+++ b/packages/orchestrator-agent/.env.template
@@ -69,6 +69,11 @@ MCP_GATEWAY_CLIENT_ID=gatana
 # memory peak scale with the size of the gateway catalogue. Lower this if the
 # pod is memory-constrained, raise it to trade memory for cold-start latency.
 MCP_DISCOVERY_CONCURRENCY=5
+# Reject any single inbound MCP SSE event larger than this, BEFORE parsing it
+# (the unbounded parse of one 22MB tools/list OOMKilled the pod). Events above
+# the warn level are logged with their server slug.
+MCP_SSE_MAX_EVENT_BYTES=10485760
+MCP_SSE_WARN_EVENT_BYTES=1048576
 
 # ===================================
 # A2A Client Timeout Configuration

--- a/packages/orchestrator-agent/.env.template
+++ b/packages/orchestrator-agent/.env.template
@@ -74,6 +74,9 @@ MCP_DISCOVERY_CONCURRENCY=5
 # the warn level are logged with their server slug.
 MCP_SSE_MAX_EVENT_BYTES=10485760
 MCP_SSE_WARN_EVENT_BYTES=1048576
+# Hard per-server timeout (seconds) for a discovery tools/list fetch — the
+# backstop that releases the discovery slot if a server stalls. 0 disables.
+MCP_DISCOVERY_TIMEOUT_S=120
 
 # ===================================
 # A2A Client Timeout Configuration

--- a/packages/orchestrator-agent/AGENTS.md
+++ b/packages/orchestrator-agent/AGENTS.md
@@ -121,6 +121,21 @@ The orchestrator ships with built-in default skills (e.g., `find-skills`). These
 
 ## Critical Design Decisions
 
+### MCP Message Size Guard Is a Process-Wide Monkeypatch
+
+`app/core/mcp_guard.py` wraps `StreamableHTTPTransport._handle_sse_event` and
+`_handle_json_response` at class level, installed once during lifespan startup.
+This is deliberate: the MCP SDK offers no hook at its parse site, and the
+unbounded `JSONRPCMessage.model_validate_json` there is what OOMKilled prod
+(ringier-data/nannos#152 — one server's 21.9MB `tools/list` amplified ~7x into
+pydantic objects). Rejection must follow the SDK's parse-failure contract
+(deliver the error via `read_stream_writer`, report the stream complete) —
+raising out of the handler is swallowed by every SDK call site and triggers a
+Last-Event-ID reconnect that replays the same payload. Because it patches
+private SDK methods, treat any `mcp` version bump as a signal to re-run
+`tests/test_mcp_guard.py`, which exercises the real transport class and fails
+loudly at startup if the methods are renamed.
+
 ### One Graph Per Model Type, Not Per User
 
 Graphs are cached by `(model_name, thinking_level)`. All users share the same compiled graph. User-specific state (tools, sub-agents, preferences) is injected at runtime via `GraphRuntimeContext` and `DynamicToolDispatchMiddleware`. This is critical for performance — graph compilation is expensive.

--- a/packages/orchestrator-agent/app/core/discovery.py
+++ b/packages/orchestrator-agent/app/core/discovery.py
@@ -314,8 +314,20 @@ class ToolDiscoveryService:
                 # Hold a slot only for the fetch itself. Keeping it across the
                 # backoff sleep below would let a few flaky servers idle away the
                 # whole budget while healthy ones wait on a user-facing path.
+                #
+                # The timeout is the backstop that guarantees the slot is ever
+                # released: session.send_request waits with timeout=None, so any
+                # response that never completes (stalled server, or an inbound
+                # message the size guard rejected without being able to recover
+                # the request id) would otherwise hold this slot forever and
+                # deadlock discovery process-wide after a handful of failures.
                 async with self._discovery_semaphore():
-                    server_tools = await client.get_tools(server_name=server_name)
+                    timeout_s = self.config.MCP_DISCOVERY_TIMEOUT_S
+                    if timeout_s > 0:
+                        async with asyncio.timeout(timeout_s):
+                            server_tools = await client.get_tools(server_name=server_name)
+                    else:
+                        server_tools = await client.get_tools(server_name=server_name)
                 # Tag tools with server_name metadata
                 for tool in server_tools:
                     if tool.metadata is None:

--- a/packages/orchestrator-agent/app/core/mcp_guard.py
+++ b/packages/orchestrator-agent/app/core/mcp_guard.py
@@ -1,0 +1,118 @@
+"""Size guard for inbound MCP SSE events.
+
+Every MCP message the orchestrator receives — tool catalogues at discovery,
+tool results mid-turn, code-mode sessions — arrives as a Server-Sent Event that
+the MCP SDK parses with ``JSONRPCMessage.model_validate_json`` and NO size
+bound (``mcp/client/streamable_http.py``). Parsing amplifies the wire size
+roughly 7x into live pydantic objects, and several parses run concurrently, so
+a single oversized payload can OOM the pod.
+
+This is not hypothetical: in prod, one gateway server answered ``tools/list``
+with a 21.9 MB single event; cold-cache turns peaked at 2.3-4.2 GB RSS and the
+pod was OOMKilled repeatedly (2026-08-15/17, see
+alloy-ch/rcplus-alloy-infrastructure-agents#241). Nothing named the offending
+server, so the failure surfaced as an unexplained pod kill instead of a config
+error.
+
+The guard wraps ``StreamableHTTPTransport._handle_sse_event`` process-wide —
+the SDK offers no hook at the parse site — and does two things:
+
+* **rejects** any event over ``MCP_SSE_MAX_EVENT_BYTES`` *before* it is
+  parsed, raising :class:`McpEventTooLargeError` that names the server slug
+  and size. Discovery already degrades gracefully per server
+  (``_get_tools_with_retry`` catches and logs per-slug failures), so a
+  rejected catalogue costs one server's tools, not the process. A rejected
+  tool result surfaces as that tool call's error.
+* **logs** every event over ``MCP_SSE_WARN_EVENT_BYTES`` with the server slug,
+  so catalogue growth is a visible trend long before it reaches the cap.
+
+Sizes are measured on the raw SSE ``data`` string, before any parsing.
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import parse_qs, urlparse
+
+logger = logging.getLogger(__name__)
+
+_installed = False
+
+
+class McpEventTooLargeError(RuntimeError):
+    """An inbound MCP SSE event exceeded the configured size cap."""
+
+    def __init__(self, server: str, size_bytes: int, max_bytes: int) -> None:
+        self.server = server
+        self.size_bytes = size_bytes
+        self.max_bytes = max_bytes
+        super().__init__(
+            f"MCP SSE event from server '{server}' is {size_bytes / 2**20:.1f}MB, "
+            f"exceeding the {max_bytes / 2**20:.1f}MB cap (MCP_SSE_MAX_EVENT_BYTES). "
+            f"Refusing to parse it — an unbounded parse of this payload is what "
+            f"OOMKilled the orchestrator (see ringier-data/nannos#152). "
+            f"Trim this server's catalogue/results at the gateway, or raise the cap "
+            f"only with a matching memory-limit review."
+        )
+
+
+def _server_slug(url: str) -> str:
+    """Best-effort server identity for logs: the gateway slug, else the host.
+
+    Gateway connections carry ``includeOnlyServerSlugs=<slug>``; other MCP
+    endpoints (e.g. the console backend) are identified by their netloc.
+    """
+    try:
+        parsed = urlparse(url)
+        slugs = parse_qs(parsed.query).get("includeOnlyServerSlugs")
+        return slugs[0] if slugs else (parsed.netloc or url)
+    except Exception:
+        return url
+
+
+def install_mcp_size_guard(max_event_bytes: int, warn_event_bytes: int) -> None:
+    """Wrap the MCP transport's SSE handler with the size guard. Idempotent.
+
+    Must be called once at startup, before any MCP session is opened. Patching
+    the class method covers every ``StreamableHTTPTransport`` in the process —
+    discovery, tool dispatch and code-mode sessions alike — which is the point:
+    the failure mode does not care which path the fat payload arrives on.
+    """
+    global _installed
+    if _installed:
+        return
+
+    from mcp.client.streamable_http import StreamableHTTPTransport
+
+    original = StreamableHTTPTransport._handle_sse_event
+
+    async def _guarded_handle_sse_event(self, sse, *args, **kwargs):
+        data = getattr(sse, "data", None)
+        if data:
+            size = len(data)
+            if size > max_event_bytes:
+                server = _server_slug(self.url)
+                logger.error(
+                    "[MCP-GUARD] rejecting %.1fMB SSE event from server=%s (cap %.1fMB)",
+                    size / 2**20,
+                    server,
+                    max_event_bytes / 2**20,
+                )
+                raise McpEventTooLargeError(server, size, max_event_bytes)
+            if size > warn_event_bytes:
+                logger.warning(
+                    "[MCP-GUARD] large SSE event: %.1fMB from server=%s "
+                    "(cap %.1fMB — growth here eventually becomes an outage)",
+                    size / 2**20,
+                    _server_slug(self.url),
+                    max_event_bytes / 2**20,
+                )
+        return await original(self, sse, *args, **kwargs)
+
+    StreamableHTTPTransport._handle_sse_event = _guarded_handle_sse_event
+    _installed = True
+    logger.info(
+        "MCP SSE size guard installed (cap=%.1fMB, warn=%.1fMB)",
+        max_event_bytes / 2**20,
+        warn_event_bytes / 2**20,
+    )

--- a/packages/orchestrator-agent/app/core/mcp_guard.py
+++ b/packages/orchestrator-agent/app/core/mcp_guard.py
@@ -7,12 +7,11 @@ tool results mid-turn, code-mode sessions — is parsed by the MCP SDK with
 7x into live pydantic objects, and several parses run concurrently, so a
 single oversized payload can OOM the pod.
 
-This is not hypothetical: in prod, one gateway server answered ``tools/list``
-with a 21.9 MB single event; cold-cache turns peaked at 2.3-4.2 GB RSS and the
-pod was OOMKilled repeatedly (2026-08-15/17, see
-alloy-ch/rcplus-alloy-infrastructure-agents#241). Nothing named the offending
-server, so the failure surfaced as an unexplained pod kill instead of a config
-error.
+This is not hypothetical: one gateway server answered ``tools/list`` with a
+21.9 MB single event; cold-cache turns peaked at 2.3-4.2 GB RSS and the pod was
+OOMKilled repeatedly. Nothing named the offending server, so the failure
+surfaced as an unexplained pod kill instead of a config error. The full
+write-up is in ringier-data/nannos#152.
 
 The guard wraps the transport's two inbound parse paths process-wide — the SDK
 offers no hook at the parse site — and does two things:

--- a/packages/orchestrator-agent/app/core/mcp_guard.py
+++ b/packages/orchestrator-agent/app/core/mcp_guard.py
@@ -1,11 +1,11 @@
-"""Size guard for inbound MCP SSE events.
+"""Size guard for inbound MCP messages.
 
 Every MCP message the orchestrator receives — tool catalogues at discovery,
-tool results mid-turn, code-mode sessions — arrives as a Server-Sent Event that
-the MCP SDK parses with ``JSONRPCMessage.model_validate_json`` and NO size
-bound (``mcp/client/streamable_http.py``). Parsing amplifies the wire size
-roughly 7x into live pydantic objects, and several parses run concurrently, so
-a single oversized payload can OOM the pod.
+tool results mid-turn, code-mode sessions — is parsed by the MCP SDK with
+``JSONRPCMessage.model_validate_json`` and NO size bound
+(``mcp/client/streamable_http.py``). Parsing amplifies the wire size roughly
+7x into live pydantic objects, and several parses run concurrently, so a
+single oversized payload can OOM the pod.
 
 This is not hypothetical: in prod, one gateway server answered ``tools/list``
 with a 21.9 MB single event; cold-cache turns peaked at 2.3-4.2 GB RSS and the
@@ -14,19 +14,29 @@ alloy-ch/rcplus-alloy-infrastructure-agents#241). Nothing named the offending
 server, so the failure surfaced as an unexplained pod kill instead of a config
 error.
 
-The guard wraps ``StreamableHTTPTransport._handle_sse_event`` process-wide —
-the SDK offers no hook at the parse site — and does two things:
+The guard wraps the transport's two inbound parse paths process-wide — the SDK
+offers no hook at the parse site — and does two things:
 
-* **rejects** any event over ``MCP_SSE_MAX_EVENT_BYTES`` *before* it is
-  parsed, raising :class:`McpEventTooLargeError` that names the server slug
-  and size. Discovery already degrades gracefully per server
-  (``_get_tools_with_retry`` catches and logs per-slug failures), so a
-  rejected catalogue costs one server's tools, not the process. A rejected
-  tool result surfaces as that tool call's error.
-* **logs** every event over ``MCP_SSE_WARN_EVENT_BYTES`` with the server slug,
-  so catalogue growth is a visible trend long before it reaches the cap.
+* **rejects** any payload over ``MCP_SSE_MAX_EVENT_BYTES`` *before* it is
+  parsed. Rejection follows the SDK's own parse-failure contract: the error is
+  delivered through ``read_stream_writer`` so the pending request FAILS with
+  :class:`McpEventTooLargeError` naming the server slug and size. It must not
+  be raised out of the handler instead — every SDK call site swallows
+  exceptions (``except Exception: logger.debug``) and then *reconnects with
+  Last-Event-ID*, which would replay the same oversized payload and leave the
+  pending request hanging on a permanently-held semaphore slot. Discovery
+  already degrades gracefully per server (``_get_tools_with_retry``), so a
+  rejected catalogue costs one server's tools, not the process; a rejected
+  tool result surfaces as that call's error.
+* **logs** every payload over ``MCP_SSE_WARN_EVENT_BYTES`` with the server
+  slug, so catalogue growth is a visible trend long before it reaches the cap.
 
-Sizes are measured on the raw SSE ``data`` string, before any parsing.
+Sizes are measured in UTF-8 **bytes** (what the parser and the allocator see),
+not characters: SSE ``data`` is already str-decoded, and a multibyte-heavy
+catalogue can weigh up to 4x its character count. The exact encode is only
+paid when the cheap character-count bounds cannot decide.
+
+Setting a threshold to ``0`` disables that threshold.
 """
 
 from __future__ import annotations
@@ -36,18 +46,18 @@ from urllib.parse import parse_qs, urlparse
 
 logger = logging.getLogger(__name__)
 
-_installed = False
+_WRAP_MARKER = "_nannos_mcp_guard"
 
 
 class McpEventTooLargeError(RuntimeError):
-    """An inbound MCP SSE event exceeded the configured size cap."""
+    """An inbound MCP message exceeded the configured size cap."""
 
     def __init__(self, server: str, size_bytes: int, max_bytes: int) -> None:
         self.server = server
         self.size_bytes = size_bytes
         self.max_bytes = max_bytes
         super().__init__(
-            f"MCP SSE event from server '{server}' is {size_bytes / 2**20:.1f}MB, "
+            f"MCP message from server '{server}' is {size_bytes / 2**20:.1f}MB, "
             f"exceeding the {max_bytes / 2**20:.1f}MB cap (MCP_SSE_MAX_EVENT_BYTES). "
             f"Refusing to parse it — an unbounded parse of this payload is what "
             f"OOMKilled the orchestrator (see ringier-data/nannos#152). "
@@ -70,49 +80,117 @@ def _server_slug(url: str) -> str:
         return url
 
 
-def install_mcp_size_guard(max_event_bytes: int, warn_event_bytes: int) -> None:
-    """Wrap the MCP transport's SSE handler with the size guard. Idempotent.
+def _utf8_size(data: str | bytes, decide_at: int) -> int:
+    """Size of *data* in bytes, paying the exact encode only when it matters.
 
-    Must be called once at startup, before any MCP session is opened. Patching
-    the class method covers every ``StreamableHTTPTransport`` in the process —
-    discovery, tool dispatch and code-mode sessions alike — which is the point:
-    the failure mode does not care which path the fat payload arrives on.
+    For ``str``, character count is a lower bound and 4x it an upper bound on
+    the UTF-8 byte size; when the upper bound stays below ``decide_at`` the
+    exact size is irrelevant and the lower bound is returned as-is.
     """
-    global _installed
-    if _installed:
-        return
+    if isinstance(data, bytes):
+        return len(data)
+    chars = len(data)
+    if decide_at <= 0 or chars * 4 < decide_at:
+        return chars
+    return len(data.encode("utf-8", errors="replace"))
 
+
+class _SizeVerdict:
+    __slots__ = ("error", "size")
+
+    def __init__(self, size: int, error: McpEventTooLargeError | None) -> None:
+        self.size = size
+        self.error = error
+
+
+def _check(data: str | bytes, url: str, max_bytes: int, warn_bytes: int) -> _SizeVerdict:
+    decide_at = min(t for t in (max_bytes, warn_bytes) if t > 0) if (max_bytes > 0 or warn_bytes > 0) else 0
+    size = _utf8_size(data, decide_at)
+    if max_bytes > 0 and size > max_bytes:
+        return _SizeVerdict(size, McpEventTooLargeError(_server_slug(url), size, max_bytes))
+    if warn_bytes > 0 and size > warn_bytes:
+        logger.warning(
+            "[MCP-GUARD] large MCP message: %.1fMB from server=%s "
+            "(warn threshold %.1fMB, cap %s — growth here eventually becomes an outage)",
+            size / 2**20,
+            _server_slug(url),
+            warn_bytes / 2**20,
+            f"{max_bytes / 2**20:.1f}MB" if max_bytes > 0 else "disabled",
+        )
+    return _SizeVerdict(size, None)
+
+
+def install_mcp_size_guard(max_event_bytes: int, warn_event_bytes: int) -> None:
+    """Wrap the MCP transport's inbound parse paths with the size guard.
+
+    Idempotent. Must be called once at startup, before any MCP session is
+    opened. Patching the class methods covers every ``StreamableHTTPTransport``
+    in the process — discovery, tool dispatch and code-mode sessions alike —
+    which is the point: the failure mode does not care which path the fat
+    payload arrives on.
+
+    ``max_event_bytes <= 0`` disables rejection; ``warn_event_bytes <= 0``
+    disables the warning. A warn threshold above an enabled cap is clamped to
+    the cap (an event cannot warn after it has already been rejected).
+    """
     from mcp.client.streamable_http import StreamableHTTPTransport
 
-    original = StreamableHTTPTransport._handle_sse_event
+    if getattr(StreamableHTTPTransport._handle_sse_event, _WRAP_MARKER, False):
+        return
 
-    async def _guarded_handle_sse_event(self, sse, *args, **kwargs):
-        data = getattr(sse, "data", None)
-        if data:
-            size = len(data)
-            if size > max_event_bytes:
-                server = _server_slug(self.url)
-                logger.error(
-                    "[MCP-GUARD] rejecting %.1fMB SSE event from server=%s (cap %.1fMB)",
-                    size / 2**20,
-                    server,
-                    max_event_bytes / 2**20,
-                )
-                raise McpEventTooLargeError(server, size, max_event_bytes)
-            if size > warn_event_bytes:
-                logger.warning(
-                    "[MCP-GUARD] large SSE event: %.1fMB from server=%s "
-                    "(cap %.1fMB — growth here eventually becomes an outage)",
-                    size / 2**20,
-                    _server_slug(self.url),
-                    max_event_bytes / 2**20,
-                )
-        return await original(self, sse, *args, **kwargs)
+    if max_event_bytes > 0 and warn_event_bytes > max_event_bytes:
+        logger.warning(
+            "MCP_SSE_WARN_EVENT_BYTES (%d) exceeds MCP_SSE_MAX_EVENT_BYTES (%d); clamping warn to the cap",
+            warn_event_bytes,
+            max_event_bytes,
+        )
+        warn_event_bytes = max_event_bytes
 
+    original_sse = StreamableHTTPTransport._handle_sse_event
+    original_json = StreamableHTTPTransport._handle_json_response
+
+    async def _guarded_handle_sse_event(self, sse, read_stream_writer, *args, **kwargs):
+        # Only "message" events are ever parsed by the SDK; priming/unknown
+        # events pass through untouched.
+        if getattr(sse, "event", None) == "message" and getattr(sse, "data", None):
+            verdict = _check(sse.data, self.url, max_event_bytes, warn_event_bytes)
+            if verdict.error is not None:
+                logger.error("[MCP-GUARD] %s", verdict.error)
+                try:
+                    # The SDK's own parse-failure contract: deliver the error to
+                    # the session so the pending request fails immediately...
+                    await read_stream_writer.send(verdict.error)
+                except Exception:  # writer already closed — nothing to notify
+                    logger.debug("[MCP-GUARD] read_stream_writer closed while rejecting oversized event")
+                # ...and report the stream complete so the caller closes the
+                # response instead of reconnecting with Last-Event-ID and
+                # replaying the same oversized payload.
+                return True
+        return await original_sse(self, sse, read_stream_writer, *args, **kwargs)
+
+    async def _guarded_handle_json_response(self, response, read_stream_writer, *args, **kwargs):
+        # Same parse, different transport shape (application/json bodies).
+        # httpx caches aread(), so the original's own aread() is a no-op replay.
+        try:
+            content = await response.aread()
+        except Exception:
+            return await original_json(self, response, read_stream_writer, *args, **kwargs)
+        verdict = _check(content, self.url, max_event_bytes, warn_event_bytes)
+        if verdict.error is not None:
+            logger.error("[MCP-GUARD] %s", verdict.error)
+            try:
+                await read_stream_writer.send(verdict.error)
+            except Exception:
+                logger.debug("[MCP-GUARD] read_stream_writer closed while rejecting oversized response")
+            return None
+        return await original_json(self, response, read_stream_writer, *args, **kwargs)
+
+    setattr(_guarded_handle_sse_event, _WRAP_MARKER, True)
+    setattr(_guarded_handle_json_response, _WRAP_MARKER, True)
     StreamableHTTPTransport._handle_sse_event = _guarded_handle_sse_event
-    _installed = True
+    StreamableHTTPTransport._handle_json_response = _guarded_handle_json_response
     logger.info(
-        "MCP SSE size guard installed (cap=%.1fMB, warn=%.1fMB)",
-        max_event_bytes / 2**20,
-        warn_event_bytes / 2**20,
+        "MCP message size guard installed (cap=%s, warn=%s)",
+        f"{max_event_bytes / 2**20:.1f}MB" if max_event_bytes > 0 else "disabled",
+        f"{warn_event_bytes / 2**20:.1f}MB" if warn_event_bytes > 0 else "disabled",
     )

--- a/packages/orchestrator-agent/app/core/mcp_guard.py
+++ b/packages/orchestrator-agent/app/core/mcp_guard.py
@@ -125,20 +125,26 @@ def _check(data: str | bytes, url: str, max_bytes: int, warn_bytes: int) -> _Siz
 # and the first "id" key in a response document is the top-level one whenever
 # "result" follows it. A bounded head-scan plus full-scan fallback is O(n) on the
 # raw string with NO parse amplification — the entire point of rejecting here.
-_ID_RE = re.compile(r'"id"\s*:\s*(\d+|"(?:[^"\\]|\\.){1,256}")')
+_ID_RE = re.compile(r'"id"\s*:\s*(-?\d+|"(?:[^"\\]|\\.){1,256}")')
 
 
 def _extract_request_id(data: str | bytes):
     """Best-effort top-level ``id`` of a JSONRPC payload, without parsing it.
 
     Returns an ``int`` or ``str``, or ``None`` when nothing safe was found.
-    Wrong-id extraction is tolerable: the synthetic error then matches no
-    pending request, which degrades to the delivered-Exception fallback path
-    (same behaviour as not finding an id at all).
+
+    Known imprecision, accepted deliberately: when the head scan misses and the
+    full-string fallback picks up a body-level ``"id"``, the value can collide
+    with a DIFFERENT in-flight request on a multiplexed session (ids are small
+    sequential ints). The blast radius is bounded: that innocent request fails
+    fast with a correctly-attributed size error, and the truly pending one is
+    reaped by the MCP_DISCOVERY_TIMEOUT_S backstop. Escaped-string ids are also
+    returned verbatim (not unescaped) and will simply match nothing —
+    degrading, like every miss here, to the bare-exception fallback.
     """
     if isinstance(data, bytes):
-        data = data[:4096].decode("utf-8", errors="replace")
-        m = _ID_RE.search(data)
+        head = data[:4096].decode("utf-8", errors="replace")
+        m = _ID_RE.search(head) or _ID_RE.search(data.decode("utf-8", errors="replace"))
     else:
         m = _ID_RE.search(data, 0, 4096) or _ID_RE.search(data)
     if not m:

--- a/packages/orchestrator-agent/app/core/mcp_guard.py
+++ b/packages/orchestrator-agent/app/core/mcp_guard.py
@@ -42,6 +42,7 @@ Setting a threshold to ``0`` disables that threshold.
 from __future__ import annotations
 
 import logging
+import re
 from urllib.parse import parse_qs, urlparse
 
 logger = logging.getLogger(__name__)
@@ -120,6 +121,71 @@ def _check(data: str | bytes, url: str, max_bytes: int, warn_bytes: int) -> _Siz
     return _SizeVerdict(size, None)
 
 
+# Top-level JSONRPC ids in practice appear early ({"jsonrpc":"2.0","id":..,...}),
+# and the first "id" key in a response document is the top-level one whenever
+# "result" follows it. A bounded head-scan plus full-scan fallback is O(n) on the
+# raw string with NO parse amplification — the entire point of rejecting here.
+_ID_RE = re.compile(r'"id"\s*:\s*(\d+|"(?:[^"\\]|\\.){1,256}")')
+
+
+def _extract_request_id(data: str | bytes):
+    """Best-effort top-level ``id`` of a JSONRPC payload, without parsing it.
+
+    Returns an ``int`` or ``str``, or ``None`` when nothing safe was found.
+    Wrong-id extraction is tolerable: the synthetic error then matches no
+    pending request, which degrades to the delivered-Exception fallback path
+    (same behaviour as not finding an id at all).
+    """
+    if isinstance(data, bytes):
+        data = data[:4096].decode("utf-8", errors="replace")
+        m = _ID_RE.search(data)
+    else:
+        m = _ID_RE.search(data, 0, 4096) or _ID_RE.search(data)
+    if not m:
+        return None
+    raw = m.group(1)
+    if raw.startswith('"'):
+        return raw[1:-1]
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+async def _reject(read_stream_writer, data, error: McpEventTooLargeError) -> None:
+    """Fail the pending request per the SDK's routing rules.
+
+    Only a ``JSONRPCError`` whose ``id`` matches the pending request completes
+    ``send_request`` (which otherwise waits with ``timeout=None``); a bare
+    ``Exception`` on the read stream lands in ``_handle_incoming``, a no-op.
+    So: synthesize a JSONRPCError with the id recovered from the raw payload,
+    falling back to the bare exception when no id can be recovered.
+    """
+    from mcp.shared.message import SessionMessage
+    from mcp.types import INTERNAL_ERROR, ErrorData, JSONRPCError, JSONRPCMessage
+
+    logger.error("[MCP-GUARD] %s", error)
+    request_id = _extract_request_id(data)
+    try:
+        if request_id is not None:
+            reply = JSONRPCMessage(
+                JSONRPCError(
+                    jsonrpc="2.0",
+                    id=request_id,
+                    error=ErrorData(code=INTERNAL_ERROR, message=str(error)),
+                )
+            )
+            await read_stream_writer.send(SessionMessage(reply))
+        else:
+            logger.warning(
+                "[MCP-GUARD] could not recover a request id from the oversized payload; "
+                "delivering a bare exception (the pending request will rely on the caller's timeout)"
+            )
+            await read_stream_writer.send(error)
+    except Exception:  # writer already closed — nothing to notify
+        logger.debug("[MCP-GUARD] read_stream_writer closed while rejecting oversized message")
+
+
 def install_mcp_size_guard(max_event_bytes: int, warn_event_bytes: int) -> None:
     """Wrap the MCP transport's inbound parse paths with the size guard.
 
@@ -155,16 +221,11 @@ def install_mcp_size_guard(max_event_bytes: int, warn_event_bytes: int) -> None:
         if getattr(sse, "event", None) == "message" and getattr(sse, "data", None):
             verdict = _check(sse.data, self.url, max_event_bytes, warn_event_bytes)
             if verdict.error is not None:
-                logger.error("[MCP-GUARD] %s", verdict.error)
-                try:
-                    # The SDK's own parse-failure contract: deliver the error to
-                    # the session so the pending request fails immediately...
-                    await read_stream_writer.send(verdict.error)
-                except Exception:  # writer already closed — nothing to notify
-                    logger.debug("[MCP-GUARD] read_stream_writer closed while rejecting oversized event")
-                # ...and report the stream complete so the caller closes the
-                # response instead of reconnecting with Last-Event-ID and
-                # replaying the same oversized payload.
+                # Fail the pending request (JSONRPCError routed by request id —
+                # see _reject) and report the stream complete so the caller
+                # closes the response instead of reconnecting with
+                # Last-Event-ID and replaying the same oversized payload.
+                await _reject(read_stream_writer, sse.data, verdict.error)
                 return True
         return await original_sse(self, sse, read_stream_writer, *args, **kwargs)
 
@@ -177,11 +238,7 @@ def install_mcp_size_guard(max_event_bytes: int, warn_event_bytes: int) -> None:
             return await original_json(self, response, read_stream_writer, *args, **kwargs)
         verdict = _check(content, self.url, max_event_bytes, warn_event_bytes)
         if verdict.error is not None:
-            logger.error("[MCP-GUARD] %s", verdict.error)
-            try:
-                await read_stream_writer.send(verdict.error)
-            except Exception:
-                logger.debug("[MCP-GUARD] read_stream_writer closed while rejecting oversized response")
+            await _reject(read_stream_writer, content, verdict.error)
             return None
         return await original_json(self, response, read_stream_writer, *args, **kwargs)
 

--- a/packages/orchestrator-agent/app/models/config.py
+++ b/packages/orchestrator-agent/app/models/config.py
@@ -354,6 +354,12 @@ class AgentSettings:
     MCP_SSE_MAX_EVENT_BYTES = _int_env("MCP_SSE_MAX_EVENT_BYTES", 10 * 1024 * 1024)
     MCP_SSE_WARN_EVENT_BYTES = _int_env("MCP_SSE_WARN_EVENT_BYTES", 1024 * 1024)
 
+    # Hard per-server timeout on a discovery tools/list fetch. The MCP session
+    # awaits responses with timeout=None, so without this backstop a stalled or
+    # guard-rejected response would hold a discovery-semaphore slot forever.
+    # 0 disables (not recommended).
+    MCP_DISCOVERY_TIMEOUT_S = _int_env("MCP_DISCOVERY_TIMEOUT_S", 120)
+
     # How many MCP servers may be queried for their tool catalogue at the same time
     # during a cold discovery.  Discovery opens one connection per server, so an
     # unbounded fan-out holds every server's session, response body, parsed schema

--- a/packages/orchestrator-agent/app/models/config.py
+++ b/packages/orchestrator-agent/app/models/config.py
@@ -346,12 +346,13 @@ class AgentSettings:
     MCP_GATEWAY_URL = os.getenv("MCP_GATEWAY_URL", "https://alloych.gatana.ai/mcp")
     MCP_GATEWAY_CLIENT_ID = os.getenv("MCP_GATEWAY_CLIENT_ID", "gatana")
 
-    # Inbound MCP SSE event size guard (see app/core/mcp_guard.py). Events over
+    # Inbound MCP message size guard (see app/core/mcp_guard.py). Messages over
     # the cap are rejected BEFORE the pydantic parse whose ~7x amplification
-    # OOMKilled the pod (ringier-data/nannos#152); events over the warn level are
-    # logged with their server slug so catalogue growth is visible early.
-    MCP_SSE_MAX_EVENT_BYTES = max(1, _int_env("MCP_SSE_MAX_EVENT_BYTES", 10 * 1024 * 1024))
-    MCP_SSE_WARN_EVENT_BYTES = max(1, _int_env("MCP_SSE_WARN_EVENT_BYTES", 1024 * 1024))
+    # OOMKilled the pod (ringier-data/nannos#152); messages over the warn level
+    # are logged with their server slug so catalogue growth is visible early.
+    # Sizes are UTF-8 bytes. 0 disables the respective threshold.
+    MCP_SSE_MAX_EVENT_BYTES = _int_env("MCP_SSE_MAX_EVENT_BYTES", 10 * 1024 * 1024)
+    MCP_SSE_WARN_EVENT_BYTES = _int_env("MCP_SSE_WARN_EVENT_BYTES", 1024 * 1024)
 
     # How many MCP servers may be queried for their tool catalogue at the same time
     # during a cold discovery.  Discovery opens one connection per server, so an

--- a/packages/orchestrator-agent/app/models/config.py
+++ b/packages/orchestrator-agent/app/models/config.py
@@ -346,6 +346,13 @@ class AgentSettings:
     MCP_GATEWAY_URL = os.getenv("MCP_GATEWAY_URL", "https://alloych.gatana.ai/mcp")
     MCP_GATEWAY_CLIENT_ID = os.getenv("MCP_GATEWAY_CLIENT_ID", "gatana")
 
+    # Inbound MCP SSE event size guard (see app/core/mcp_guard.py). Events over
+    # the cap are rejected BEFORE the pydantic parse whose ~7x amplification
+    # OOMKilled the pod (ringier-data/nannos#152); events over the warn level are
+    # logged with their server slug so catalogue growth is visible early.
+    MCP_SSE_MAX_EVENT_BYTES = max(1, _int_env("MCP_SSE_MAX_EVENT_BYTES", 10 * 1024 * 1024))
+    MCP_SSE_WARN_EVENT_BYTES = max(1, _int_env("MCP_SSE_WARN_EVENT_BYTES", 1024 * 1024))
+
     # How many MCP servers may be queried for their tool catalogue at the same time
     # during a cold discovery.  Discovery opens one connection per server, so an
     # unbounded fan-out holds every server's session, response body, parsed schema

--- a/packages/orchestrator-agent/main.py
+++ b/packages/orchestrator-agent/main.py
@@ -98,6 +98,16 @@ def create_lifespan(
         # Startup: Initialize and start budget guard singleton
         logger.info("Starting application lifespan...")
 
+        # Guard inbound MCP SSE events before anything can open an MCP session:
+        # an unbounded parse of one oversized event is what OOMKilled the pod
+        # (ringier-data/nannos#152). Process-wide by design.
+        from app.core.mcp_guard import install_mcp_size_guard
+
+        install_mcp_size_guard(
+            max_event_bytes=AgentSettings.MCP_SSE_MAX_EVENT_BYTES,
+            warn_event_bytes=AgentSettings.MCP_SSE_WARN_EVENT_BYTES,
+        )
+
         # Fail fast if the Model Gateway isn't configured: it's the sole path
         # for LLM traffic, so surface a missing LLM_GATEWAY_URL loudly at boot rather than
         # as an opaque per-request failure (or a misleading "no models registered").

--- a/packages/orchestrator-agent/tests/test_discovery.py
+++ b/packages/orchestrator-agent/tests/test_discovery.py
@@ -210,6 +210,7 @@ class TestToolDiscoveryService:
         config.MCP_GATEWAY_URL = "https://mock-gateway/mcp"
         config.CONSOLE_BACKEND_URL = None
         config.MCP_DISCOVERY_CONCURRENCY = 5
+        config.MCP_DISCOVERY_TIMEOUT_S = 120
 
         oauth2_client = AsyncMock()
         oauth2_client.exchange_token = AsyncMock(return_value="mcp_token")
@@ -262,6 +263,7 @@ class TestToolDiscoveryService:
         config.MCP_GATEWAY_URL = "https://mock-gateway/mcp"
         config.CONSOLE_BACKEND_URL = None
         config.MCP_DISCOVERY_CONCURRENCY = 3
+        config.MCP_DISCOVERY_TIMEOUT_S = 120
 
         oauth2_client = AsyncMock()
         oauth2_client.exchange_token = AsyncMock(return_value="mcp_token")

--- a/packages/orchestrator-agent/tests/test_mcp_guard.py
+++ b/packages/orchestrator-agent/tests/test_mcp_guard.py
@@ -295,3 +295,15 @@ async def test_session_pending_request_actually_fails(real_transport):
 
     err = result["error"]
     assert "fat-server" in str(err), f"pending request must fail with the guard's message, got: {err!r}"
+
+
+def test_extract_request_id_variants():
+    from app.core.mcp_guard import _extract_request_id
+
+    assert _extract_request_id('{"jsonrpc":"2.0","id":42,"result":{}}') == 42
+    assert _extract_request_id('{"jsonrpc":"2.0","id":-7,"result":{}}') == -7
+    assert _extract_request_id('{"jsonrpc":"2.0","id":"abc","result":{}}') == "abc"
+    assert _extract_request_id("no ids here") is None
+    # bytes path scans past the 4KB head, matching the str path's behaviour
+    late = b'{"jsonrpc":"2.0","result":{"pad":"' + b"x" * 5000 + b'"},"id":9}'
+    assert _extract_request_id(late) == 9

--- a/packages/orchestrator-agent/tests/test_mcp_guard.py
+++ b/packages/orchestrator-agent/tests/test_mcp_guard.py
@@ -1,0 +1,122 @@
+"""Tests for the inbound MCP SSE event size guard.
+
+The guard exists because one gateway server's 21.9MB ``tools/list`` event,
+parsed without any bound, transiently allocated gigabytes and OOMKilled the
+prod pod (ringier-data/nannos#152). These tests pin the contract:
+
+* under the cap        -> passes through to the original handler untouched
+* over the warn level  -> passes through, but is logged with the server slug
+* over the cap         -> rejected BEFORE the original handler (i.e. before the
+                          parse) with an error naming the server and sizes
+"""
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+import app.core.mcp_guard as mcp_guard
+from app.core.mcp_guard import McpEventTooLargeError, _server_slug, install_mcp_size_guard
+
+CAP = 1000
+WARN = 100
+
+GATEWAY_URL = "https://gateway.example/mcp?includeOnlyServerSlugs=fat-server"
+CONSOLE_URL = "http://console.example/mcp"
+
+
+@pytest.fixture
+def transport_cls(monkeypatch):
+    """Install the guard against a stand-in transport class.
+
+    The guard patches ``StreamableHTTPTransport._handle_sse_event`` at class
+    level; using a stand-in keeps the real SDK class pristine for other tests
+    and lets each test start from an unguarded state (the module is idempotent
+    via a global flag, which we reset).
+    """
+    calls: list[str] = []
+
+    class FakeTransport:
+        def __init__(self, url: str) -> None:
+            self.url = url
+
+        async def _handle_sse_event(self, sse, *args, **kwargs):
+            calls.append(sse.data)
+            return True
+
+    monkeypatch.setattr(mcp_guard, "_installed", False)
+
+    import mcp.client.streamable_http as real_module
+
+    monkeypatch.setattr(real_module, "StreamableHTTPTransport", FakeTransport)
+    install_mcp_size_guard(max_event_bytes=CAP, warn_event_bytes=WARN)
+    FakeTransport.handled = calls  # type: ignore[attr-defined]
+    return FakeTransport
+
+
+def sse(data: str):
+    return SimpleNamespace(data=data, event="message", id=None)
+
+
+async def test_small_event_passes_through(transport_cls):
+    t = transport_cls(GATEWAY_URL)
+    assert await t._handle_sse_event(sse("x" * 10)) is True
+    assert transport_cls.handled == ["x" * 10]
+
+
+async def test_warn_level_logs_slug_but_passes(transport_cls, caplog):
+    t = transport_cls(GATEWAY_URL)
+    with caplog.at_level(logging.WARNING, logger="app.core.mcp_guard"):
+        assert await t._handle_sse_event(sse("x" * (WARN + 1))) is True
+    assert transport_cls.handled, "event over the warn level must still be handled"
+    assert any("fat-server" in r.getMessage() for r in caplog.records)
+
+
+async def test_oversized_event_rejected_before_parse(transport_cls, caplog):
+    t = transport_cls(GATEWAY_URL)
+    with caplog.at_level(logging.ERROR, logger="app.core.mcp_guard"):
+        with pytest.raises(McpEventTooLargeError) as exc:
+            await t._handle_sse_event(sse("x" * (CAP + 1)))
+    # The whole point: the original handler (the parse) must never see it.
+    assert transport_cls.handled == []
+    assert exc.value.server == "fat-server"
+    assert exc.value.size_bytes == CAP + 1
+    assert "fat-server" in str(exc.value)
+
+
+async def test_empty_priming_event_passes(transport_cls):
+    """Resumability priming events have no data and must not be broken."""
+    t = transport_cls(GATEWAY_URL)
+    assert await t._handle_sse_event(SimpleNamespace(data="", event="message", id="7")) is True
+
+
+async def test_non_gateway_url_falls_back_to_host(transport_cls):
+    t = transport_cls(CONSOLE_URL)
+    with pytest.raises(McpEventTooLargeError) as exc:
+        await t._handle_sse_event(sse("x" * (CAP + 1)))
+    assert exc.value.server == "console.example"
+
+
+def test_server_slug_extraction():
+    assert _server_slug(GATEWAY_URL) == "fat-server"
+    assert _server_slug(CONSOLE_URL) == "console.example"
+    assert _server_slug("not a url") == "not a url"
+
+
+def test_install_is_idempotent(monkeypatch):
+    monkeypatch.setattr(mcp_guard, "_installed", False)
+
+    class FakeTransport:
+        def __init__(self, url):
+            self.url = url
+
+        async def _handle_sse_event(self, sse, *a, **kw):
+            return True
+
+    import mcp.client.streamable_http as real_module
+
+    monkeypatch.setattr(real_module, "StreamableHTTPTransport", FakeTransport)
+    install_mcp_size_guard(max_event_bytes=CAP, warn_event_bytes=WARN)
+    first = FakeTransport._handle_sse_event
+    install_mcp_size_guard(max_event_bytes=CAP, warn_event_bytes=WARN)
+    assert FakeTransport._handle_sse_event is first, "second install must not re-wrap"

--- a/packages/orchestrator-agent/tests/test_mcp_guard.py
+++ b/packages/orchestrator-agent/tests/test_mcp_guard.py
@@ -1,22 +1,35 @@
-"""Tests for the inbound MCP SSE event size guard.
+"""Tests for the inbound MCP message size guard.
 
 The guard exists because one gateway server's 21.9MB ``tools/list`` event,
 parsed without any bound, transiently allocated gigabytes and OOMKilled the
-prod pod (ringier-data/nannos#152). These tests pin the contract:
+prod pod (ringier-data/nannos#152).
 
-* under the cap        -> passes through to the original handler untouched
-* over the warn level  -> passes through, but is logged with the server slug
-* over the cap         -> rejected BEFORE the original handler (i.e. before the
-                          parse) with an error naming the server and sizes
+These tests run against the REAL ``StreamableHTTPTransport`` (not a stub):
+the rejection contract only works if it matches the SDK's call sites, which
+swallow raised exceptions and reconnect-with-replay. The contract under test:
+
+* under every threshold -> parsed and delivered to the session, untouched
+* over the warn level   -> delivered, but logged with the server slug
+* over the cap          -> NOT parsed; McpEventTooLargeError is delivered via
+                           read_stream_writer (failing the pending request)
+                           and the handler reports the stream complete (True),
+                           so the SDK closes the response instead of
+                           reconnecting with Last-Event-ID and replaying.
 """
 
+import json
 import logging
 from types import SimpleNamespace
 
+import anyio
 import pytest
 
-import app.core.mcp_guard as mcp_guard
-from app.core.mcp_guard import McpEventTooLargeError, _server_slug, install_mcp_size_guard
+from app.core.mcp_guard import (
+    McpEventTooLargeError,
+    _server_slug,
+    _utf8_size,
+    install_mcp_size_guard,
+)
 
 CAP = 1000
 WARN = 100
@@ -24,77 +37,174 @@ WARN = 100
 GATEWAY_URL = "https://gateway.example/mcp?includeOnlyServerSlugs=fat-server"
 CONSOLE_URL = "http://console.example/mcp"
 
+# A minimal, valid JSONRPC response the SDK can parse end-to-end.
+SMALL_RESULT = json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"ok": True}})
+
 
 @pytest.fixture
-def transport_cls(monkeypatch):
-    """Install the guard against a stand-in transport class.
+def real_transport(monkeypatch):
+    """A real StreamableHTTPTransport with the guard installed.
 
-    The guard patches ``StreamableHTTPTransport._handle_sse_event`` at class
-    level; using a stand-in keeps the real SDK class pristine for other tests
-    and lets each test start from an unguarded state (the module is idempotent
-    via a global flag, which we reset).
+    The guard patches the SDK class in-process; restore the originals after
+    each test so the patch (and its captured thresholds) cannot leak into
+    other test modules.
     """
-    calls: list[str] = []
+    import mcp.client.streamable_http as sdk
 
-    class FakeTransport:
-        def __init__(self, url: str) -> None:
-            self.url = url
-
-        async def _handle_sse_event(self, sse, *args, **kwargs):
-            calls.append(sse.data)
-            return True
-
-    monkeypatch.setattr(mcp_guard, "_installed", False)
-
-    import mcp.client.streamable_http as real_module
-
-    monkeypatch.setattr(real_module, "StreamableHTTPTransport", FakeTransport)
+    monkeypatch.setattr(sdk.StreamableHTTPTransport, "_handle_sse_event", sdk.StreamableHTTPTransport._handle_sse_event)
+    monkeypatch.setattr(
+        sdk.StreamableHTTPTransport, "_handle_json_response", sdk.StreamableHTTPTransport._handle_json_response
+    )
     install_mcp_size_guard(max_event_bytes=CAP, warn_event_bytes=WARN)
-    FakeTransport.handled = calls  # type: ignore[attr-defined]
-    return FakeTransport
+
+    def make(url: str = GATEWAY_URL):
+        return sdk.StreamableHTTPTransport(url)
+
+    return make
 
 
-def sse(data: str):
-    return SimpleNamespace(data=data, event="message", id=None)
+def sse(data: str, event: str = "message", id: str | None = "evt-1"):
+    return SimpleNamespace(data=data, event=event, id=id, retry=None)
 
 
-async def test_small_event_passes_through(transport_cls):
-    t = transport_cls(GATEWAY_URL)
-    assert await t._handle_sse_event(sse("x" * 10)) is True
-    assert transport_cls.handled == ["x" * 10]
+async def drain_one(receiver):
+    with anyio.fail_after(2):
+        return await receiver.receive()
 
 
-async def test_warn_level_logs_slug_but_passes(transport_cls, caplog):
-    t = transport_cls(GATEWAY_URL)
+async def test_small_event_parses_and_delivers(real_transport):
+    t = real_transport()
+    send, recv = anyio.create_memory_object_stream(10)
+    complete = await t._handle_sse_event(sse(SMALL_RESULT), send)
+    delivered = await drain_one(recv)
+    # A JSONRPC response both completes the stream and reaches the session.
+    assert complete is True
+    assert not isinstance(delivered, Exception)
+
+
+async def test_warn_level_logs_slug_but_still_parses(real_transport, caplog):
+    t = real_transport()
+    send, recv = anyio.create_memory_object_stream(10)
+    # Valid JSONRPC padded past the warn level but under the cap.
+    padded = json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"pad": "x" * (WARN + 1)}})
+    assert WARN < len(padded) <= CAP
     with caplog.at_level(logging.WARNING, logger="app.core.mcp_guard"):
-        assert await t._handle_sse_event(sse("x" * (WARN + 1))) is True
-    assert transport_cls.handled, "event over the warn level must still be handled"
+        complete = await t._handle_sse_event(sse(padded), send)
+    delivered = await drain_one(recv)
+    assert complete is True
+    assert not isinstance(delivered, Exception)
     assert any("fat-server" in r.getMessage() for r in caplog.records)
 
 
-async def test_oversized_event_rejected_before_parse(transport_cls, caplog):
-    t = transport_cls(GATEWAY_URL)
+async def test_oversized_event_fails_request_without_reconnect_replay(real_transport, caplog):
+    """The critical contract, against the real SDK handler.
+
+    Raising out of the handler would be swallowed by every SDK call site
+    (except Exception -> logger.debug) followed by a Last-Event-ID reconnect
+    replaying the same payload — a hang plus replay loop, worse than the OOM.
+    The guard must instead deliver the error to the session AND report the
+    stream complete.
+    """
+    t = real_transport()
+    send, recv = anyio.create_memory_object_stream(10)
     with caplog.at_level(logging.ERROR, logger="app.core.mcp_guard"):
-        with pytest.raises(McpEventTooLargeError) as exc:
-            await t._handle_sse_event(sse("x" * (CAP + 1)))
-    # The whole point: the original handler (the parse) must never see it.
-    assert transport_cls.handled == []
-    assert exc.value.server == "fat-server"
-    assert exc.value.size_bytes == CAP + 1
-    assert "fat-server" in str(exc.value)
+        complete = await t._handle_sse_event(sse("x" * (CAP + 1)), send)
+
+    assert complete is True, "must report completion so the SDK does not reconnect and replay"
+    delivered = await drain_one(recv)
+    assert isinstance(delivered, McpEventTooLargeError)
+    assert delivered.server == "fat-server"
+    assert delivered.size_bytes == CAP + 1
+    assert any("fat-server" in r.getMessage() for r in caplog.records)
 
 
-async def test_empty_priming_event_passes(transport_cls):
-    """Resumability priming events have no data and must not be broken."""
-    t = transport_cls(GATEWAY_URL)
-    assert await t._handle_sse_event(SimpleNamespace(data="", event="message", id="7")) is True
+async def test_oversized_json_response_fails_request(real_transport):
+    """The application/json body path runs the same parse and is guarded too."""
+
+    class FakeResponse:
+        async def aread(self):
+            return b"x" * (CAP + 1)
+
+    t = real_transport()
+    send, recv = anyio.create_memory_object_stream(10)
+    await t._handle_json_response(FakeResponse(), send)
+    delivered = await drain_one(recv)
+    assert isinstance(delivered, McpEventTooLargeError)
 
 
-async def test_non_gateway_url_falls_back_to_host(transport_cls):
-    t = transport_cls(CONSOLE_URL)
-    with pytest.raises(McpEventTooLargeError) as exc:
-        await t._handle_sse_event(sse("x" * (CAP + 1)))
-    assert exc.value.server == "console.example"
+async def test_small_json_response_delegates_to_sdk(real_transport):
+    class FakeResponse:
+        async def aread(self):
+            return SMALL_RESULT.encode()
+
+    t = real_transport()
+    send, recv = anyio.create_memory_object_stream(10)
+    await t._handle_json_response(FakeResponse(), send)
+    delivered = await drain_one(recv)
+    assert not isinstance(delivered, Exception)
+
+
+async def test_multibyte_payload_measured_in_bytes(real_transport):
+    """4-byte emoji: character count sits under the cap, byte size over it."""
+    t = real_transport()
+    send, recv = anyio.create_memory_object_stream(10)
+    payload = "\U0001f600" * ((CAP // 4) + 1)  # chars ~ CAP/4, bytes > CAP
+    assert len(payload) <= CAP < len(payload.encode())
+    complete = await t._handle_sse_event(sse(payload), send)
+    assert complete is True
+    assert isinstance(await drain_one(recv), McpEventTooLargeError)
+
+
+async def test_priming_and_non_message_events_untouched(real_transport):
+    t = real_transport()
+    send, _recv = anyio.create_memory_object_stream(10)
+    # Priming event: no data, only an ID (resumability) — SDK returns False.
+    assert await t._handle_sse_event(SimpleNamespace(data="", event="message", id="7", retry=None), send) is False
+    # Non-message events are never parsed and must not be size-checked.
+    assert await t._handle_sse_event(sse("x" * (CAP + 1), event="ping"), send) is False
+
+
+async def test_cap_zero_disables_rejection(monkeypatch, caplog):
+    import mcp.client.streamable_http as sdk
+
+    monkeypatch.setattr(sdk.StreamableHTTPTransport, "_handle_sse_event", sdk.StreamableHTTPTransport._handle_sse_event)
+    monkeypatch.setattr(
+        sdk.StreamableHTTPTransport, "_handle_json_response", sdk.StreamableHTTPTransport._handle_json_response
+    )
+    install_mcp_size_guard(max_event_bytes=0, warn_event_bytes=WARN)
+    t = sdk.StreamableHTTPTransport(GATEWAY_URL)
+    send, recv = anyio.create_memory_object_stream(10)
+    big_but_valid = json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"pad": "x" * (CAP * 2)}})
+    with caplog.at_level(logging.WARNING, logger="app.core.mcp_guard"):
+        complete = await t._handle_sse_event(sse(big_but_valid), send)
+    assert complete is True
+    assert not isinstance(await drain_one(recv), Exception), "cap=0 must disable rejection"
+    assert any("fat-server" in r.getMessage() for r in caplog.records), "warn stays active"
+
+
+def test_warn_above_cap_is_clamped(monkeypatch, caplog):
+    import mcp.client.streamable_http as sdk
+
+    monkeypatch.setattr(sdk.StreamableHTTPTransport, "_handle_sse_event", sdk.StreamableHTTPTransport._handle_sse_event)
+    monkeypatch.setattr(
+        sdk.StreamableHTTPTransport, "_handle_json_response", sdk.StreamableHTTPTransport._handle_json_response
+    )
+    with caplog.at_level(logging.WARNING, logger="app.core.mcp_guard"):
+        install_mcp_size_guard(max_event_bytes=CAP, warn_event_bytes=CAP * 10)
+    assert any("clamping warn" in r.getMessage() for r in caplog.records)
+
+
+def test_install_is_idempotent(monkeypatch):
+    import mcp.client.streamable_http as sdk
+
+    monkeypatch.setattr(sdk.StreamableHTTPTransport, "_handle_sse_event", sdk.StreamableHTTPTransport._handle_sse_event)
+    monkeypatch.setattr(
+        sdk.StreamableHTTPTransport, "_handle_json_response", sdk.StreamableHTTPTransport._handle_json_response
+    )
+    install_mcp_size_guard(max_event_bytes=CAP, warn_event_bytes=WARN)
+    first = sdk.StreamableHTTPTransport._handle_sse_event
+    install_mcp_size_guard(max_event_bytes=CAP, warn_event_bytes=WARN)
+    assert sdk.StreamableHTTPTransport._handle_sse_event is first, "second install must not re-wrap"
 
 
 def test_server_slug_extraction():
@@ -103,20 +213,8 @@ def test_server_slug_extraction():
     assert _server_slug("not a url") == "not a url"
 
 
-def test_install_is_idempotent(monkeypatch):
-    monkeypatch.setattr(mcp_guard, "_installed", False)
-
-    class FakeTransport:
-        def __init__(self, url):
-            self.url = url
-
-        async def _handle_sse_event(self, sse, *a, **kw):
-            return True
-
-    import mcp.client.streamable_http as real_module
-
-    monkeypatch.setattr(real_module, "StreamableHTTPTransport", FakeTransport)
-    install_mcp_size_guard(max_event_bytes=CAP, warn_event_bytes=WARN)
-    first = FakeTransport._handle_sse_event
-    install_mcp_size_guard(max_event_bytes=CAP, warn_event_bytes=WARN)
-    assert FakeTransport._handle_sse_event is first, "second install must not re-wrap"
+def test_utf8_size_bounds():
+    assert _utf8_size(b"abc", 10) == 3
+    assert _utf8_size("abc", 10) == 3  # 3*4 >= 10 -> exact encode, still 3
+    assert _utf8_size("a" * 100, 1000) == 100  # upper bound below threshold -> cheap path
+    assert _utf8_size("\U0001f600", 2) == 4  # exact path counts bytes

--- a/packages/orchestrator-agent/tests/test_mcp_guard.py
+++ b/packages/orchestrator-agent/tests/test_mcp_guard.py
@@ -218,3 +218,80 @@ def test_utf8_size_bounds():
     assert _utf8_size("abc", 10) == 3  # 3*4 >= 10 -> exact encode, still 3
     assert _utf8_size("a" * 100, 1000) == 100  # upper bound below threshold -> cheap path
     assert _utf8_size("\U0001f600", 2) == 4  # exact path counts bytes
+
+
+async def test_oversized_with_recoverable_id_becomes_jsonrpc_error(real_transport):
+    """When the payload's id is recoverable, the rejection is a routable
+    JSONRPCError — the form the session actually matches to a pending request."""
+    from mcp.shared.message import SessionMessage
+    from mcp.types import JSONRPCError
+
+    t = real_transport()
+    send, recv = anyio.create_memory_object_stream(10)
+    payload = '{"jsonrpc":"2.0","id":42,"result":{"pad":"' + "x" * (CAP + 1) + '"}}'
+    complete = await t._handle_sse_event(sse(payload), send)
+    assert complete is True
+    delivered = await drain_one(recv)
+    assert isinstance(delivered, SessionMessage)
+    assert isinstance(delivered.message.root, JSONRPCError)
+    assert delivered.message.root.id == 42
+    assert "fat-server" in delivered.message.root.error.message
+
+
+async def test_session_pending_request_actually_fails(real_transport):
+    """End-to-end across the session boundary: a ClientSession's pending
+    list_tools request must FAIL (not hang) when the guard rejects the
+    oversized response. This is the scenario that survived round 2's fix —
+    a bare Exception on the read stream routes to a no-op handler while
+    send_request waits with timeout=None."""
+    from mcp import ClientSession
+    from mcp.shared.exceptions import McpError
+    from mcp.shared.message import SessionMessage
+
+    t = real_transport()
+
+    # session <- read_recv ; guard writes into read_send
+    read_send, read_recv = anyio.create_memory_object_stream(16)
+    write_send, write_recv = anyio.create_memory_object_stream(16)
+
+    async with ClientSession(read_recv, write_send) as session:
+        result: dict = {}
+
+        async def run_request():
+            try:
+                await session.send_request(_list_tools_request(), _ListToolsResultType())
+            except McpError as e:
+                result["error"] = e
+            except Exception as e:  # pragma: no cover - diagnostic
+                result["error"] = e
+
+        def _list_tools_request():
+            from mcp.types import ClientRequest, ListToolsRequest
+
+            return ClientRequest(ListToolsRequest(method="tools/list"))
+
+        def _ListToolsResultType():
+            from mcp.types import ListToolsResult
+
+            return ListToolsResult
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(run_request)
+            # Capture the outgoing request to learn its id.
+            with anyio.fail_after(2):
+                outgoing: SessionMessage = await write_recv.receive()
+            request_id = outgoing.message.root.id
+
+            # The server "responds" with an oversized payload carrying that id.
+            payload = (
+                '{"jsonrpc":"2.0","id":' + str(request_id) + ',"result":{"tools":[],"pad":"' + "x" * (CAP + 1) + '"}}'
+            )
+            complete = await t._handle_sse_event(sse(payload), read_send)
+            assert complete is True
+
+            with anyio.fail_after(2):
+                while "error" not in result:
+                    await anyio.sleep(0.01)
+
+    err = result["error"]
+    assert "fat-server" in str(err), f"pending request must fail with the guard's message, got: {err!r}"


### PR DESCRIPTION
closes ringier-data/nannos#152

## Problem

Every MCP message the orchestrator receives — tool catalogues at discovery, tool results mid-turn, code-mode sessions — arrives as an SSE event the SDK parses with `JSONRPCMessage.model_validate_json` and **no size bound**. The parse amplifies wire size ~7× into live pydantic objects, and several parses run concurrently.

Measured consequence (local stack, same gateway as prod): one server answering `tools/list` with a **21.9 MB** event drove a cold-cache turn from a 56 MB baseline to a **2348 MB** peak (**4159 MB** on a heavy task); top allocation site was 663 MB in 10M blocks at `mcp/client/streamable_http.py:217`. This is what OOMKilled prod on 2026-08-15/17. Nothing named the server, so attribution took a tracemalloc hunt; disabling the one server dropped the same turn's peak to **456 MB**.

## Change

`app/core/mcp_guard.py`, installed at lifespan startup, wraps `StreamableHTTPTransport._handle_sse_event` process-wide (the SDK offers no hook at the parse site; one wrap covers discovery, tool dispatch and code-mode):

- **Reject before the parse**: events over `MCP_SSE_MAX_EVENT_BYTES` (default 10 MB) raise `McpEventTooLargeError` naming the server slug and sizes. Discovery already degrades gracefully per server, so a rejected catalogue costs one server's tools, not the pod; a rejected tool result surfaces as that call's error.
- **Warn with attribution**: events over `MCP_SSE_WARN_EVENT_BYTES` (default 1 MB) log the server slug, making catalogue growth a visible trend. Yesterday this line alone would have named the culprit weeks earlier.

Knobs declared in `.env.template` and the example k8s manifest.

## Deliberately out of scope

- **Lazy catalogue loading** — reduces aggregate parse cost, but only *reschedules* the fatal parse; a cap prevents it. Follow-up per #152.
- **Cache trimming** — the transient parse *is* the spike; trimming happens after parsing and fixes nothing.
- `agent-runner` (separate process), gateway-side budgets, and an upstream `mcp` issue for bounded/streaming SSE parsing.

## Verification

- 7 new unit tests pin the contract: pass-through under cap, warn-with-slug, **reject-before-parse** (asserts the original handler never sees the event), empty priming events unaffected, non-gateway URL slug fallback, idempotent install.
- Full orchestrator suite: **633 passed**.
- `ruff check` clean on the new files; `main.py`/`config.py` error counts identical to baseline (32/1 — pre-existing).

Refs the production incident in our internal tracker.