### PR TITLE
chore: SCIM: explicitly store flag is_mcp_gateway instead of inferring from URL

### DIFF
--- a/packages/agent-runner/agent/core.py
+++ b/packages/agent-runner/agent/core.py
@@ -73,7 +73,7 @@ logger = logging.getLogger(__name__)
 
 _CONSOLE_BACKEND_URL = os.getenv("CONSOLE_BACKEND_URL", "http://localhost:5001")
 _CONSOLE_BACKEND_CLIENT_ID = os.getenv("CONSOLE_BACKEND_CLIENT_ID", "agent-console")
-_MCP_GATEWAY_URL = os.getenv("MCP_GATEWAY_URL", "https://alloych.gatana.ai/mcp")
+_MCP_GATEWAY_URL = os.getenv("MCP_GATEWAY_URL", "https://nannos.gatana.nannos.ringier.ch/mcp")
 _MCP_TIMEOUT_SECONDS = int(os.getenv("MCP_TIMEOUT_SECONDS", "300"))
 _DOCUMENT_STORE_S3_BUCKET = os.getenv("DOCUMENT_STORE_S3_BUCKET", "")
 _MAX_RECURSION_LIMIT = int(os.getenv("MAX_RECURSION_LIMIT", "50"))

--- a/packages/console-backend/console_backend/config.py
+++ b/packages/console-backend/console_backend/config.py
@@ -104,7 +104,7 @@ class KeycloakAdminConfig(BaseModel):
 class MCPGatewayConfig(BaseModel):
     """MCP Gateway configuration for tool discovery."""
 
-    url: str = Field(default_factory=lambda: os.getenv("MCP_GATEWAY_URL", "https://alloych.gatana.ai/mcp"))
+    url: str = Field(default_factory=lambda: os.getenv("MCP_GATEWAY_URL", "https://nannos.gatana.nannos.ringier.ch/mcp"))
     client_id: str = Field(default_factory=lambda: os.getenv("MCP_GATEWAY_CLIENT_ID", "gatana"))
 
 

--- a/packages/console-backend/console_backend/models/outbound_scim.py
+++ b/packages/console-backend/console_backend/models/outbound_scim.py
@@ -15,6 +15,7 @@ class OutboundScimEndpointCreate(BaseModel):
     bearer_token: str = Field(..., min_length=1, description="Bearer token for authenticating with the remote SCIM server")
     push_users: bool = Field(True, description="Whether to push user changes to this endpoint")
     push_groups: bool = Field(True, description="Whether to push group changes to this endpoint")
+    is_mcp_gateway: bool = Field(False, description="Whether this endpoint is the MCP gateway (Gatana), enabling server access management for synced groups")
 
 
 class OutboundScimEndpointUpdate(BaseModel):
@@ -26,6 +27,7 @@ class OutboundScimEndpointUpdate(BaseModel):
     enabled: bool | None = None
     push_users: bool | None = None
     push_groups: bool | None = None
+    is_mcp_gateway: bool | None = None
 
 
 class OutboundScimEndpoint(BaseModel):
@@ -38,6 +40,7 @@ class OutboundScimEndpoint(BaseModel):
     enabled: bool
     push_users: bool
     push_groups: bool
+    is_mcp_gateway: bool
     created_by: str
     created_at: datetime
     updated_at: datetime
@@ -56,6 +59,7 @@ class OutboundScimEndpointCreated(BaseModel):
     enabled: bool
     push_users: bool
     push_groups: bool
+    is_mcp_gateway: bool
     created_at: datetime
 
 

--- a/packages/console-backend/console_backend/routers/outbound_scim_router.py
+++ b/packages/console-backend/console_backend/routers/outbound_scim_router.py
@@ -59,6 +59,7 @@ async def create_outbound_scim_endpoint(
         bearer_token=body.bearer_token,
         push_users=body.push_users,
         push_groups=body.push_groups,
+        is_mcp_gateway=body.is_mcp_gateway,
         actor=admin,
     )
     await db.commit()
@@ -118,6 +119,7 @@ async def update_outbound_scim_endpoint(
         enabled=body.enabled,
         push_users=body.push_users,
         push_groups=body.push_groups,
+        is_mcp_gateway=body.is_mcp_gateway,
     )
     if not endpoint:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Outbound SCIM endpoint not found")

--- a/packages/console-backend/console_backend/services/mcp_gateway_server_access_service.py
+++ b/packages/console-backend/console_backend/services/mcp_gateway_server_access_service.py
@@ -2,11 +2,11 @@
 
 Manages server access permissions in the MCP gateway (Gatana) for groups
 that are synced via outbound SCIM. A group is "managed" if it has a SCIM
-remote_id for an outbound endpoint whose hostname matches MCP_GATEWAY_URL.
+remote_id for an outbound endpoint flagged as the MCP gateway
+(outbound_scim_endpoints.is_mcp_gateway).
 """
 
 import logging
-from urllib.parse import urlparse
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -17,23 +17,11 @@ from ..models.mcp_gateway_server_access import McpGatewayServerPermission
 logger = logging.getLogger(__name__)
 
 
-def _apex_domain(hostname: str) -> str:
-    """Extract apex domain (last two labels) from a hostname.
-
-    e.g. 'scim.gatana.ai' -> 'gatana.ai', 'alloych.gatana.ai' -> 'gatana.ai'
-    """
-    parts = hostname.rstrip(".").split(".")
-    if len(parts) >= 2:
-        return ".".join(parts[-2:])
-    return hostname
-
-
 class McpGatewayServerAccessService:
     """Manages MCP gateway server access permissions for groups."""
 
     def __init__(self) -> None:
         self._db_session_factory: async_sessionmaker[AsyncSession] | None = None
-        self._gateway_hostname: str | None = None
         self._api_base_url: str | None = None
 
     def set_db_session_factory(self, factory: async_sessionmaker[AsyncSession]) -> None:
@@ -44,14 +32,6 @@ class McpGatewayServerAccessService:
         if self._db_session_factory is None:
             raise RuntimeError("db_session_factory not set on McpGatewayServerAccessService")
         return self._db_session_factory
-
-    @property
-    def gateway_hostname(self) -> str:
-        """Hostname of the MCP gateway URL, used for matching outbound SCIM endpoints."""
-        if self._gateway_hostname is None:
-            parsed = urlparse(config.mcp_gateway.url)
-            self._gateway_hostname = parsed.hostname or ""
-        return self._gateway_hostname
 
     @property
     def api_base_url(self) -> str:
@@ -73,79 +53,52 @@ class McpGatewayServerAccessService:
         """Resolve the MCP gateway team ID for a group.
 
         Looks up the outbound SCIM sync state to find a remote_id for this group
-        at an endpoint whose hostname matches the MCP gateway hostname.
+        at an active endpoint flagged as the MCP gateway (is_mcp_gateway).
 
         Returns:
             The remote_id (Gatana team ID) if found, None otherwise.
         """
-        gateway_host = self.gateway_hostname
-        logger.debug(
-            f"resolve_gateway_team_id: group_id={group_id}, "
-            f"gateway_hostname='{gateway_host}', "
-            f"mcp_gateway_url='{config.mcp_gateway.url}'"
-        )
-        if not gateway_host:
-            logger.warning("resolve_gateway_team_id: gateway_hostname is empty, returning None")
-            return None
-
         async with self.db_session_factory() as db:
             result = await db.execute(
                 text("""
-                    SELECT ss.remote_id, ss.entity_id, ss.entity_type, ss.endpoint_id,
-                           ep.endpoint_url, ep.enabled, ep.deleted_at
+                    SELECT ss.remote_id, ss.endpoint_id, ep.endpoint_url
                     FROM outbound_scim_sync_state ss
                     JOIN outbound_scim_endpoints ep
                         ON ep.id = ss.endpoint_id
                     WHERE ss.entity_type = 'group'
                       AND ss.entity_id = :entity_id
+                      AND ss.remote_id IS NOT NULL
+                      AND ep.is_mcp_gateway = true
+                      AND ep.enabled = true
+                      AND ep.deleted_at IS NULL
+                    ORDER BY ss.endpoint_id
                 """),
                 {"entity_id": str(group_id)},
             )
-            all_rows = result.fetchall()
+            rows = result.fetchall()
 
-        logger.debug(
-            f"resolve_gateway_team_id: found {len(all_rows)} total sync_state rows "
-            f"for group entity_id='{group_id}'"
-        )
-
-        for row in all_rows:
-            logger.debug(
-                f"resolve_gateway_team_id: row endpoint_id={row.endpoint_id}, "
-                f"endpoint_url='{row.endpoint_url}', "
-                f"remote_id='{row.remote_id}', "
-                f"enabled={row.enabled}, "
-                f"deleted_at={row.deleted_at}"
+        if not rows:
+            logger.warning(
+                f"resolve_gateway_team_id: no sync state for group_id={group_id} at any "
+                f"active endpoint flagged is_mcp_gateway. Check that the MCP gateway's "
+                f"outbound SCIM endpoint has the flag set."
             )
-            if row.remote_id is None:
-                logger.debug("  -> skipped: remote_id is None")
-                continue
-            if row.deleted_at is not None:
-                logger.debug("  -> skipped: endpoint deleted_at is set")
-                continue
-            if not row.enabled:
-                logger.debug("  -> skipped: endpoint is disabled")
-                continue
+            return None
 
-            ep_hostname = urlparse(row.endpoint_url).hostname or ""
-            ep_apex = _apex_domain(ep_hostname)
-            gw_apex = _apex_domain(gateway_host)
-            logger.debug(
-                f"  -> parsed endpoint hostname='{ep_hostname}' (apex='{ep_apex}'), "
-                f"comparing to gateway_host='{gateway_host}' (apex='{gw_apex}'), "
-                f"match={ep_apex == gw_apex}"
+        if len(rows) > 1:
+            logger.warning(
+                f"resolve_gateway_team_id: group_id={group_id} is synced to "
+                f"{len(rows)} endpoints flagged is_mcp_gateway "
+                f"({[(r.endpoint_id, r.endpoint_url) for r in rows]}); "
+                f"using endpoint_id={rows[0].endpoint_id}"
             )
-            if ep_apex == gw_apex:
-                logger.info(
-                    f"resolve_gateway_team_id: matched! group_id={group_id} -> "
-                    f"team_id='{row.remote_id}'"
-                )
-                return row.remote_id
 
-        logger.warning(
-            f"resolve_gateway_team_id: no matching endpoint found for group_id={group_id}. "
-            f"Expected gateway_host='{gateway_host}'"
+        row = rows[0]
+        logger.info(
+            f"resolve_gateway_team_id: group_id={group_id} -> team_id='{row.remote_id}' "
+            f"(endpoint_id={row.endpoint_id})"
         )
-        return None
+        return row.remote_id
 
     async def list_server_access(
         self, gatana_token: str, group_id: int

--- a/packages/console-backend/console_backend/services/outbound_scim_endpoint_service.py
+++ b/packages/console-backend/console_backend/services/outbound_scim_endpoint_service.py
@@ -37,14 +37,15 @@ class OutboundScimEndpointService:
         bearer_token: str,
         push_users: bool,
         push_groups: bool,
+        is_mcp_gateway: bool,
         actor: User,
     ) -> OutboundScimEndpointCreated:
         """Create a new outbound SCIM endpoint."""
         result = await db.execute(
             text("""
                 INSERT INTO outbound_scim_endpoints
-                    (name, endpoint_url, bearer_token, push_users, push_groups, created_by)
-                VALUES (:name, :endpoint_url, :bearer_token, :push_users, :push_groups, :created_by)
+                    (name, endpoint_url, bearer_token, push_users, push_groups, is_mcp_gateway, created_by)
+                VALUES (:name, :endpoint_url, :bearer_token, :push_users, :push_groups, :is_mcp_gateway, :created_by)
                 RETURNING id, enabled, created_at
             """),
             {
@@ -53,6 +54,7 @@ class OutboundScimEndpointService:
                 "bearer_token": bearer_token,
                 "push_users": push_users,
                 "push_groups": push_groups,
+                "is_mcp_gateway": is_mcp_gateway,
                 "created_by": actor.id,
             },
         )
@@ -64,7 +66,7 @@ class OutboundScimEndpointService:
             entity_type=AuditEntityType.OUTBOUND_SCIM_ENDPOINT,
             entity_id=str(row.id),
             action=AuditAction.CREATE,
-            changes={"after": {"name": name, "endpoint_url": endpoint_url, "push_users": push_users, "push_groups": push_groups}},
+            changes={"after": {"name": name, "endpoint_url": endpoint_url, "push_users": push_users, "push_groups": push_groups, "is_mcp_gateway": is_mcp_gateway}},
         )
 
         return OutboundScimEndpointCreated(
@@ -75,6 +77,7 @@ class OutboundScimEndpointService:
             enabled=row.enabled,
             push_users=push_users,
             push_groups=push_groups,
+            is_mcp_gateway=is_mcp_gateway,
             created_at=row.created_at,
         )
 
@@ -83,7 +86,7 @@ class OutboundScimEndpointService:
         result = await db.execute(
             text("""
                 SELECT id, name, endpoint_url, bearer_token, enabled,
-                       push_users, push_groups, created_by, created_at, updated_at
+                       push_users, push_groups, is_mcp_gateway, created_by, created_at, updated_at
                 FROM outbound_scim_endpoints
                 WHERE deleted_at IS NULL
                 ORDER BY created_at DESC
@@ -99,6 +102,7 @@ class OutboundScimEndpointService:
                 enabled=row.enabled,
                 push_users=row.push_users,
                 push_groups=row.push_groups,
+                is_mcp_gateway=row.is_mcp_gateway,
                 created_by=row.created_by,
                 created_at=row.created_at,
                 updated_at=row.updated_at,
@@ -111,7 +115,7 @@ class OutboundScimEndpointService:
         result = await db.execute(
             text("""
                 SELECT id, name, endpoint_url, bearer_token, enabled,
-                       push_users, push_groups, created_by, created_at, updated_at
+                       push_users, push_groups, is_mcp_gateway, created_by, created_at, updated_at
                 FROM outbound_scim_endpoints
                 WHERE id = :id AND deleted_at IS NULL
             """),
@@ -129,6 +133,7 @@ class OutboundScimEndpointService:
             enabled=row.enabled,
             push_users=row.push_users,
             push_groups=row.push_groups,
+            is_mcp_gateway=row.is_mcp_gateway,
             created_by=row.created_by,
             created_at=row.created_at,
             updated_at=row.updated_at,
@@ -146,6 +151,7 @@ class OutboundScimEndpointService:
         enabled: bool | None = None,
         push_users: bool | None = None,
         push_groups: bool | None = None,
+        is_mcp_gateway: bool | None = None,
     ) -> OutboundScimEndpoint | None:
         """Update an outbound SCIM endpoint."""
         # Build dynamic SET clause
@@ -162,6 +168,8 @@ class OutboundScimEndpointService:
             fields["push_users"] = push_users
         if push_groups is not None:
             fields["push_groups"] = push_groups
+        if is_mcp_gateway is not None:
+            fields["is_mcp_gateway"] = is_mcp_gateway
 
         if not fields:
             return await self.get_endpoint(db, endpoint_id)

--- a/packages/console-backend/sqlmigrations/ddl/079_outbound_scim_is_mcp_gateway.sql
+++ b/packages/console-backend/sqlmigrations/ddl/079_outbound_scim_is_mcp_gateway.sql
@@ -1,0 +1,21 @@
+-- rambler up
+
+-- Marks the outbound SCIM endpoint(s) that provision groups into the MCP
+-- gateway (Gatana). Console-backend used to infer this by comparing the
+-- endpoint hostname's apex domain against MCP_GATEWAY_URL, which breaks for
+-- on-premise gateways hosted under a corporate domain: every SCIM endpoint
+-- under that domain would match. The flag makes the relationship explicit.
+ALTER TABLE outbound_scim_endpoints
+    ADD COLUMN is_mcp_gateway BOOLEAN NOT NULL DEFAULT false;
+
+-- One-time seed approximating the old heuristic: Gatana endpoints (cloud
+-- *.gatana.ai or on-premise hosts carrying a "gatana" label) are the only
+-- ones that ever matched it. Adjust afterwards via the admin API/UI.
+UPDATE outbound_scim_endpoints
+SET is_mcp_gateway = true
+WHERE deleted_at IS NULL
+  AND endpoint_url ILIKE '%gatana%';
+
+-- rambler down
+
+ALTER TABLE outbound_scim_endpoints DROP COLUMN IF EXISTS is_mcp_gateway;

--- a/packages/console-backend/tests/test_mcp_router.py
+++ b/packages/console-backend/tests/test_mcp_router.py
@@ -108,7 +108,7 @@ class TestListMcpTools:
                 # Verify MCP JSON-RPC request
                 mock_client.post.assert_awaited_once()
                 call_args = mock_client.post.call_args
-                assert call_args[0][0] == "https://alloych.gatana.ai/mcp"
+                assert call_args[0][0] == "https://nannos.gatana.nannos.ringier.ch/mcp"
                 assert call_args[1]["headers"]["Authorization"] == "Bearer mcp_gateway_token"
                 assert call_args[1]["json"]["method"] == "tools/list"
                 assert call_args[1]["json"]["jsonrpc"] == "2.0"

--- a/packages/console-frontend/src/pages/admin/OutboundScimPage.tsx
+++ b/packages/console-frontend/src/pages/admin/OutboundScimPage.tsx
@@ -30,6 +30,7 @@ interface OutboundScimEndpoint {
   enabled: boolean;
   push_users: boolean;
   push_groups: boolean;
+  is_mcp_gateway: boolean;
   created_by: string;
   created_at: string;
   updated_at: string;
@@ -43,6 +44,7 @@ interface OutboundScimEndpointCreated {
   enabled: boolean;
   push_users: boolean;
   push_groups: boolean;
+  is_mcp_gateway: boolean;
   created_at: string;
 }
 
@@ -83,6 +85,7 @@ export function OutboundScimPage() {
   const [bearerToken, setBearerToken] = useState('');
   const [pushUsers, setPushUsers] = useState(true);
   const [pushGroups, setPushGroups] = useState(true);
+  const [isMcpGateway, setIsMcpGateway] = useState(false);
 
   // Edit form state
   const [editName, setEditName] = useState('');
@@ -91,6 +94,7 @@ export function OutboundScimPage() {
   const [editPushUsers, setEditPushUsers] = useState(true);
   const [editPushGroups, setEditPushGroups] = useState(true);
   const [editEnabled, setEditEnabled] = useState(true);
+  const [editIsMcpGateway, setEditIsMcpGateway] = useState(false);
 
   const { data, isLoading } = useQuery<OutboundScimListResponse>({
     queryKey: ['outboundScimEndpoints'],
@@ -107,6 +111,7 @@ export function OutboundScimPage() {
       bearer_token: string;
       push_users: boolean;
       push_groups: boolean;
+      is_mcp_gateway: boolean;
     }) => {
       const res = await client.post<OutboundScimEndpointCreated>({ url: API_BASE, body });
       return res.data as OutboundScimEndpointCreated;
@@ -187,6 +192,7 @@ export function OutboundScimPage() {
     setBearerToken('');
     setPushUsers(true);
     setPushGroups(true);
+    setIsMcpGateway(false);
   };
 
   const handleCreate = () => {
@@ -196,6 +202,7 @@ export function OutboundScimPage() {
       bearer_token: bearerToken,
       push_users: pushUsers,
       push_groups: pushGroups,
+      is_mcp_gateway: isMcpGateway,
     });
   };
 
@@ -206,6 +213,7 @@ export function OutboundScimPage() {
     setEditPushUsers(endpoint.push_users);
     setEditPushGroups(endpoint.push_groups);
     setEditEnabled(endpoint.enabled);
+    setEditIsMcpGateway(endpoint.is_mcp_gateway);
     setEditDialog({ open: true, endpoint });
   };
 
@@ -217,6 +225,7 @@ export function OutboundScimPage() {
       push_users: editPushUsers,
       push_groups: editPushGroups,
       enabled: editEnabled,
+      is_mcp_gateway: editIsMcpGateway,
     };
     if (editBearerToken) body.bearer_token = editBearerToken;
     updateMutation.mutate({ id: editDialog.endpoint.id, body });
@@ -277,6 +286,7 @@ export function OutboundScimPage() {
                     <div className="flex gap-1">
                       {ep.push_users && <Badge variant="secondary">Users</Badge>}
                       {ep.push_groups && <Badge variant="secondary">Groups</Badge>}
+                      {ep.is_mcp_gateway && <Badge>MCP Gateway</Badge>}
                     </div>
                   </TableCell>
                   <TableCell>
@@ -395,6 +405,14 @@ export function OutboundScimPage() {
                 <Label htmlFor="ep-push-groups">Push Groups</Label>
               </div>
             </div>
+            <div className="flex items-center gap-2">
+              <Switch id="ep-is-mcp-gateway" checked={isMcpGateway} onCheckedChange={setIsMcpGateway} />
+              <Label htmlFor="ep-is-mcp-gateway">MCP Gateway endpoint</Label>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Mark this endpoint as the MCP gateway (Gatana) to enable server access management for groups synced to
+              it.
+            </p>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setCreateDialogOpen(false)}>
@@ -452,6 +470,10 @@ export function OutboundScimPage() {
                 <Switch id="edit-push-groups" checked={editPushGroups} onCheckedChange={setEditPushGroups} />
                 <Label htmlFor="edit-push-groups">Push Groups</Label>
               </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <Switch id="edit-is-mcp-gateway" checked={editIsMcpGateway} onCheckedChange={setEditIsMcpGateway} />
+              <Label htmlFor="edit-is-mcp-gateway">MCP Gateway endpoint</Label>
             </div>
             <div className="flex items-center gap-2">
               <Switch id="edit-enabled" checked={editEnabled} onCheckedChange={setEditEnabled} />

--- a/packages/orchestrator-agent/app/models/config.py
+++ b/packages/orchestrator-agent/app/models/config.py
@@ -343,7 +343,7 @@ class AgentSettings:
     DOCUMENT_STORE_S3_BUCKET = os.getenv("DOCUMENT_STORE_S3_BUCKET", "dev-nannos-infrastructure-agents-files")
 
     # MCP gateway configuration
-    MCP_GATEWAY_URL = os.getenv("MCP_GATEWAY_URL", "https://alloych.gatana.ai/mcp")
+    MCP_GATEWAY_URL = os.getenv("MCP_GATEWAY_URL", "https://nannos.gatana.nannos.ringier.ch/mcp")
     MCP_GATEWAY_CLIENT_ID = os.getenv("MCP_GATEWAY_CLIENT_ID", "gatana")
 
     # How many MCP servers may be queried for their tool catalogue at the same time

--- a/packages/orchestrator-agent/docs/authentication-authorization-flow.md
+++ b/packages/orchestrator-agent/docs/authentication-authorization-flow.md
@@ -316,7 +316,7 @@ async def discover_tools(self, token: str, white_list: List[str] = None):
         connections={
             "gatana": StreamableHttpConnection(
                 transport="streamable_http",
-                url="https://alloych.gatana.ai/mcp",
+                url="https://nannos.gatana.nannos.ringier.ch/mcp",
                 headers={"Authorization": f"Bearer {mcp_gateway_token}"},
             )
         }

--- a/packages/orchestrator-agent/tests/test_discovery.py
+++ b/packages/orchestrator-agent/tests/test_discovery.py
@@ -146,10 +146,10 @@ class TestToolDiscoveryService:
             # ".com" host (verified against the old code: it produces
             # "https://gateway.example.co", dropping the "m"). This is the one
             # case that actually fails without the fix; the others below don't
-            # (alloych.gatana.ai ends in "i", not m/c/p — accidentally correct
+            # (nannos.gatana.nannos.ringier.ch ends in "i", not m/c/p — accidentally correct
             # either way — and are kept for the trailing-slash-only regression).
             ("https://gateway.example.com/mcp", "https://gateway.example.com/api/v1/mcp-servers"),
-            ("https://alloych.gatana.ai/mcp", "https://alloych.gatana.ai/api/v1/mcp-servers"),
+            ("https://nannos.gatana.nannos.ringier.ch/mcp", "https://nannos.gatana.nannos.ringier.ch/api/v1/mcp-servers"),
             # A trailing slash is a no-op for removesuffix("/mcp") unless the
             # slash is stripped first — regression coverage for that fix.
             ("https://gw.example/mcp/", "https://gw.example/api/v1/mcp-servers"),

--- a/scripts/start-local.sh
+++ b/scripts/start-local.sh
@@ -591,7 +591,7 @@ docker compose exec -T postgres-console psql -U postgres -d console -c \
 docker compose exec -T postgres-console psql -U postgres -d console -c \
   "INSERT INTO users (id, sub, email, first_name, last_name, is_administrator, role, status, created_at, updated_at)
    VALUES (gen_random_uuid(), 'local-test-user', 'test@local.dev', 'Test', 'User', true, 'admin', 'active', now(), now())
-   ON CONFLICT (email) DO UPDATE SET is_administrator = true, role = 'admin';" \
+   ON CONFLICT (LOWER(email)) WHERE deleted_at IS NULL DO UPDATE SET is_administrator = true, role = 'admin';" \
   >/dev/null 2>&1 || true
 
 # ─── 6. Wait for Keycloak ────────────────────────────────────────


### PR DESCRIPTION
`079_outbound_scim_is_mcp_gateway.sql` adds this flag + UI & Console-Backend API changes

also:
* ensure `test@local.dev` user in `just start-local` gets admin role)
* env `MCP_GATEWAY_URL`: fallback updated to `https://nannos.gatana.nannos.ringier.ch/mcp`

closes #

## Checklist
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨
