### PR TITLE
fix(console): enforce user status on the paths that pick a user

### DIFF
--- a/packages/console-backend/console_backend/routers/admin_user_router.py
+++ b/packages/console-backend/console_backend/routers/admin_user_router.py
@@ -21,6 +21,7 @@ from ..models.user import (
     UserGroupsUpdate,
     UserListResponse,
     UserRoleUpdate,
+    UserStatus,
     UserStatusUpdate,
 )
 from ..services.audit_service import AuditService
@@ -181,6 +182,19 @@ async def update_user_groups(
     # Get current group IDs
     current_group_ids = {g.group_id for g in current_user.groups}
     target_group_ids = set(update_request.group_ids)
+
+    # A user that is not active cannot be added to a group. Refuse before anything runs: removals
+    # sync to Keycloak as they go, so failing on a later add would roll back the database and leave
+    # those Keycloak removals behind.
+    if (
+        update_request.operation in ("set", "add")
+        and target_group_ids - current_group_ids
+        and current_user.status != UserStatus.ACTIVE
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Cannot add users that are not active: {user_id}",
+        )
 
     try:
         if update_request.operation == "set":

--- a/packages/console-backend/console_backend/routers/group_router.py
+++ b/packages/console-backend/console_backend/routers/group_router.py
@@ -145,13 +145,19 @@ async def add_members(
             detail="Group not found",
         )
 
-    members = await user_group_service.add_members(
-        db,
-        actor=user,
-        group_id=group_id,
-        user_ids=request_body.user_ids,
-        role=request_body.role,
-    )
+    try:
+        members = await user_group_service.add_members(
+            db,
+            actor=user,
+            group_id=group_id,
+            user_ids=request_body.user_ids,
+            role=request_body.role,
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
     await db.commit()
 
     return GroupMemberListResponse(

--- a/packages/console-backend/console_backend/routers/group_router.py
+++ b/packages/console-backend/console_backend/routers/group_router.py
@@ -22,7 +22,7 @@ from ..models.user_group import (
     UserGroupWithMembers,
 )
 from ..services.orchestrator_cache import schedule_orchestrator_discovery_cache_invalidation
-from ..services.user_group_service import UserGroupService
+from ..services.user_group_service import InactiveUserError, UserGroupService
 
 router = APIRouter(prefix="/api/v1/groups", tags=["groups"])
 
@@ -153,7 +153,7 @@ async def add_members(
             user_ids=request_body.user_ids,
             role=request_body.role,
         )
-    except ValueError as e:
+    except InactiveUserError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),

--- a/packages/console-backend/console_backend/services/scim_service.py
+++ b/packages/console-backend/console_backend/services/scim_service.py
@@ -880,7 +880,12 @@ class ScimGroupService:
     async def _add_member(self, db: AsyncSession, group_id: int, user_id: str) -> None:
         """Add a member to a group via UserGroupService (handles Keycloak sync and agent activation)."""
         try:
-            await self.user_group_service.add_member(db, SCIM_ACTOR, group_id, user_id, role="write")
+            # require_active=False: the IdP owns the group graph and keeps suspended users in their
+            # groups (active=false maps to `suspended` here), so mirroring it must not drop them.
+            # Their suspension is enforced at sign-in, not by pruning memberships.
+            await self.user_group_service.add_member(
+                db, SCIM_ACTOR, group_id, user_id, role="write", require_active=False
+            )
         except Exception as exc:
             # Log but swallow so that a single bad member reference doesn't abort the whole operation.
             logger.warning("SCIM _add_member(%s, %s) failed: %s", group_id, user_id, exc)

--- a/packages/console-backend/console_backend/services/sub_agent_service.py
+++ b/packages/console-backend/console_backend/services/sub_agent_service.py
@@ -1726,9 +1726,12 @@ class SubAgentService:
         query = text("""
             SELECT DISTINCT u.id
             FROM users u
-            WHERE 
+            WHERE
+                -- Only active users can act on an approval request
+                u.status = 'active'
+                AND u.deleted_at IS NULL
                 -- User has approver or admin role
-                (u.role IN ('approver', 'admin') OR u.is_administrator = true)
+                AND (u.role IN ('approver', 'admin') OR u.is_administrator = true)
                 AND (
                     -- User is the owner
                     EXISTS (

--- a/packages/console-backend/console_backend/services/user_group_service.py
+++ b/packages/console-backend/console_backend/services/user_group_service.py
@@ -32,6 +32,14 @@ from ..services.sub_agent_service import SubAgentService
 logger = logging.getLogger(__name__)
 
 
+class InactiveUserError(ValueError):
+    """Raised when a group membership change targets a user that is not active.
+
+    A ValueError subclass so that callers which already map ValueError to a client error keep
+    working, while routers that need to answer this case specifically can catch just this.
+    """
+
+
 class UserGroupService:
     """Service for managing user groups and memberships."""
 
@@ -578,7 +586,7 @@ class UserGroupService:
             user_ids: User IDs to validate
 
         Raises:
-            ValueError: If at least one ID does not belong to an active user
+            InactiveUserError: If at least one ID does not belong to an active user
         """
         result = await db.execute(
             text("SELECT id, status FROM users WHERE id = ANY(:user_ids) AND deleted_at IS NULL"),
@@ -587,7 +595,7 @@ class UserGroupService:
         status_by_id = {row[0]: row[1] for row in result.fetchall()}
         not_active = sorted({uid for uid in user_ids if status_by_id.get(uid) != UserStatus.ACTIVE.value})
         if not_active:
-            raise ValueError(f"Cannot add users that are not active: {', '.join(not_active)}")
+            raise InactiveUserError(f"Cannot add users that are not active: {', '.join(not_active)}")
 
     async def _add_members(
         self,

--- a/packages/console-backend/console_backend/services/user_group_service.py
+++ b/packages/console-backend/console_backend/services/user_group_service.py
@@ -14,7 +14,7 @@ from ..authorization import (
 )
 from ..models.notification import NotificationData, NotificationType
 from ..models.sub_agent import ActivationSource
-from ..models.user import User
+from ..models.user import User, UserStatus
 from ..models.user_group import (
     BulkDeleteResult,
     MemberInfo,
@@ -570,6 +570,25 @@ class UserGroupService:
 
     # Member management
 
+    async def _reject_inactive_users(self, db: AsyncSession, user_ids: list[str]) -> None:
+        """Raise if any of the given user IDs is unknown, soft-deleted or not active.
+
+        Args:
+            db: Database session
+            user_ids: User IDs to validate
+
+        Raises:
+            ValueError: If at least one ID does not belong to an active user
+        """
+        result = await db.execute(
+            text("SELECT id, status FROM users WHERE id = ANY(:user_ids) AND deleted_at IS NULL"),
+            {"user_ids": user_ids},
+        )
+        status_by_id = {row[0]: row[1] for row in result.fetchall()}
+        not_active = sorted({uid for uid in user_ids if status_by_id.get(uid) != UserStatus.ACTIVE.value})
+        if not_active:
+            raise ValueError(f"Cannot add users that are not active: {', '.join(not_active)}")
+
     async def _add_members(
         self,
         db: AsyncSession,
@@ -577,6 +596,7 @@ class UserGroupService:
         group_id: int,
         user_ids: list[str],
         role: Literal["read", "write", "manager"] = "read",
+        require_active: bool = True,
     ) -> list[MemberInfo]:
         """Internal helper to add members to a group.
 
@@ -589,6 +609,8 @@ class UserGroupService:
             group_id: Group ID
             user_ids: List of user IDs to add
             role: Role for the new members
+            require_active: Reject user IDs that are not active users. Only SCIM sets this to False,
+                where the IdP is authoritative for the group graph.
 
         Returns:
             List of added members
@@ -596,6 +618,12 @@ class UserGroupService:
         existing = await self.get_group(db, group_id)
         if existing is None:
             raise ValueError("Group not found")
+
+        # Only active users may be added. Every membership read is scoped to active users, so accepting
+        # a suspended or soft-deleted one would create a member nobody can see or remove, and a client
+        # picking from an unfiltered user list must not be able to slip one through.
+        if require_active:
+            await self._reject_inactive_users(db, user_ids)
 
         # Prepare member additions
         member_additions = [{"user_id": user_id, "role": role} for user_id in user_ids]
@@ -812,6 +840,7 @@ class UserGroupService:
         group_id: int,
         user_ids: list[str],
         role: Literal["read", "write", "manager"] = "read",
+        require_active: bool = True,
     ) -> list[MemberInfo]:
         """Add members to a group (bulk operation).
 
@@ -821,13 +850,14 @@ class UserGroupService:
             group_id: Group ID
             user_ids: List of user IDs to add
             role: Role for the new members
+            require_active: Reject user IDs that are not active users (see _add_members)
 
         Returns:
             Updated member list
         """
         try:
             # Use internal helper
-            await self._add_members(db, actor, group_id, user_ids, role)
+            await self._add_members(db, actor, group_id, user_ids, role, require_active=require_active)
 
             # Trigger outbound SCIM push (fire-and-forget)
             if self._outbound_scim_push_service:
@@ -847,6 +877,7 @@ class UserGroupService:
         group_id: int,
         user_id: str,
         role: Literal["read", "write", "manager"] = "read",
+        require_active: bool = True,
     ) -> MemberInfo:
         """Add a single member to a group.
 
@@ -856,13 +887,14 @@ class UserGroupService:
             group_id: Group ID
             user_id: User ID to add
             role: Role for the new member
+            require_active: Reject the user ID if it is not an active user (see _add_members)
 
         Returns:
             Added member info
         """
         try:
             # Use internal helper
-            added = await self._add_members(db, actor, group_id, [user_id], role)
+            added = await self._add_members(db, actor, group_id, [user_id], role, require_active=require_active)
             if not added:
                 raise ValueError("Failed to add member")
             return added[0]

--- a/packages/console-backend/tests/test_admin_user_router.py
+++ b/packages/console-backend/tests/test_admin_user_router.py
@@ -155,6 +155,88 @@ class TestAdminUserPatchEndpoint:
 
 
 @pytest.mark.asyncio
+class TestAdminUserGroupsEndpoint:
+    """Test PUT /admin/users/{id}/groups."""
+
+    async def test_set_groups_refuses_suspended_user_without_removing_anything(
+        self, admin_client, inserted_user, non_admin_user_model, pg_session
+    ):
+        """A suspended user cannot be added to a group, and the refusal happens before any removal."""
+        keep_id, add_id = (
+            await pg_session.execute(
+                text("""
+                INSERT INTO user_groups (name, description, created_at, updated_at)
+                VALUES ('Current Group', '', NOW(), NOW()), ('New Group', '', NOW(), NOW())
+                RETURNING id
+                """)
+            )
+        ).scalars().all()
+        await pg_session.execute(
+            text("""
+                INSERT INTO user_group_members (user_group_id, user_id, group_role, created_at)
+                VALUES (:group_id, :user_id, 'read', NOW())
+            """),
+            {"group_id": keep_id, "user_id": non_admin_user_model.id},
+        )
+        await pg_session.execute(
+            text("UPDATE users SET status = 'suspended' WHERE id = :id"),
+            {"id": non_admin_user_model.id},
+        )
+        await pg_session.commit()
+
+        response = await admin_client.put(
+            f"/api/v1/admin/users/{non_admin_user_model.id}/groups",
+            json={"group_ids": [add_id], "operation": "set"},
+        )
+        assert response.status_code == 409
+
+        # The membership it would have removed on the way is still there
+        remaining = await pg_session.execute(
+            text("SELECT user_group_id FROM user_group_members WHERE user_id = :uid"),
+            {"uid": non_admin_user_model.id},
+        )
+        assert remaining.scalars().all() == [keep_id]
+
+    async def test_remove_groups_still_works_for_suspended_user(
+        self, admin_client, inserted_user, non_admin_user_model, pg_session
+    ):
+        """Suspension blocks additions only — an admin can still take groups away."""
+        group_id = (
+            await pg_session.execute(
+                text("""
+                INSERT INTO user_groups (name, description, created_at, updated_at)
+                VALUES ('Leaving Group', '', NOW(), NOW())
+                RETURNING id
+                """)
+            )
+        ).scalar_one()
+        await pg_session.execute(
+            text("""
+                INSERT INTO user_group_members (user_group_id, user_id, group_role, created_at)
+                VALUES (:group_id, :user_id, 'read', NOW())
+            """),
+            {"group_id": group_id, "user_id": non_admin_user_model.id},
+        )
+        await pg_session.execute(
+            text("UPDATE users SET status = 'suspended' WHERE id = :id"),
+            {"id": non_admin_user_model.id},
+        )
+        await pg_session.commit()
+
+        response = await admin_client.put(
+            f"/api/v1/admin/users/{non_admin_user_model.id}/groups",
+            json={"group_ids": [group_id], "operation": "remove"},
+        )
+        assert response.status_code == 200
+
+        remaining = await pg_session.execute(
+            text("SELECT COUNT(*) FROM user_group_members WHERE user_id = :uid"),
+            {"uid": non_admin_user_model.id},
+        )
+        assert remaining.scalar() == 0
+
+
+@pytest.mark.asyncio
 class TestAdminUserPatchAuthorization:
     """Test authorization for PATCH endpoint."""
 

--- a/packages/console-backend/tests/test_group_router.py
+++ b/packages/console-backend/tests/test_group_router.py
@@ -436,6 +436,42 @@ class TestAddMembersEndpoint:
         assert "user-3" in user_ids and "user-4" in user_ids
 
     @pytest.mark.asyncio
+    async def test_add_members_rejects_non_active_users(
+        self,
+        get_mock_request,
+        mock_user,
+        db_test_user,
+        db_test_user_groups,
+        pg_session,
+    ):
+        """Test that suspended and unknown users are rejected server-side, not just hidden in the UI."""
+        from console_backend.models.user_group import GroupMemberAdd
+
+        await pg_session.execute(
+            text("""
+            INSERT INTO users (id, sub, email, first_name, last_name, is_administrator, role, status)
+            VALUES ('user-5', 'user-5', 'user5@test.com', 'User', 'Five', false, 'member', 'suspended')
+            """),
+        )
+        await pg_session.commit()
+        mock_request = get_mock_request(user=mock_user)
+
+        for user_ids in (["user-5"], ["user-unknown"], ["user-5", "user-unknown"]):
+            request_body = GroupMemberAdd(user_ids=user_ids, role="write")
+            with pytest.raises(HTTPException) as exc_info:
+                await group_router.add_members(1, mock_request, request_body, pg_session, mock_user)
+            assert exc_info.value.status_code == 400
+
+        # No membership row was created for any of them
+        count = await pg_session.execute(
+            text("""
+                SELECT COUNT(*) FROM user_group_members
+                WHERE user_group_id = 1 AND user_id IN ('user-5', 'user-unknown')
+            """)
+        )
+        assert count.scalar() == 0
+
+    @pytest.mark.asyncio
     async def test_add_members_group_not_found(
         self,
         get_mock_request,

--- a/packages/console-backend/tests/test_scim_router.py
+++ b/packages/console-backend/tests/test_scim_router.py
@@ -612,6 +612,34 @@ class TestScimGroups:
         member_ids = [m["value"] for m in data.get("members", [])]
         assert seed_user in member_ids
 
+    async def test_patch_group_add_suspended_member(self, scim_client, seed_group, seed_user, pg_session):
+        """The IdP owns the group graph: a user suspended here must still be mirrored into its groups."""
+        await pg_session.execute(
+            text("UPDATE users SET status = 'suspended' WHERE id = :id"),
+            {"id": seed_user},
+        )
+        await pg_session.commit()
+
+        response = await scim_client.patch(
+            f"/api/scim/v2/Groups/{seed_group}",
+            json={
+                "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+                "Operations": [
+                    {
+                        "op": "add",
+                        "path": "members",
+                        "value": [{"value": seed_user}],
+                    }
+                ],
+            },
+        )
+        assert response.status_code == 200
+        row = await pg_session.execute(
+            text("SELECT COUNT(*) FROM user_group_members WHERE user_group_id = :gid AND user_id = :uid"),
+            {"gid": int(seed_group), "uid": seed_user},
+        )
+        assert row.scalar() == 1
+
     async def test_patch_group_remove_member(self, scim_client, seed_group, seed_user, pg_session):
         # First add the member
         await pg_session.execute(

--- a/packages/console-backend/tests/test_sub_agent_service.py
+++ b/packages/console-backend/tests/test_sub_agent_service.py
@@ -870,6 +870,31 @@ class TestVersionSubmissionWorkflow:
         assert result.config_version.change_summary == summary
 
 
+class TestApproverEligibility:
+    """Test which users are offered a sub-agent's approval requests."""
+
+    @pytest.mark.asyncio
+    async def test_suspended_admin_is_not_an_eligible_approver(
+        self, pg_session: AsyncSession, sub_agent_service: SubAgentService, test_user_db: User, test_admin_user_db: User
+    ):
+        """Test that suspending a user removes them from the approvers notified for a submission."""
+        from sqlalchemy import text
+
+        agent = await _create_sub_agent(pg_session, test_user_db, "Agent", sub_agent_service)
+
+        eligible = await sub_agent_service._get_eligible_approvers_for_sub_agent(pg_session, agent.id)
+        assert test_admin_user_db.id in eligible
+
+        await pg_session.execute(
+            text("UPDATE users SET status = 'suspended' WHERE id = :id"),
+            {"id": test_admin_user_db.id},
+        )
+        await pg_session.commit()
+
+        eligible = await sub_agent_service._get_eligible_approvers_for_sub_agent(pg_session, agent.id)
+        assert test_admin_user_db.id not in eligible
+
+
 class TestVersionApprovalWorkflow:
     """Test version approval and rejection workflows."""
 

--- a/packages/console-frontend/src/pages/admin/GroupDetailPage.tsx
+++ b/packages/console-frontend/src/pages/admin/GroupDetailPage.tsx
@@ -285,7 +285,9 @@ export function GroupDetailPage() {
   const membersMeta = membersData?.meta ?? { page: 1, limit: 20, total: 0 };
   const allUsers = usersData?.data ?? [];
   const memberUserIds = new Set(members.map((m) => m.user_id));
-  const availableUsers = allUsers.filter((u) => !memberUserIds.has(u.id));
+  // Only active users can be added to a group — the backend rejects anyone else, and the admin user
+  // list this comes from deliberately still shows suspended users.
+  const availableUsers = allUsers.filter((u) => u.status === 'active' && !memberUserIds.has(u.id));
 
   const accessibleAgents = defaultAgentsData ?? [];
   const defaultAgents = accessibleAgents.filter((a: any) => a.is_default);


### PR DESCRIPTION
closes ringier-data/nannos#168

## What was wrong

A suspended user could be picked from the group *Add member* dialog and added:

- the picker filtered only on "not already a member" (`GroupDetailPage.tsx`),
- its source (`list_users`) excludes only `deleted` — correct for the admin user table, wrong as a picker feed,
- and `UserGroupService._add_members` validated the group but nothing about the user ids, so the API accepted them regardless of the UI.

Once added, the member was invisible: every membership read is scoped to `status = 'active'`, while the `user_group_members` row and the Keycloak membership stayed. So the member could not be seen or removed, could be "added" again, and reappeared on re-activation.

Separately, `_get_eligible_approvers_for_sub_agent` filtered on neither `status` nor `deleted_at`, so suspended and soft-deleted users were returned as eligible approvers and notified.

## The rule this implements

**A non-active user is never selectable and never notified; nothing else about them is pruned.** Their memberships and ownership stay in place, and sign-in already blocks them (`dependencies.py:187`).

## Changes

- `UserGroupService`: `_reject_inactive_users` rejects unknown, soft-deleted and suspended user ids in `_add_members`; `group_router.add_members` maps that to 400. The admin "set user groups" path already maps `ValueError` to 409 with the message.
- `ScimGroupService._add_member` passes `require_active=False`. The IdP owns the group graph and keeps suspended users (`active=false` → `suspended` here) in their groups, so mirroring it must not silently drop memberships that would be needed again on reactivation.
- `GroupDetailPage`: the picker offers active users only.
- `_get_eligible_approvers_for_sub_agent`: `status = 'active' AND deleted_at IS NULL`.

## Deliberately not in this PR

- **Whether a suspended member should be *visible* (badged) in the group member list** instead of silently filtered out. That is a product/UX call, not a correctness one — with the server-side guard in place the invisible-member bug can no longer be created, but a member suspended *after* joining still disappears from the list. Worth deciding separately; it needs a `MemberInfo.status` field, an SDK regeneration and UI work.
- `memberUserIds` in the picker is built from the *paginated* member list (limit 20), so members on page 2+ still show as available. Pre-existing and unrelated to status.
- Two names in the issue body were wrong and have been corrected there: there is no `get_members_by_ids` (the unfiltered query at that line is `_add_members`' own "return the added members" fetch, which is now covered by the guard), and the approver function is `_get_eligible_approvers_for_sub_agent`.

## Verification

- `pytest tests/test_group_router.py tests/test_admin_group_router.py tests/test_scim_router.py tests/test_user_management.py tests/test_admin_user_router.py tests/test_user_group_keycloak_transactions.py tests/test_group_default_agents.py` → 122 passed, plus the sub-agent approval/submission suites (23 passed).
- New tests: non-active and unknown ids rejected with no membership row created; SCIM still mirrors a suspended member; a suspended admin drops out of the eligible approvers.
- `tsc -b` clean; `eslint GroupDetailPage.tsx` reports the same 12 pre-existing `no-explicit-any` errors as on `main`; `ruff check` adds no new findings (the repo is not `ruff format`-clean on `main`).

## Checklist
- [x] I have performed a self-review of my code
- [x] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨 — the add-member API now rejects non-active user ids with 400 (previously accepted silently); no schema change.
