### PR TITLE
feat: raw-bytes tool catalogue — stateless MCP listing, shared with sub-agents, PTC eval self-correction

### DIFF
--- a/packages/agent-common/agent_common/agents/dynamic_agent.py
+++ b/packages/agent-common/agent_common/agents/dynamic_agent.py
@@ -90,6 +90,7 @@ from agent_common.core.graph_utils import (
 )
 from agent_common.core.model_factory import get_model_input_capabilities
 from agent_common.core.catalogue_ingest import fetch_catalogue_mcp
+from agent_common.core.token_provider import UserTokenProvider, bearer_interceptor
 from agent_common.core.tool_catalog import TOOL_CATALOG_PROMPT_ADDENDUM, ToolCatalogMiddleware
 from agent_common.core.tool_catalogue import get_catalogue_store, make_lazy_tool
 from agent_common.middleware.conversation_context_tools_middleware import ContextGatedTool
@@ -244,6 +245,7 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         inject_all_tools: Optional[List[BaseTool]] = None,
         tool_catalog: Optional[dict[str, BaseTool]] = None,
         pre_resolved_tools: Optional[Mapping[str, BaseTool]] = None,
+        token_provider: UserTokenProvider | None = None,
         risk_scorer: RiskScorerFn | None = None,
         tool_risk_cache: ToolRiskCache | None = None,
         tool_bypass_rules: dict[str, Any] | None = None,
@@ -271,6 +273,8 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
             user_id: User's stable database ID (for playbook loading)
             group_ids: User's group IDs for group playbook loading (all groups)
             extra_middlewares: Optional list of middleware instances to prepend to the standard stack.
+            token_provider: Optional per-user UserTokenProvider; exchanges go through it and
+                self-discovered tools mint their bearer per call instead of embedding one.
             pre_resolved_tools: Optional name -> tool map of already-authenticated MCP tools
                 discovered by the orchestrator for this user; whitelisted names present here
                 are reused without any token exchange or ``tools/list`` (missing ones are still
@@ -327,6 +331,11 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         # as-is — same user, same audience, same token — so a delegation performs no token
         # exchange and no tools/list of its own; only names missing here are discovered.
         self.pre_resolved_tools: Mapping[str, BaseTool] = pre_resolved_tools or {}
+        # The user's per-turn-refreshed provider of exchanged MCP bearers (from the embedding
+        # orchestrator). When present, this runnable's own exchanges go through it and the
+        # tools it discovers itself are built token-free with a per-call bearer interceptor,
+        # exactly like the orchestrator's. Standalone (agent-runner) keeps exchanging directly.
+        self.token_provider = token_provider
         self._risk_scorer: RiskScorerFn | None = risk_scorer
         self._tool_risk_cache: ToolRiskCache | None = tool_risk_cache
         self._tool_bypass_rules: dict[str, Any] = tool_bypass_rules if tool_bypass_rules is not None else {}
@@ -636,6 +645,8 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         MCP discovery — see _TokenExchangeError for why that matters.
         """
         try:
+            if self.token_provider is not None:
+                return await self.token_provider.get(target_client_id)
             return await self.oauth2_client.exchange_token(
                 subject_token=self.user_token,
                 target_client_id=target_client_id,
@@ -898,6 +909,25 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         store = get_catalogue_store()
         callbacks = client.callbacks
         tools: list[BaseTool] = []
+        # With a provider, tools must not embed the listing bearer: strip it from the connection
+        # they call on and mint per call instead (same as the orchestrator's tools).
+        interceptors: list[Any] | None = None
+        if self.token_provider is not None:
+            provider = self.token_provider
+
+            console_audience = self.console_backend_client_id or "agent-console"
+            gateway_audience = self.mcp_gateway_client_id or "gatana"
+
+            def _audience(server_name: str) -> str:
+                return console_audience if server_name == "console" else gateway_audience
+
+            interceptors = [bearer_interceptor(provider, _audience)]
+
+        def _call_connection(connection: Any) -> Any:
+            if interceptors is None or not isinstance(connection, dict) or not connection.get("headers"):
+                return connection
+            headers = {k: v for k, v in connection["headers"].items() if k.lower() != "authorization"}
+            return {**connection, "headers": headers or None}
 
         def _connection_for(tool_name: str, server_name: str | None = None) -> Any | None:
             """Pick the connection that can reach ``tool_name`` — by key, never by position.
@@ -921,7 +951,13 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
             if connection is None:
                 continue  # whitelisted but this agent has no connection that can reach it
             tools.append(
-                make_lazy_tool(held_entry, server_name=held.server_name, connection=connection, callbacks=callbacks)
+                make_lazy_tool(
+                    held_entry,
+                    server_name=held.server_name,
+                    connection=_call_connection(connection),
+                    callbacks=callbacks,
+                    tool_interceptors=interceptors,
+                )
             )
         missing = {n for n in wanted if n not in resolved and _connection_for(n) is not None}
 
@@ -944,7 +980,13 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                     if entry is None:
                         continue
                     tools.append(
-                        make_lazy_tool(entry, server_name=catalogue.server_name, connection=connection, callbacks=callbacks)
+                        make_lazy_tool(
+                            entry,
+                            server_name=catalogue.server_name,
+                            connection=_call_connection(connection),
+                            callbacks=callbacks,
+                            tool_interceptors=interceptors,
+                        )
                     )
                     fetched += 1
         logger.info(
@@ -1046,11 +1088,7 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         try:
             console_headers: dict[str, str] = {}
             if self.oauth2_client and self.user_token:
-                console_token = await self.oauth2_client.exchange_token(
-                    subject_token=self.user_token,
-                    target_client_id=self.console_backend_client_id,
-                    requested_scopes=["openid", "profile", "offline_access"],
-                )
+                console_token = await self._exchange_token_for(self.console_backend_client_id or "agent-console")
                 console_headers["Authorization"] = f"Bearer {console_token}"
             elif self.user_token:
                 console_headers["Authorization"] = f"Bearer {self.user_token}"
@@ -1886,6 +1924,7 @@ def create_dynamic_local_subagent(
     inject_all_tools: Optional[List[BaseTool]] = None,
     tool_catalog: Optional[dict[str, BaseTool]] = None,
     pre_resolved_tools: Optional[Mapping[str, BaseTool]] = None,
+    token_provider: UserTokenProvider | None = None,
     risk_scorer: RiskScorerFn | None = None,
     tool_risk_cache: ToolRiskCache | None = None,
     tool_bypass_rules: dict[str, Any] | None = None,
@@ -1959,6 +1998,7 @@ def create_dynamic_local_subagent(
         inject_all_tools=inject_all_tools,
         tool_catalog=tool_catalog,
         pre_resolved_tools=pre_resolved_tools,
+        token_provider=token_provider,
         risk_scorer=risk_scorer,
         tool_risk_cache=tool_risk_cache,
         tool_bypass_rules=tool_bypass_rules,

--- a/packages/agent-common/agent_common/agents/dynamic_agent.py
+++ b/packages/agent-common/agent_common/agents/dynamic_agent.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import AsyncIterable, Callable
+from collections.abc import AsyncIterable, Callable, Mapping
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
 from deepagents import CompiledSubAgent
@@ -89,7 +89,9 @@ from agent_common.core.graph_utils import (
     isolate_parent_stream_context,
 )
 from agent_common.core.model_factory import get_model_input_capabilities
+from agent_common.core.catalogue_ingest import fetch_catalogue_mcp
 from agent_common.core.tool_catalog import TOOL_CATALOG_PROMPT_ADDENDUM, ToolCatalogMiddleware
+from agent_common.core.tool_catalogue import get_catalogue_store, make_lazy_tool
 from agent_common.middleware.conversation_context_tools_middleware import ContextGatedTool
 from agent_common.utils import get_language_display_name
 
@@ -241,6 +243,7 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         extra_middlewares: Optional[List[Any]] = None,
         inject_all_tools: Optional[List[BaseTool]] = None,
         tool_catalog: Optional[dict[str, BaseTool]] = None,
+        pre_resolved_tools: Optional[Mapping[str, BaseTool]] = None,
         risk_scorer: RiskScorerFn | None = None,
         tool_risk_cache: ToolRiskCache | None = None,
         tool_bypass_rules: dict[str, Any] | None = None,
@@ -268,6 +271,10 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
             user_id: User's stable database ID (for playbook loading)
             group_ids: User's group IDs for group playbook loading (all groups)
             extra_middlewares: Optional list of middleware instances to prepend to the standard stack.
+            pre_resolved_tools: Optional name -> tool map of already-authenticated MCP tools
+                discovered by the orchestrator for this user; whitelisted names present here
+                are reused without any token exchange or ``tools/list`` (missing ones are still
+                discovered).
             inject_all_tools: Optional pre-discovered tools to use directly (bypasses MCP discovery).
                 When set, these tools are used as the agent's MCP tools without gateway discovery.
             tool_catalog: Optional name -> BaseTool mapping (held by reference) of a large
@@ -315,6 +322,11 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         self.extra_middlewares = extra_middlewares
         self.inject_all_tools = inject_all_tools
         self.tool_catalog = tool_catalog
+        # Already-authenticated tools the embedding orchestrator discovered for this same
+        # user (name -> tool). Whitelisted / self-improvement names found here are reused
+        # as-is — same user, same audience, same token — so a delegation performs no token
+        # exchange and no tools/list of its own; only names missing here are discovered.
+        self.pre_resolved_tools: Mapping[str, BaseTool] = pre_resolved_tools or {}
         self._risk_scorer: RiskScorerFn | None = risk_scorer
         self._tool_risk_cache: ToolRiskCache | None = tool_risk_cache
         self._tool_bypass_rules: dict[str, Any] = tool_bypass_rules if tool_bypass_rules is not None else {}
@@ -671,7 +683,20 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
 
         mcp_gateway_url = self.mcp_gateway_url
         mcp_gateway_client_id = self.mcp_gateway_client_id
-        mcp_tool_names = set(self.config.mcp_tools or [])
+        wanted = set(self.config.mcp_tools or [])
+
+        # Reuse the orchestrator's already-authenticated tools for every name it holds;
+        # only the remainder needs a connection of our own.
+        pre_resolved = self._take_pre_resolved(wanted)
+        mcp_tool_names = wanted - pre_resolved.keys()
+        if pre_resolved:
+            logger.info(
+                f"Reusing {len(pre_resolved)}/{len(wanted)} MCP tools for {self.name} from the orchestrator "
+                f"(no token exchange, no tools/list); {len(mcp_tool_names)} still to discover"
+            )
+        if not mcp_tool_names:
+            self._mcp_discovery_error = None
+            return list(pre_resolved.values())
 
         # Determine which MCP servers to connect to. ``is_console_backend_tool``
         # (module-level) is the single source of truth for the console-backend
@@ -741,14 +766,11 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
                     callbacks=Callbacks(on_progress=on_mcp_progress),
                 )
 
-                tools = await client.get_tools()
-                logger.info(f"Discovered {len(tools)} MCP tools for {self.name}")
-
-                tools = [tool for tool in tools if tool.name in mcp_tool_names]
+                tools = await self._resolve_catalogue_tools(client, connections, mcp_tool_names)
                 logger.info(f"Filtered to {len(tools)} tools based on whitelist for {self.name}")
 
                 # Validate tool schemas to prevent OpenAI API errors
-                validated_tools = [_validate_tool_schema(tool) for tool in tools]
+                validated_tools = list(pre_resolved.values()) + [_validate_tool_schema(tool) for tool in tools]
 
                 if attempt > 0:
                     logger.info(f"Successfully discovered MCP tools for {self.name} on attempt {attempt + 1}")
@@ -843,6 +865,88 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         }
     )
 
+    def _take_pre_resolved(self, wanted: set[str]) -> dict[str, BaseTool]:
+        """Pick the wanted names the orchestrator already resolved, as validated private copies.
+
+        Copies (``model_copy``) because ``_validate_tool_schema`` may rewrite ``args_schema``
+        in place and the originals are the orchestrator's live registry entries shared with
+        every other consumer this turn.
+        """
+        found: dict[str, BaseTool] = {}
+        for name in wanted:
+            tool = self.pre_resolved_tools.get(name)
+            if isinstance(tool, BaseTool):
+                found[name] = _validate_tool_schema(tool.model_copy())
+        return found
+
+    async def _resolve_catalogue_tools(
+        self,
+        client: MultiServerMCPClient,
+        connections: Mapping[str, Any],
+        wanted: set[str],
+    ) -> List[BaseTool]:
+        """Resolve a whitelist of tool names to tools, reusing catalogues already in the process.
+
+        The orchestrator's discovery interns every server's catalogue (bytes + cards) in the
+        process-wide :class:`CatalogueStore`; a sub-agent only needs a handful of names from
+        it, so first look them up there — no network at all. Only names the store does not
+        hold trigger an MCP ``tools/list`` on this agent's own connection(s), and that
+        result is interned too (flattened to bytes, pydantic objects dropped) so the next
+        delegation is served from the store. Every returned tool is a :class:`LazyMcpTool`
+        bound to *this agent's* connection (its own exchanged token), whatever the source.
+        """
+        store = get_catalogue_store()
+        callbacks = client.callbacks
+        tools: list[BaseTool] = []
+
+        def _connection_for(tool_name: str) -> Any | None:
+            if is_console_backend_tool(tool_name):
+                return connections.get("console")
+            gateway = [c for name, c in connections.items() if name != "console"]
+            return gateway[0] if gateway else None
+
+        resolved = store.resolve(wanted)
+        for name, (held, held_entry) in resolved.items():
+            connection = _connection_for(name)
+            if connection is None:
+                continue  # whitelisted but this agent has no connection that can reach it
+            tools.append(
+                make_lazy_tool(held_entry, server_name=held.server_name, connection=connection, callbacks=callbacks)
+            )
+        missing = {n for n in wanted if n not in resolved and _connection_for(n) is not None}
+
+        fetched = 0
+        if missing:
+            # Which connections can still contribute: console for console_*/scheduler_*
+            # names, the gateway-wide connection for everything else.
+            need_console = any(is_console_backend_tool(n) for n in missing)
+            need_gateway = any(not is_console_backend_tool(n) for n in missing)
+            for conn_name, connection in connections.items():
+                is_console = conn_name == "console"
+                if (is_console and not need_console) or (not is_console and not need_gateway):
+                    continue
+                def _open_session(name: str = conn_name) -> Any:
+                    return client.session(name)
+
+                catalogue = store.intern(await fetch_catalogue_mcp(_open_session, server_slug=conn_name))
+                for name in sorted(missing):
+                    entry = catalogue.tools.get(name)
+                    if entry is None:
+                        continue
+                    tools.append(
+                        make_lazy_tool(entry, server_name=catalogue.server_name, connection=connection, callbacks=callbacks)
+                    )
+                    fetched += 1
+        logger.info(
+            "Resolved %d/%d MCP tools for %s: %d from the shared catalogue store, %d via tools/list",
+            len(tools),
+            len(wanted),
+            self.name,
+            len(tools) - fetched,
+            fetched,
+        )
+        return tools
+
     def _wrap_with_agent_name(self, tool: BaseTool) -> BaseTool:
         """Wrap a tool to auto-inject agent_name, hiding it from the LLM schema.
 
@@ -919,6 +1023,16 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
             logger.debug(f"No console backend MCP URL configured for {self.name}, skipping self-improvement tools")
             return []
 
+        wanted = set(self._CONSOLE_SELF_IMPROVEMENT_TOOLS)
+        pre_resolved = self._take_pre_resolved(wanted)
+        missing = wanted - pre_resolved.keys()
+        pre_wrapped = [self._wrap_with_agent_name(t) for t in pre_resolved.values()]
+        if not missing:
+            logger.info(
+                f"Reusing {len(pre_wrapped)} console self-improvement tools for {self.name} from the orchestrator"
+            )
+            return pre_wrapped
+
         try:
             console_headers: dict[str, str] = {}
             if self.oauth2_client and self.user_token:
@@ -931,23 +1045,23 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
             elif self.user_token:
                 console_headers["Authorization"] = f"Bearer {self.user_token}"
 
+            connections: dict[str, Any] = {
+                "console": StreamableHttpConnection(
+                    transport="streamable_http",
+                    url=self.console_backend_mcp_url,
+                    headers=console_headers if console_headers else None,
+                ),
+            }
             client = MultiServerMCPClient(
-                connections={
-                    "console": StreamableHttpConnection(
-                        transport="streamable_http",
-                        url=self.console_backend_mcp_url,
-                        headers=console_headers if console_headers else None,
-                    ),
-                },
+                connections=connections,
                 callbacks=Callbacks(on_progress=on_mcp_progress),
             )
 
-            tools = await client.get_tools()
-            tools = [t for t in tools if t.name in self._CONSOLE_SELF_IMPROVEMENT_TOOLS]
+            tools = await self._resolve_catalogue_tools(client, connections, missing)
             validated = [_validate_tool_schema(t) for t in tools]
 
             # Wrap tools to auto-inject agent_name so the LLM doesn't need to provide it
-            wrapped = [self._wrap_with_agent_name(t) for t in validated]
+            wrapped = pre_wrapped + [self._wrap_with_agent_name(t) for t in validated]
             logger.info(f"Discovered {len(wrapped)} console self-improvement tools for {self.name}")
             return wrapped
 
@@ -1761,6 +1875,7 @@ def create_dynamic_local_subagent(
     extra_middlewares: Optional[List[Any]] = None,
     inject_all_tools: Optional[List[BaseTool]] = None,
     tool_catalog: Optional[dict[str, BaseTool]] = None,
+    pre_resolved_tools: Optional[Mapping[str, BaseTool]] = None,
     risk_scorer: RiskScorerFn | None = None,
     tool_risk_cache: ToolRiskCache | None = None,
     tool_bypass_rules: dict[str, Any] | None = None,
@@ -1833,6 +1948,7 @@ def create_dynamic_local_subagent(
         extra_middlewares=extra_middlewares,
         inject_all_tools=inject_all_tools,
         tool_catalog=tool_catalog,
+        pre_resolved_tools=pre_resolved_tools,
         risk_scorer=risk_scorer,
         tool_risk_cache=tool_risk_cache,
         tool_bypass_rules=tool_bypass_rules,

--- a/packages/agent-common/agent_common/agents/dynamic_agent.py
+++ b/packages/agent-common/agent_common/agents/dynamic_agent.py
@@ -899,15 +899,25 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         callbacks = client.callbacks
         tools: list[BaseTool] = []
 
-        def _connection_for(tool_name: str) -> Any | None:
+        def _connection_for(tool_name: str, server_name: str | None = None) -> Any | None:
+            """Pick the connection that can reach ``tool_name`` — by key, never by position.
+
+            Console-backend tools go to the ``console`` connection. Everything else is a
+            gateway tool: prefer a connection keyed by the tool's own server slug (an agent
+            wired with per-server connections), else the gateway-wide connection keyed by
+            ``mcp_gateway_client_id`` (how this runnable builds it). ``None`` means this agent
+            has no connection that can reach the tool, so it is skipped rather than guessed.
+            """
             if is_console_backend_tool(tool_name):
                 return connections.get("console")
-            gateway = [c for name, c in connections.items() if name != "console"]
-            return gateway[0] if gateway else None
+            if server_name and server_name != "console" and server_name in connections:
+                return connections[server_name]
+            gateway_key = self.mcp_gateway_client_id
+            return connections.get(gateway_key) if gateway_key else None
 
         resolved = store.resolve(wanted)
         for name, (held, held_entry) in resolved.items():
-            connection = _connection_for(name)
+            connection = _connection_for(name, held.server_name)
             if connection is None:
                 continue  # whitelisted but this agent has no connection that can reach it
             tools.append(

--- a/packages/agent-common/agent_common/agents/dynamic_agent.py
+++ b/packages/agent-common/agent_common/agents/dynamic_agent.py
@@ -904,7 +904,9 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         hold trigger an MCP ``tools/list`` on this agent's own connection(s), and that
         result is interned too (flattened to bytes, pydantic objects dropped) so the next
         delegation is served from the store. Every returned tool is a :class:`LazyMcpTool`
-        bound to *this agent's* connection (its own exchanged token), whatever the source.
+        bound to *this agent's* connection, whatever the source — token-free with a per-call
+        bearer interceptor when a token provider is configured, else carrying this agent's own
+        exchanged token (standalone execution).
         """
         store = get_catalogue_store()
         callbacks = client.callbacks

--- a/packages/agent-common/agent_common/core/catalogue_ingest.py
+++ b/packages/agent-common/agent_common/core/catalogue_ingest.py
@@ -114,6 +114,7 @@ def _walk_object(
 ) -> Iterator[Any]:
     pos = _skip_ws(text, pos + 1)  # past '{'
     if text[pos] == "}":
+        siblings["__end__"] = pos + 1  # an empty object still has to report where it ends
         return
     while True:
         key, pos = dec.raw_decode(text, pos)
@@ -272,8 +273,10 @@ async def fetch_catalogue_stateless(
         try:
             body = rpc_body_from_response(response)
             page, cursor = parse_tools_list_reply(server_slug, body)
-        except (ValueError, IndexError) as e:
-            # IndexError: the bounded scanner ran off the end of a truncated body.
+        except (ValueError, LookupError) as e:
+            # LookupError: the bounded scanner ran off the end of a truncated body (IndexError)
+            # or met a shape it does not handle (KeyError) — never let a parser bug take the
+            # server down when the SDK path can still list it.
             raise StatelessListError(f"{url}: unparseable tools/list reply: {e}") from e
         tools.extend(page)
         if not cursor:

--- a/packages/agent-common/agent_common/core/catalogue_ingest.py
+++ b/packages/agent-common/agent_common/core/catalogue_ingest.py
@@ -1,0 +1,327 @@
+"""Ingest strategies that turn a server's tool list into a :class:`ServerCatalogue`.
+
+Two paths, one representation (see :mod:`tool_catalogue`):
+
+* :func:`fetch_catalogue_stateless` — **fast path, feature-detected, never assumed.** A
+  single stateless JSON-RPC ``tools/list`` POST over plain ``httpx`` to the server's MCP
+  URL — the standard MCP method and result shape, but without the SDK: no
+  ``initialize``, no session id, no protocol negotiation, no resumability to own. The
+  reply (JSON, or a single SSE frame) is scanned one tool at a time with a bounded
+  ``raw_decode`` walk, so at no point is the catalogue materialised as Python objects and
+  pydantic is never involved. Because it is the MCP listing itself, made with the
+  caller's own token, the gateway applies overrides, disabled flags and per-user
+  entitlements exactly as it does for the SDK path. A server that refuses a stateless
+  request (a JSON-RPC error or 4xx on the probe) marks the path unsupported for that URL
+  and everything falls back; any other failure falls back for that server only.
+  This is the same pattern console-backend uses in production for its own tool
+  listing and tool calls (``console_backend.services.mcp_tool_client``).
+* :func:`fetch_catalogue_mcp` — **universal fallback**: the MCP ``tools/list`` through
+  the SDK session exactly as before. It still pays the SDK's parse on receive, but
+  each ``mcp.types.Tool`` is immediately flattened to bytes + card and the pydantic
+  objects dropped, recovering the steady-state and cross-user sharing wins; only the
+  transient parse peak remains (bounded by the inbound size guard once #153 lands).
+
+Which path each server took is reported to the caller so discovery can log it —
+a silent fall-back to the slow path must be visible, not mysterious.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import AbstractAsyncContextManager
+from typing import Any
+
+import httpx
+
+from agent_common.core.tool_catalogue import (
+    CatalogueTool,
+    ServerCatalogue,
+    build_server_catalogue,
+    make_catalogue_tool,
+)
+
+logger = logging.getLogger(__name__)
+
+# Default per-request timeout for a stateless catalogue fetch. Catalogues can be tens of MB.
+STATELESS_TIMEOUT_S = 30.0
+
+# One JSON-RPC id per request so a notification or ping streamed ahead of the reply on an
+# SSE response can never be mistaken for it.
+_LIST_ID = "catalogue-tools-list"
+
+# Never follow more than this many `nextCursor` pages for one server.
+_MAX_LIST_PAGES = 1000
+
+# JSON-RPC error codes that mean "this server will not serve a stateless request", as
+# opposed to a transient failure. -32600 invalid request (e.g. "session required"),
+# -32601 method not found, -32602 invalid params.
+_UNSUPPORTED_RPC_CODES = {-32600, -32601, -32602}
+
+
+class StatelessListUnsupported(Exception):
+    """The MCP endpoint does not serve ``tools/list`` without a session — fall back for good."""
+
+
+class StatelessListError(Exception):
+    """The endpoint serves stateless requests but this fetch failed — fall back for this server only."""
+
+
+# --------------------------------------------------------------------------------------
+# Bounded scanner: walk a JSON object by key path and yield one array element at a time
+# --------------------------------------------------------------------------------------
+
+_WS = re.compile(r"\s*")
+
+
+def _skip_ws(text: str, pos: int) -> int:
+    return _WS.match(text, pos).end()  # type: ignore[union-attr]
+
+
+def iter_array_at(
+    text: str,
+    path: tuple[str, ...],
+    siblings: dict[str, Any] | None = None,
+    *,
+    keep: frozenset[str] = frozenset(),
+) -> Iterator[Any]:
+    """Yield the elements of the array found at ``path`` in a JSON object, one at a time.
+
+    Walks objects key by key with ``JSONDecoder.raw_decode`` so only one element of the
+    target array is alive at once; every other member along the way is decoded and
+    dropped, except keys named in ``keep`` (small scalars such as ``nextCursor`` or
+    ``error``) which are stored in ``siblings`` keyed by ``"<depth>.<key>"`` → value.
+    Locating the array by *parsing* (rather than searching for ``"tools": [``) means a
+    tool whose schema contains a ``tools`` property cannot derail the scan.
+    """
+    dec = json.JSONDecoder()
+    pos = _skip_ws(text, 0)
+    if pos >= len(text) or text[pos] != "{":
+        raise ValueError("payload is not a JSON object")
+    yield from _walk_object(text, pos, path, 0, dec, siblings if siblings is not None else {}, keep)
+
+
+def _walk_object(
+    text: str,
+    pos: int,
+    path: tuple[str, ...],
+    depth: int,
+    dec: json.JSONDecoder,
+    siblings: dict[str, Any],
+    keep: frozenset[str],
+) -> Iterator[Any]:
+    pos = _skip_ws(text, pos + 1)  # past '{'
+    if text[pos] == "}":
+        return
+    while True:
+        key, pos = dec.raw_decode(text, pos)
+        pos = _skip_ws(text, pos)
+        if text[pos] != ":":
+            raise ValueError("malformed payload (expected ':')")
+        pos = _skip_ws(text, pos + 1)
+        if key == path[depth]:
+            if depth == len(path) - 1:
+                if text[pos] != "[":
+                    raise ValueError(f"'{key}' is not an array")
+                pos = _skip_ws(text, pos + 1)
+                if text[pos] != "]":
+                    while True:
+                        item, pos = dec.raw_decode(text, pos)
+                        yield item
+                        pos = _skip_ws(text, pos)
+                        if text[pos] == ",":
+                            pos = _skip_ws(text, pos + 1)
+                            continue
+                        if text[pos] == "]":
+                            break
+                        raise ValueError(f"malformed '{key}' array")
+                pos += 1
+            else:
+                if text[pos] != "{":
+                    raise ValueError(f"'{key}' is not an object")
+                # Recurse; the nested walker leaves `pos` just past its closing brace.
+                sub = _walk_object(text, pos, path, depth + 1, dec, siblings, keep)
+                yield from sub
+                pos = siblings.pop("__end__")
+        else:
+            value, pos = dec.raw_decode(text, pos)
+            if key in keep:
+                siblings[f"{depth}.{key}"] = value
+        pos = _skip_ws(text, pos)
+        if text[pos] == ",":
+            pos = _skip_ws(text, pos + 1)
+            continue
+        if text[pos] == "}":
+            siblings["__end__"] = pos + 1
+            return
+        raise ValueError("malformed payload")
+
+
+# --------------------------------------------------------------------------------------
+# Stateless JSON-RPC tools/list
+# --------------------------------------------------------------------------------------
+
+
+def rpc_body_from_response(response: httpx.Response) -> str:
+    """Return the JSON-RPC reply text, whether the server answered JSON or a single SSE frame.
+
+    An SSE reply may carry notifications or pings ahead of the response: take the first
+    ``data:`` line that is a response (has ``result`` or ``error``) with our request id.
+    Kept textual so the caller can scan it without decoding the whole catalogue.
+    """
+    content_type = response.headers.get("content-type", "")
+    if "text/event-stream" not in content_type:
+        return response.text
+    for line in response.text.split("\n"):
+        if not line.startswith("data:"):
+            continue
+        data = line[5:].removeprefix(" ").rstrip("\r")
+        # Cheap pre-check before scanning: must look like our response envelope.
+        if f'"id": "{_LIST_ID}"' in data or f'"id":"{_LIST_ID}"' in data:
+            if '"result"' in data or '"error"' in data:
+                return data
+    raise ValueError("no JSON-RPC response frame in SSE reply")
+
+
+def mcp_tool_dict_to_catalogue_tool(server_name: str, item: Mapping[str, Any]) -> CatalogueTool | None:
+    """Flatten one ``tools/list`` result element (a plain dict) into bytes + card."""
+    name = item.get("name")
+    if not isinstance(name, str) or not name:
+        return None
+    description = item.get("description")
+    return make_catalogue_tool(
+        server_name=server_name,
+        name=name,
+        description=description if isinstance(description, str) else None,
+        input_schema=item.get("inputSchema") if isinstance(item.get("inputSchema"), Mapping) else None,
+        output_schema=item.get("outputSchema") if isinstance(item.get("outputSchema"), Mapping) else None,
+        annotations=item.get("annotations") if isinstance(item.get("annotations"), Mapping) else None,
+        meta=item.get("_meta") if isinstance(item.get("_meta"), Mapping) else None,
+    )
+
+
+def parse_tools_list_reply(server_name: str, body: str) -> tuple[list[CatalogueTool], str | None]:
+    """Scan one ``tools/list`` JSON-RPC reply into catalogue tools + the next cursor.
+
+    Raises :class:`StatelessListUnsupported` for a JSON-RPC error whose code says the
+    server will not serve this request, :class:`StatelessListError` for other RPC errors,
+    and ``ValueError`` for a malformed body.
+    """
+    siblings: dict[str, Any] = {}
+    tools: list[CatalogueTool] = []
+    for item in iter_array_at(body, ("result", "tools"), siblings, keep=frozenset({"error", "nextCursor", "id"})):
+        if isinstance(item, Mapping):
+            tool = mcp_tool_dict_to_catalogue_tool(server_name, item)
+            if tool is not None:
+                tools.append(tool)
+    error = siblings.get("0.error")
+    if isinstance(error, dict):
+        code = error.get("code")
+        message = error.get("message") or "unknown error"
+        if code in _UNSUPPORTED_RPC_CODES or "session" in str(message).lower():
+            raise StatelessListUnsupported(f"JSON-RPC {code}: {message}")
+        raise StatelessListError(f"JSON-RPC {code}: {message}")
+    cursor = siblings.get("1.nextCursor")
+    return tools, cursor if isinstance(cursor, str) and cursor else None
+
+
+async def fetch_catalogue_stateless(
+    client: httpx.AsyncClient,
+    *,
+    url: str,
+    headers: Mapping[str, str] | None,
+    server_slug: str,
+) -> ServerCatalogue:
+    """``tools/list`` (all pages) as stateless JSON-RPC POSTs, scanned into a catalogue.
+
+    ``url``/``headers`` are the server's MCP connection (the same URL and bearer token
+    the SDK path would use, e.g. ``…/mcp?includeOnlyServerSlugs=<slug>``).
+    """
+    request_headers = {
+        **(headers or {}),
+        "Content-Type": "application/json",
+        # Gateways may answer either; accept both so a streaming-only server still works.
+        "Accept": "application/json, text/event-stream",
+    }
+    tools: list[CatalogueTool] = []
+    cursor: str | None = None
+    for _ in range(_MAX_LIST_PAGES):
+        params: dict[str, Any] = {"cursor": cursor} if cursor else {}
+        try:
+            response = await client.post(
+                url,
+                headers=request_headers,
+                json={"jsonrpc": "2.0", "id": _LIST_ID, "method": "tools/list", "params": params},
+            )
+        except httpx.HTTPError as e:
+            raise StatelessListError(f"{url}: {e}") from e
+        if 300 <= response.status_code < 400:
+            # Redirect not followed (client built without follow_redirects): retrying via the
+            # SDK would follow it, so treat as a per-server failure, not a refusal.
+            raise StatelessListError(
+                f"{url} -> HTTP {response.status_code} redirect to {response.headers.get('location')!r} not followed"
+            )
+        if response.status_code in (400, 404, 405, 406):
+            # The endpoint rejects the request shape itself (no session, wrong method,
+            # unacceptable media) — a property of the endpoint, not of this fetch.
+            raise StatelessListUnsupported(f"{url} -> HTTP {response.status_code}: {response.text[:200]}")
+        if response.status_code >= 400:
+            raise StatelessListError(f"{url} -> HTTP {response.status_code}: {response.text[:300]}")
+        try:
+            body = rpc_body_from_response(response)
+            page, cursor = parse_tools_list_reply(server_slug, body)
+        except (ValueError, IndexError) as e:
+            # IndexError: the bounded scanner ran off the end of a truncated body.
+            raise StatelessListError(f"{url}: unparseable tools/list reply: {e}") from e
+        tools.extend(page)
+        if not cursor:
+            break
+    else:
+        raise StatelessListError(f"tools/list on '{server_slug}' exceeded {_MAX_LIST_PAGES} pages")
+    return build_server_catalogue(server_slug, tools, source="stateless")
+
+
+# --------------------------------------------------------------------------------------
+# SDK-session fallback
+# --------------------------------------------------------------------------------------
+
+
+def mcp_tool_to_catalogue_tool(server_name: str, tool: Any) -> CatalogueTool:
+    """Flatten an ``mcp.types.Tool`` into bytes + card (the pydantic object is dropped by the caller)."""
+    annotations = tool.annotations.model_dump(exclude_none=True) if getattr(tool, "annotations", None) else None
+    return make_catalogue_tool(
+        server_name=server_name,
+        name=tool.name,
+        description=tool.description,
+        input_schema=tool.inputSchema,
+        output_schema=getattr(tool, "outputSchema", None),
+        annotations=annotations,
+        meta=getattr(tool, "meta", None),
+    )
+
+
+async def fetch_catalogue_mcp(
+    session_factory: Callable[[], AbstractAsyncContextManager[Any]],
+    *,
+    server_slug: str,
+) -> ServerCatalogue:
+    """``tools/list`` (all pages) through an MCP SDK session, flattened page by page.
+
+    ``session_factory`` is typically ``lambda: client.session(server_slug)`` on a
+    ``MultiServerMCPClient`` — it owns transport, callbacks and ``initialize()``.
+    """
+    tools: list[CatalogueTool] = []
+    async with session_factory() as session:
+        cursor: str | None = None
+        for _ in range(_MAX_LIST_PAGES):
+            page = await session.list_tools(cursor=cursor)
+            for mcp_tool in page.tools or []:
+                tools.append(mcp_tool_to_catalogue_tool(server_slug, mcp_tool))
+            cursor = page.nextCursor
+            if not cursor:
+                break
+        else:
+            raise RuntimeError(f"tools/list on '{server_slug}' exceeded {_MAX_LIST_PAGES} pages")
+    return build_server_catalogue(server_slug, tools, source="mcp")

--- a/packages/agent-common/agent_common/core/graph_utils.py
+++ b/packages/agent-common/agent_common/core/graph_utils.py
@@ -26,9 +26,12 @@ build_sub_agent_graph
 from __future__ import annotations
 
 import contextlib
+from collections.abc import Iterable
 import contextvars
+import difflib
 import logging
 import os
+import re
 import threading
 from typing import TYPE_CHECKING, Annotated, Any, Iterator, Optional
 
@@ -54,6 +57,7 @@ from langchain.agents.middleware.types import PrivateStateAttr
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import ToolMessage
 from langchain_quickjs import CodeInterpreterMiddleware
+from langchain_quickjs._prompt import to_camel_case
 from langchain_quickjs.middleware import REPLState, _resolve_thread_id
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.config import get_config
@@ -391,6 +395,103 @@ def code_interpreter_ptc_enabled() -> bool:
     return _code_interpreter_ptc_enabled()
 
 
+# Appended to the interpreter prompt: langchain-quickjs' own text only *prefers* the
+# last expression over console.log; it never says the code is a script, so models
+# trained on function-bodied sandboxes emit `return x;` and hit a SyntaxError.
+_TOP_LEVEL_RETURN_RULE = (
+    "\n- The code runs as a script, not inside a function: a top-level `return` is a "
+    "SyntaxError. End with the expression whose value you want back (e.g. the variable "
+    "holding your result) instead of `return`ing it.\n"
+)
+
+_TOP_LEVEL_RETURN_ERROR_MARKER = "'return' statement can only be used within a function body"
+
+# Console tools that list raw MCP tool names; kept out of ``eval`` when discovery is attached.
+_RAW_LISTING_TOOL_NAMES = frozenset({"console_grep_mcp_tools", "console_list_mcp_servers"})
+
+# ``tools.<name>`` member accesses in an eval program.
+_TOOLS_MEMBER_RE = re.compile(r"\btools\.([A-Za-z_$][\w$]*)")
+
+# Names models reach for by habit that map onto the PTC discovery surface.
+_DISCOVERY_SYNONYMS = {
+    "search_tools": PTC_SEARCH_TOOL_NAME,
+    "searchTools": PTC_SEARCH_TOOL_NAME,
+    "describe_tool": PTC_DESCRIBE_TOOL_NAME,
+    "describeTool": PTC_DESCRIBE_TOOL_NAME,
+}
+
+
+def _is_not_a_function_error(result: Any) -> bool:
+    content = getattr(result, "content", result)
+    if isinstance(content, list):
+        content = " ".join(block.get("text", "") if isinstance(block, dict) else str(block) for block in content)
+    return isinstance(content, str) and 'type="TypeError"' in content and "not a function" in content
+
+
+def _not_a_function_hint(code: str, exposed_names: Iterable[str]) -> str:
+    """Explain a ``tools.<x> is not a function`` in terms the model can act on.
+
+    QuickJS' message does not name the member, so find every ``tools.<x>`` in the
+    program that is not an exposed camelCase bridge and say what it should have been.
+    The advice depends on what this ``eval`` actually has: with in-sandbox discovery
+    (core-only mode) point at ``tools.search``; without it (inline mode — the
+    orchestrator's few whitelisted tools) list the callable names and say the rest are
+    regular tool calls or a ``task`` delegation. No aliases are installed: the namespace
+    stays camelCase-only, the error just becomes self-correcting.
+    """
+    exposed = [n for n in exposed_names if isinstance(n, str)]
+    known = {to_camel_case(n) for n in exposed}
+    has_search = PTC_SEARCH_TOOL_NAME in known
+    raw_listers_camel = {to_camel_case(n) for n in _RAW_LISTING_TOOL_NAMES}
+    callable_list = ", ".join(f"`tools.{n}`" for n in sorted(known)[:30]) + (" …" if len(known) > 30 else "")
+    outside = (
+        "Tools not in that list are not reachable from eval: call them as regular tool calls if you have "
+        "them, or delegate the work with `task`."
+    )
+    search_tip = f"Use `await tools.{PTC_SEARCH_TOOL_NAME}({{ query: '...' }})` to find callable names."
+
+    lines: list[str] = []
+    for ident in dict.fromkeys(_TOOLS_MEMBER_RE.findall(code)):
+        if ident in known:
+            continue
+        camel = to_camel_case(ident)
+        if ident in _DISCOVERY_SYNONYMS:
+            if has_search:
+                lines.append(f"`tools.{ident}` does not exist — use `tools.{_DISCOVERY_SYNONYMS[ident]}`.")
+            else:
+                lines.append(f"`tools.{ident}` does not exist and this eval has no discovery helper. Callable here: {callable_list}. {outside}")
+        elif ident == "call_tool":
+            lines.append("`tools.call_tool` does not exist — call the tool directly, e.g. `await tools.githubGetMe({...})`.")
+        elif camel in known:
+            lines.append(f"`tools.{ident}` does not exist — tool names are camelCase here: use `tools.{camel}`.")
+        elif ident in _RAW_LISTING_TOOL_NAMES or camel in raw_listers_camel:
+            lines.append(
+                f"`tools.{ident}` is not available inside eval. Call `{ident if ident in _RAW_LISTING_TOOL_NAMES else next(n for n in _RAW_LISTING_TOOL_NAMES if to_camel_case(n) == camel)}` "
+                "as a regular tool call instead; tools it lists are mostly not callable here — delegate work that needs them with `task`."
+            )
+        elif has_search:
+            close = difflib.get_close_matches(camel, sorted(known), n=3, cutoff=0.6)
+            hint = f" Did you mean {', '.join(f'`tools.{c}`' for c in close)}?" if close else ""
+            lines.append(f"`tools.{ident}` is not exposed in this eval.{hint} {search_tip}")
+        else:
+            close = difflib.get_close_matches(camel, sorted(known), n=3, cutoff=0.6)
+            hint = f" Did you mean {', '.join(f'`tools.{c}`' for c in close)}?" if close else ""
+            lines.append(f"`tools.{ident}` is not available inside eval.{hint} Callable here: {callable_list}. {outside}")
+    if not lines:
+        return ""
+    return "\n<hint>\n" + "\n".join(lines) + "\n</hint>"
+
+
+def _is_top_level_return_parse_error(result: Any) -> bool:
+    """True when an ``eval`` result is QuickJS' parse error for a top-level ``return``."""
+    content = getattr(result, "content", result)
+    if isinstance(content, list):
+        content = " ".join(block.get("text", "") if isinstance(block, dict) else str(block) for block in content)
+    if not isinstance(content, str):
+        return False
+    return 'type="SyntaxError"' in content and _TOP_LEVEL_RETURN_ERROR_MARKER in content
+
+
 class _PTCToleranceCodeInterpreterMiddleware(CodeInterpreterMiddleware):
     """``CodeInterpreterMiddleware`` that exposes *all* eligible tools via PTC.
 
@@ -577,8 +678,9 @@ class _PTCToleranceCodeInterpreterMiddleware(CodeInterpreterMiddleware):
         # pinned ``search``/``describe`` discovery tools (below) so the prompt
         # stays bounded and the model can find the rest at runtime.
         if not self._broaden_exposure:
+            collected = self._without_raw_listers(collected)
             if self._is_core_only(collected):
-                collected.extend(build_discovery_tools(collected))
+                collected = self._with_discovery(collected)
             return collected
 
         def _consider(tool: Any) -> None:
@@ -637,10 +739,32 @@ class _PTCToleranceCodeInterpreterMiddleware(CodeInterpreterMiddleware):
         # set (callable + rendered) so the model can find the unrendered catalog at
         # runtime. They close over the catalog collected above. Small, fixed sub-agent
         # toolsets stay fully rendered inline and need no discovery helpers.
+        collected = self._without_raw_listers(collected)
         if self._is_core_only(collected):
-            collected.extend(build_discovery_tools(collected))
+            collected = self._with_discovery(collected)
 
         return collected
+
+    @staticmethod
+    def _without_raw_listers(collected: list[BaseTool]) -> list[BaseTool]:
+        """Keep the raw MCP-catalogue listers out of the ``eval`` namespace.
+
+        ``console_grep_mcp_tools`` / ``console_list_mcp_servers`` return raw MCP names
+        (``github_get_me``) for the *whole* catalogue — tools that are mostly not callable
+        in this sandbox at all (not exposed) and never under that spelling (bridges are
+        camelCase). A model that greps inside ``eval`` then calls ``tools.github_get_me``
+        gets ``TypeError: not a function`` and detours through introspection before it
+        delegates. Outside the sandbox the same tool is bound natively and its output
+        feeds a ``task`` delegation — the right move — so it is only removed from ``eval``.
+        In core-only mode ``tools.search``/``tools.describe`` cover in-sandbox discovery
+        with callable names.
+        """
+        return [t for t in collected if t.name not in _RAW_LISTING_TOOL_NAMES]
+
+    @staticmethod
+    def _with_discovery(collected: list[BaseTool]) -> list[BaseTool]:
+        """Core-only mode: add the ``tools.search``/``tools.describe`` discovery helpers."""
+        return [*collected, *build_discovery_tools(collected)]
 
     @staticmethod
     def _mcp_tool_count(tools: list[BaseTool]) -> int:
@@ -723,7 +847,7 @@ class _PTCToleranceCodeInterpreterMiddleware(CodeInterpreterMiddleware):
             # <0.2) became the ``_base_prompt(*, ptc_attached=...)`` method in the
             # 0.2 wasm rewrite; the flag toggles whether the base prompt describes
             # the ``tools.*`` namespace.
-            return self._base_prompt(ptc_attached=False)
+            return self._base_prompt(ptc_attached=False) + _TOP_LEVEL_RETURN_RULE
         exposed = [t for t in self._ptc if isinstance(t, BaseTool) and t.name != self._tool_name]
         thread_id = _resolve_thread_id(self._fallback_thread_id)
         repl = self._registry.get(thread_id)
@@ -737,7 +861,7 @@ class _PTCToleranceCodeInterpreterMiddleware(CodeInterpreterMiddleware):
         if self._ptc_prompt_cache is None or self._ptc_prompt_cache[0] != cache_key:
             body = render_tools_namespace(render_set, tool_name=self._tool_name, discovery_note=discovery_note)
             self._ptc_prompt_cache = (cache_key, body)
-        return self._base_prompt(ptc_attached=bool(exposed)) + self._ptc_prompt_cache[1]
+        return self._base_prompt(ptc_attached=bool(exposed)) + _TOP_LEVEL_RETURN_RULE + self._ptc_prompt_cache[1]
 
     def _ptc_prompt_and_hidden(self, request: Any) -> tuple[str, set[str]]:
         """Build the PTC prompt and the set of tool names exposed this turn.
@@ -838,6 +962,52 @@ class _PTCToleranceCodeInterpreterMiddleware(CodeInterpreterMiddleware):
     async def aafter_model(self, state: Any, runtime: Any) -> dict[str, Any] | None:
         return self._exposure_state_update()
 
+    async def _run_eval_with_guidance(self, request: Any, handler: Any, thread_id: Any) -> Any:
+        """Run ``eval`` with the top-level-``return`` retry, then annotate a ``not a function``.
+
+        A ``TypeError: not a function`` on ``tools.<x>`` almost always means the model used
+        a snake_case MCP name or a misremembered discovery helper; QuickJS does not say
+        which member, so append a hint naming the offending accesses and their fix.
+        """
+        result = await self._run_eval_tolerating_top_level_return(request, handler)
+        if not _is_not_a_function_error(result) or not isinstance(getattr(result, "content", None), str):
+            return result
+        code = ((getattr(request, "tool_call", None) or {}).get("args") or {}).get("code")
+        if not isinstance(code, str):
+            return result
+        exposed = self._ptc_tools_by_thread.get(thread_id) or ()
+        hint = _not_a_function_hint(code, (t.name for t in exposed if isinstance(t, BaseTool)))
+        if not hint:
+            return result
+        logger.info("[PTC] eval called a non-existent tools.* member; appending naming hint")
+        return result.model_copy(update={"content": result.content + hint})
+
+    async def _run_eval_tolerating_top_level_return(self, request: Any, handler: Any) -> Any:
+        """Run ``eval``; if the source failed to parse only because of a top-level ``return``,
+        re-run it once wrapped in an async IIFE.
+
+        Models carry a strong prior from other sandboxes (which run code inside a function)
+        and write ``return result;`` at the top level; QuickJS parses the source as a script
+        and rejects that — a wasted round-trip per occurrence. Wrapping is done *only* on
+        that specific error, never up front: wrapping always would put the model's
+        ``const``/``let`` declarations inside the IIFE and break the persistent-REPL contract
+        the prompt promises (top-level state survives across ``eval`` calls in a turn). The
+        wrapped run's own declarations do not persist either — the prompt rule steers the
+        model away from the pattern so this stays a fallback.
+        """
+        result = await handler(request)
+        if not _is_top_level_return_parse_error(result):
+            return result
+        tool_call = getattr(request, "tool_call", None) or {}
+        args = tool_call.get("args") or {}
+        code = args.get("code")
+        if not isinstance(code, str) or not code.strip():
+            return result
+        logger.info("[PTC] eval used a top-level `return`; re-running the source wrapped in an async IIFE")
+        wrapped = f"(async () => {{\n{code}\n}})()"
+        retry = request.override(tool_call={**tool_call, "args": {**args, "code": wrapped}})
+        return await handler(retry)
+
     async def awrap_tool_call(self, request: Any, handler: Any) -> Any:
         """Drive PTC HITL approvals for the ``eval`` tool from the main graph loop.
 
@@ -861,11 +1031,13 @@ class _PTCToleranceCodeInterpreterMiddleware(CodeInterpreterMiddleware):
         tool calls (and the unguarded configuration) pass straight through.
         """
         tool_call = getattr(request, "tool_call", None) or {}
-        if not self._ptc_enabled or self._ptc_risk_scorer is None or tool_call.get("name") != self._tool_name:
+        if tool_call.get("name") != self._tool_name:
             return await handler(request)
-
         runtime = getattr(request, "runtime", None)
         thread_id = resolve_ptc_thread_id(runtime)
+        if not self._ptc_enabled or self._ptc_risk_scorer is None:
+            return await self._run_eval_with_guidance(request, handler, thread_id)
+
         context = getattr(runtime, "context", None)
         # On an interrupt *resume* the graph may have been rebuilt (a fresh
         # middleware instance on a different request/pod), so the upstream
@@ -883,7 +1055,7 @@ class _PTCToleranceCodeInterpreterMiddleware(CodeInterpreterMiddleware):
         try:
             while True:
                 clear_ptc_pending(thread_id)
-                result = await handler(request)
+                result = await self._run_eval_with_guidance(request, handler, thread_id)
                 pending = take_ptc_pending(thread_id)
                 if not pending:
                     return result

--- a/packages/agent-common/agent_common/core/token_provider.py
+++ b/packages/agent-common/agent_common/core/token_provider.py
@@ -1,0 +1,162 @@
+"""Per-user MCP bearer tokens minted at call time, not at discovery time.
+
+Why
+---
+Discovery used to exchange the user's token once per audience (gateway, console) and
+bake the result into every tool's ``StreamableHttpConnection`` headers. Token freshness
+was therefore tied to how long the discovered tools were kept — the discovery cache TTL
+had to double as a token-safety bound, a sub-agent inheriting the orchestrator's tools
+inherited a token of unknown age, and nothing could recover from an exchanged token
+expiring in the middle of a long turn.
+
+This module inverts that. A :class:`UserTokenProvider` is the single place that mints
+exchanged tokens for one user: it memoises them per audience and re-exchanges when the
+memoised one is within ``leeway`` seconds of its ``exp``. Tools carry **no** bearer in
+their connection; :func:`bearer_interceptor` asks the provider for a token for the
+tool's server on every call and injects the ``Authorization`` header for that call only
+(the same ``request.override(headers=…)`` hook the console attribution interceptor
+uses). Discovery asks the provider the same way when it needs a token to list.
+
+Scope
+-----
+The provider is **per user**: it holds that user's subject token and nothing else, so
+there is no cross-user cache to reason about. It is long-lived across that user's turns
+(it rides in the per-user discovery-cache entry next to the tools built with it) and the
+executor hands it the current subject token at the start of every turn
+(:meth:`UserTokenProvider.update_subject_token`), so an exchange after the user's token
+rotated uses the new one. If the *user's* token has expired mid-turn nothing can be
+re-minted without the user — the exchange fails and the auth-error path surfaces it,
+which is the correct outcome.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import time
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Serve a memoised exchanged token only while at least this many seconds remain, so a
+# tool call that starts right before expiry still completes with a valid token.
+DEFAULT_LEEWAY_S = 90.0
+
+_SCOPES = ["openid", "profile", "offline_access"]
+
+
+def jwt_exp(token: str) -> float | None:
+    """Read ``exp`` (unix seconds) from a JWT without verifying it; ``None`` if unreadable.
+
+    Only used to decide *when to re-mint*; trust in the token comes from the issuer.
+    """
+    try:
+        segment = token.split(".")[1]
+        segment += "=" * (-len(segment) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(segment))
+        exp = claims.get("exp")
+        return float(exp) if exp is not None else None
+    except Exception:
+        return None
+
+
+@dataclass
+class _Minted:
+    token: str
+    expires_at: float | None  # None: unknown lifetime → re-mint on every ask
+
+
+class UserTokenProvider:
+    """Mints and memoises exchanged bearer tokens for one user, per target audience.
+
+    ``exchange`` is the OAuth client's ``exchange_token`` (RFC 8693); it is the only
+    network call this class makes.
+    """
+
+    def __init__(
+        self,
+        subject_token: str,
+        exchange: Callable[..., Awaitable[str]],
+        *,
+        leeway_seconds: float = DEFAULT_LEEWAY_S,
+    ) -> None:
+        self._subject_token = subject_token
+        self._exchange = exchange
+        self._leeway = leeway_seconds
+        self._minted: dict[str, _Minted] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    # -- subject token ---------------------------------------------------------------
+    @property
+    def subject_token(self) -> str:
+        return self._subject_token
+
+    def update_subject_token(self, subject_token: str) -> None:
+        """Adopt the user's current token (called at every turn start).
+
+        A different subject token invalidates every memoised exchange: they were derived
+        from the old one and must not outlive it.
+        """
+        if subject_token != self._subject_token:
+            self._subject_token = subject_token
+            self._minted.clear()
+
+    # -- exchanged tokens ------------------------------------------------------------
+    def _fresh(self, audience: str) -> str | None:
+        minted = self._minted.get(audience)
+        if minted is None or minted.expires_at is None:
+            return None
+        if minted.expires_at - self._leeway <= time.time():
+            return None
+        return minted.token
+
+    async def get(self, audience: str) -> str:
+        """Return a bearer token for ``audience``, re-exchanging if none is fresh enough."""
+        token = self._fresh(audience)
+        if token is not None:
+            return token
+        lock = self._locks.setdefault(audience, asyncio.Lock())
+        async with lock:
+            token = self._fresh(audience)  # a concurrent caller may have minted meanwhile
+            if token is not None:
+                return token
+            token = await self._exchange(
+                subject_token=self._subject_token, target_client_id=audience, requested_scopes=_SCOPES
+            )
+            exp = jwt_exp(token)
+            subject_exp = jwt_exp(self._subject_token)
+            if exp is not None and subject_exp is not None:
+                exp = min(exp, subject_exp)  # never reuse past the user token it came from
+            self._minted[audience] = _Minted(token=token, expires_at=exp)
+            logger.debug("Minted MCP bearer token for audience %s (exp=%s)", audience, exp)
+            return token
+
+    def invalidate(self, audience: str | None = None) -> None:
+        if audience is None:
+            self._minted.clear()
+        else:
+            self._minted.pop(audience, None)
+
+
+def bearer_interceptor(
+    provider: UserTokenProvider, audience_for_server: Callable[[str], str]
+) -> Callable[[Any, Any], Awaitable[Any]]:
+    """A ``langchain_mcp_adapters`` tool interceptor that injects a fresh bearer per call.
+
+    ``audience_for_server`` maps the request's ``server_name`` to the OAuth audience
+    (e.g. ``"console"`` → the console client id, anything else → the gateway client id).
+    The header is added to *this call's* headers only; the connection itself stays
+    token-free, so tools can be shared, cached and handed to sub-agents without carrying
+    a credential.
+    """
+
+    async def _inject(request: Any, handler: Any) -> Any:
+        token = await provider.get(audience_for_server(request.server_name))
+        headers: Mapping[str, Any] = request.headers or {}
+        return await handler(request.override(headers={**headers, "Authorization": f"Bearer {token}"}))
+
+    return _inject

--- a/packages/agent-common/agent_common/core/token_provider.py
+++ b/packages/agent-common/agent_common/core/token_provider.py
@@ -11,7 +11,9 @@ expiring in the middle of a long turn.
 
 This module inverts that. A :class:`UserTokenProvider` is the single place that mints
 exchanged tokens for one user: it memoises them per audience and re-exchanges when the
-memoised one is within ``leeway`` seconds of its ``exp``. Tools carry **no** bearer in
+memoised one is within ``leeway`` seconds of its ``exp``. Reuse needs a readable ``exp``:
+an opaque (non-JWT) token has no known lifetime and is therefore re-exchanged on every
+ask — correct, just not cached. Tools carry **no** bearer in
 their connection; :func:`bearer_interceptor` asks the provider for a token for the
 tool's server on every call and injects the ``Authorization`` header for that call only
 (the same ``request.override(headers=…)`` hook the console attribution interceptor

--- a/packages/agent-common/agent_common/core/tool_catalogue.py
+++ b/packages/agent-common/agent_common/core/tool_catalogue.py
@@ -202,9 +202,11 @@ class LazyMcpTool(BaseTool):
       and delegates to its coroutine, so interceptors / progress callbacks / result
       conversion are byte-for-byte the upstream behaviour.
 
-    The MCP connection (which carries the user's exchanged bearer token) is a private
-    attribute on the tool, never on the shared catalogue — catalogue bytes are shared
-    across users, connections are not.
+    The MCP connection and the per-call interceptors (which mint the user's bearer for
+    each call — see ``agent_common.core.token_provider``) are private attributes on the
+    tool, never on the shared catalogue: catalogue bytes are shared across users,
+    connections and credentials are not. A connection may still carry a static bearer
+    when no token provider is configured (standalone execution).
     """
 
     server_name: str

--- a/packages/agent-common/agent_common/core/tool_catalogue.py
+++ b/packages/agent-common/agent_common/core/tool_catalogue.py
@@ -1,0 +1,441 @@
+"""Raw-bytes tool catalogue: cards + lazily decoded schemas, no pydantic on the catalogue path.
+
+Why
+---
+Materialising a gateway's tool catalogue through the MCP SDK amplifies the wire size
+~7x into pydantic objects at the parse site (a 21.9 MB ``tools/list`` became ~663 MB of
+live blocks), while the parsed schemas are barely used afterwards: listings and the
+toolset selector need name/description/server, ``describe`` needs one schema, model
+binding needs a handful, and the MCP server validates arguments on invoke anyway.
+
+This module keeps the catalogue as **bytes**: every tool's input schema is stored as
+canonical JSON (``bytes``) next to a lightweight :class:`ToolCard` (name, description,
+parameter names, server). A :class:`LazyMcpTool` is a real ``BaseTool`` whose
+``args_schema`` is decoded from those bytes on first access — so every existing
+consumer (``convert_to_openai_tool``, ``tool.args``, ``describe_tool``, PTC signature
+rendering, the interface hash) keeps working unchanged and only pays for the tools it
+actually touches.
+
+Ingest is a strategy (see :mod:`catalogue_ingest`): a stateless JSON-RPC ``tools/list``
+over plain HTTP, or the same call through the MCP SDK session. Both produce the same
+:class:`ServerCatalogue`, and a process-wide :class:`CatalogueStore` interns catalogues
+by ``(server, interface_hash)`` so identical catalogues share one set of bytes across
+users.
+
+Dispatch delegates to ``langchain_mcp_adapters`` on first invocation: the one tool
+being called is rebuilt as an ``mcp.types.Tool`` (a single small pydantic object) and
+converted with ``convert_mcp_tool_to_langchain_tool`` so interceptors, progress
+callbacks and result conversion behave exactly as before.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import threading
+import time
+from collections.abc import Awaitable, Callable, Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal, cast
+
+from langchain_core.tools import BaseTool, StructuredTool
+from pydantic import PrivateAttr
+
+logger = logging.getLogger(__name__)
+
+CatalogueSource = Literal["stateless", "mcp"]
+
+
+def canonical_bytes(value: Any) -> bytes:
+    """Serialise ``value`` to compact, key-sorted UTF-8 JSON.
+
+    Canonical so identical schemas hash identically regardless of ingest source.
+    """
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCard:
+    """What listings need about a tool — never the schema body."""
+
+    name: str
+    description: str
+    param_names: tuple[str, ...]
+    server_name: str
+
+    @property
+    def first_line(self) -> str:
+        stripped = self.description.strip()
+        return stripped.splitlines()[0] if stripped else ""
+
+
+@dataclass(slots=True)
+class CatalogueTool:
+    """One tool: its card plus undecoded schema bytes and the small MCP extras."""
+
+    card: ToolCard
+    schema_bytes: bytes
+    output_schema_bytes: bytes | None = None
+    annotations: dict[str, Any] | None = None
+    meta: dict[str, Any] | None = None
+
+    @property
+    def name(self) -> str:
+        return self.card.name
+
+    def decode_schema(self) -> dict[str, Any]:
+        schema = json.loads(self.schema_bytes)
+        if not isinstance(schema, dict):
+            # An MCP inputSchema must be a JSON-schema object; tolerate garbage with an
+            # accept-anything schema rather than failing the whole tool.
+            return {"type": "object", "properties": {}}
+        return schema
+
+
+@dataclass(slots=True)
+class ServerCatalogue:
+    """All tools of one MCP server, as bytes + cards, with a stable interface hash."""
+
+    server_name: str
+    tools: dict[str, CatalogueTool]
+    interface_hash: str
+    source: CatalogueSource
+    fetched_at: float = field(default_factory=time.time)
+
+    @property
+    def cards(self) -> list[ToolCard]:
+        return [t.card for t in self.tools.values()]
+
+    @property
+    def byte_size(self) -> int:
+        return sum(len(t.schema_bytes) + len(t.output_schema_bytes or b"") for t in self.tools.values())
+
+
+def _param_names(schema: Mapping[str, Any] | None) -> tuple[str, ...]:
+    props = schema.get("properties") if isinstance(schema, Mapping) else None
+    return tuple(str(k) for k in props) if isinstance(props, Mapping) else ()
+
+
+def make_catalogue_tool(
+    *,
+    server_name: str,
+    name: str,
+    description: str | None,
+    input_schema: Mapping[str, Any] | None,
+    output_schema: Mapping[str, Any] | None = None,
+    annotations: Mapping[str, Any] | None = None,
+    meta: Mapping[str, Any] | None = None,
+) -> CatalogueTool:
+    """Build a :class:`CatalogueTool` from already-decoded (transient) values.
+
+    Callers decode one tool at a time and drop the dicts right after; only the bytes
+    and the card are retained.
+    """
+    schema: Mapping[str, Any] = (
+        input_schema if isinstance(input_schema, Mapping) else {"type": "object", "properties": {}}
+    )
+    card = ToolCard(
+        name=name,
+        description=description or "",
+        param_names=_param_names(schema),
+        server_name=server_name,
+    )
+    return CatalogueTool(
+        card=card,
+        schema_bytes=canonical_bytes(schema),
+        output_schema_bytes=canonical_bytes(output_schema) if isinstance(output_schema, Mapping) else None,
+        annotations=dict(annotations) if isinstance(annotations, Mapping) and annotations else None,
+        meta=dict(meta) if isinstance(meta, Mapping) and meta else None,
+    )
+
+
+def compute_interface_hash(tools: Iterable[CatalogueTool]) -> str:
+    """SHA-256 over the sorted (name, description, schema bytes) — the tool *interface*.
+
+    Same intent as ``LangGraphAgent._compute_interface_hash`` in the SDK (change when
+    tools are added/removed or their schemas change), computed on bytes so it never
+    requires decoding a schema.
+    """
+    h = hashlib.sha256()
+    for tool in sorted(tools, key=lambda t: t.name):
+        h.update(tool.card.name.encode("utf-8"))
+        h.update(b"\x00")
+        h.update(tool.card.description.encode("utf-8"))
+        h.update(b"\x00")
+        h.update(tool.schema_bytes)
+        h.update(b"\x01")
+    return h.hexdigest()
+
+
+def build_server_catalogue(
+    server_name: str, tools: Iterable[CatalogueTool], source: CatalogueSource
+) -> ServerCatalogue:
+    by_name: dict[str, CatalogueTool] = {}
+    for tool in tools:
+        if tool.name in by_name:
+            logger.warning(
+                "Duplicate tool name '%s' on server '%s' — keeping the first",
+                tool.name,
+                server_name,
+            )
+            continue
+        by_name[tool.name] = tool
+    return ServerCatalogue(
+        server_name=server_name,
+        tools=by_name,
+        interface_hash=compute_interface_hash(by_name.values()),
+        source=source,
+    )
+
+
+class LazyMcpTool(BaseTool):
+    """A ``BaseTool`` over a :class:`CatalogueTool` whose schema stays as bytes until needed.
+
+    * ``name`` / ``description`` / ``metadata`` come from the card (cheap, always set).
+    * ``args_schema`` is a normal pydantic field, populated from ``schema_bytes`` the
+      first time it is read (``__getattribute__`` hook), so ``convert_to_openai_tool``,
+      ``tool.args``, ``tool_call_schema`` and direct ``tool.args_schema`` reads all see a
+      plain JSON-schema dict exactly like a ``langchain_mcp_adapters`` tool — but only the
+      tools that are bound, described or invoked ever decode.
+    * Invocation builds the adapter's ``StructuredTool`` for this one tool on first call
+      and delegates to its coroutine, so interceptors / progress callbacks / result
+      conversion are byte-for-byte the upstream behaviour.
+
+    The MCP connection (which carries the user's exchanged bearer token) is a private
+    attribute on the tool, never on the shared catalogue — catalogue bytes are shared
+    across users, connections are not.
+    """
+
+    server_name: str
+    response_format: Literal["content", "content_and_artifact"] = "content_and_artifact"
+
+    _entry: CatalogueTool = PrivateAttr()
+    _connection: Any = PrivateAttr(default=None)
+    _callbacks: Any = PrivateAttr(default=None)
+    _interceptors: list[Any] | None = PrivateAttr(default=None)
+    _delegate: StructuredTool | None = PrivateAttr(default=None)
+
+    def __getattribute__(self, item: str) -> Any:
+        if item == "args_schema":
+            values = object.__getattribute__(self, "__dict__")
+            if values.get("args_schema") is None:
+                private = object.__getattribute__(self, "__pydantic_private__") or {}
+                entry = private.get("_entry")
+                if entry is None:
+                    raise RuntimeError(
+                        f"LazyMcpTool '{values.get('name')}' is not bound to a catalogue entry; "
+                        "construct it via make_lazy_tool()/build_lazy_tools()"
+                    )
+                values["args_schema"] = entry.decode_schema()
+            return values["args_schema"]
+        return object.__getattribute__(self, item)
+
+    @property
+    def coroutine(self) -> Callable[..., Awaitable[Any]]:
+        """The async implementation, exposed like ``StructuredTool.coroutine``.
+
+        Wrappers that re-package MCP tools (``_wrap_tool_with_agent_name`` in the
+        orchestrator, ``DynamicLocalAgentRunnable._wrap_with_agent_name``) read
+        ``tool.coroutine`` and would silently skip a tool without one.
+        """
+
+        async def _call(**kwargs: Any) -> Any:
+            return await self._arun(**kwargs)
+
+        return _call
+
+    @property
+    def catalogue_entry(self) -> CatalogueTool:
+        return self._entry
+
+    @property
+    def schema_decoded(self) -> bool:
+        """True once ``args_schema`` has been materialised (test/diagnostic hook)."""
+        return object.__getattribute__(self, "__dict__").get("args_schema") is not None
+
+    def _get_delegate(self) -> StructuredTool:
+        if self._delegate is None:
+            from langchain_mcp_adapters.tools import convert_mcp_tool_to_langchain_tool
+            from mcp.types import Tool as MCPTool
+
+            entry = self._entry
+            input_schema = self.args_schema
+            if not isinstance(input_schema, dict):  # pragma: no cover — always a dict for catalogue tools
+                input_schema = entry.decode_schema()
+            mcp_tool = MCPTool(
+                name=entry.name,
+                description=entry.card.description or None,
+                inputSchema=input_schema,
+                annotations=entry.annotations,  # type: ignore[arg-type]
+                _meta=entry.meta,
+            )
+            delegate = convert_mcp_tool_to_langchain_tool(
+                None,
+                mcp_tool,
+                connection=self._connection,
+                callbacks=self._callbacks,
+                tool_interceptors=self._interceptors,
+                server_name=self.server_name,
+            )
+            self._delegate = cast(StructuredTool, delegate)
+        return self._delegate
+
+    def _run(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError("MCP tools are async-only; use ainvoke()")
+
+    async def _arun(self, *args: Any, **kwargs: Any) -> Any:
+        delegate = self._get_delegate()
+        # The adapter coroutine takes ``runtime`` as an injected arg; the ToolNode only
+        # injects it when it can see it on ``tool.func``/``tool.coroutine``, which this
+        # class does not expose. Nothing on our call path reads it (the console
+        # attribution interceptor uses ContextVars; the progress callback only logs).
+        if delegate.coroutine is None:  # pragma: no cover — the adapter always sets a coroutine
+            raise RuntimeError(f"MCP tool '{self.name}' has no async implementation")
+        return await delegate.coroutine(runtime=None, **kwargs)
+
+
+def build_lazy_tools(
+    catalogue: ServerCatalogue,
+    *,
+    connection: Any,
+    callbacks: Any = None,
+    tool_interceptors: list[Any] | None = None,
+    extra_metadata: Mapping[str, Any] | None = None,
+) -> list[LazyMcpTool]:
+    """Wrap every catalogue entry as a :class:`LazyMcpTool` bound to ``connection``.
+
+    Metadata mirrors ``langchain_mcp_adapters`` (``annotations`` flattened + ``_meta``)
+    and always carries ``server_name`` (discovery previously stamped it after the fact).
+    """
+    return [
+        make_lazy_tool(
+            entry,
+            server_name=catalogue.server_name,
+            connection=connection,
+            callbacks=callbacks,
+            tool_interceptors=tool_interceptors,
+            extra_metadata=extra_metadata,
+        )
+        for entry in catalogue.tools.values()
+    ]
+
+
+def make_lazy_tool(
+    entry: CatalogueTool,
+    *,
+    server_name: str,
+    connection: Any,
+    callbacks: Any = None,
+    tool_interceptors: list[Any] | None = None,
+    extra_metadata: Mapping[str, Any] | None = None,
+) -> LazyMcpTool:
+    """Wrap one catalogue entry as a :class:`LazyMcpTool` bound to ``connection``."""
+    metadata: dict[str, Any] = {**(entry.annotations or {})}
+    if entry.meta is not None:
+        metadata["_meta"] = entry.meta
+    metadata["server_name"] = server_name
+    if extra_metadata:
+        metadata.update(extra_metadata)
+    tool = LazyMcpTool(
+        name=entry.name,
+        description=entry.card.description,
+        metadata=metadata,
+        server_name=server_name,
+    )
+    tool._entry = entry
+    tool._connection = connection
+    tool._callbacks = callbacks
+    tool._interceptors = tool_interceptors
+    return tool
+
+
+class CatalogueStore:
+    """Process-wide home for server catalogues.
+
+    * **Interning** by ``(server, interface_hash)``: whichever ingest path produced a
+      catalogue, an identical one already held is returned instead, so N users of the
+      same server share one set of schema bytes. One entry per server is kept (the
+      latest interface); superseded catalogues stay alive only as long as tools built
+      from them do. Catalogues are per-user-token views, so they are never *served*
+      from here in place of a fetch — only deduplicated.
+    * **Lookup by name** (:meth:`resolve`) for consumers that hold only tool names.
+    * **Capability memo**: whether an MCP endpoint serves a stateless ``tools/list``
+      (probed once per URL).
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._interned: dict[str, ServerCatalogue] = {}  # server -> latest catalogue
+        self._stateless_supported: dict[str, bool] = {}  # mcp url -> supported
+
+    # -- interning -----------------------------------------------------------------
+    def intern(self, catalogue: ServerCatalogue) -> ServerCatalogue:
+        with self._lock:
+            held = self._interned.get(catalogue.server_name)
+            if held is not None and held.interface_hash == catalogue.interface_hash:
+                return held
+            self._interned[catalogue.server_name] = catalogue
+            return catalogue
+
+    def interned(self, server_name: str) -> ServerCatalogue | None:
+        with self._lock:
+            return self._interned.get(server_name)
+
+    def resolve(self, names: Iterable[str]) -> dict[str, tuple[ServerCatalogue, CatalogueTool]]:
+        """Look up tools by name across every interned catalogue.
+
+        Lets a consumer that knows only tool *names* (a sub-agent's whitelist) reuse the
+        catalogues discovery already fetched in this process instead of opening its own
+        ``tools/list``. Returns only the names found; the caller fetches the rest.
+        Gateway tool names are unique across servers (they carry the server prefix), so
+        the first catalogue holding a name wins.
+        """
+        wanted = set(names)
+        found: dict[str, tuple[ServerCatalogue, CatalogueTool]] = {}
+        if not wanted:
+            return found
+        with self._lock:
+            catalogues = list(self._interned.values())
+        for catalogue in catalogues:
+            for name in wanted - found.keys():
+                entry = catalogue.tools.get(name)
+                if entry is not None:
+                    found[name] = (catalogue, entry)
+            if len(found) == len(wanted):
+                break
+        return found
+
+    # -- capability memo -----------------------------------------------------------
+    def stateless_supported(self, url: str) -> bool | None:
+        with self._lock:
+            return self._stateless_supported.get(url)
+
+    def set_stateless_supported(self, url: str, supported: bool) -> None:
+        with self._lock:
+            self._stateless_supported[url] = supported
+
+    def clear(self) -> None:
+        with self._lock:
+            self._interned.clear()
+            self._stateless_supported.clear()
+
+
+_store: CatalogueStore | None = None
+_store_lock = threading.Lock()
+
+
+def get_catalogue_store() -> CatalogueStore:
+    """Process-wide singleton."""
+    global _store
+    with _store_lock:
+        if _store is None:
+            _store = CatalogueStore()
+        return _store
+
+
+def reset_catalogue_store() -> None:
+    """Test hook."""
+    global _store
+    with _store_lock:
+        _store = None

--- a/packages/agent-common/tests/test_dynamic_agent.py
+++ b/packages/agent-common/tests/test_dynamic_agent.py
@@ -18,6 +18,40 @@ from agent_common.agents.dynamic_agent import (
 )
 
 
+def _install_list_tools(mock_client_cls, **list_tools_kwargs):
+    """Make the patched MultiServerMCPClient's ``session(name)`` yield a session whose
+    ``list_tools`` behaves per ``list_tools_kwargs`` (AsyncMock kwargs). A ``return_value``
+    given as a list of LangChain tools is converted into an MCP ``ListToolsResult``."""
+    from contextlib import asynccontextmanager
+    from mcp.types import ListToolsResult, Tool as MCPTool
+
+    rv = list_tools_kwargs.get("return_value")
+    if isinstance(rv, list):
+        list_tools_kwargs["return_value"] = ListToolsResult(
+            tools=[
+                MCPTool(name=t.name, description=t.description, inputSchema={"type": "object", "properties": {}})
+                for t in rv
+            ],
+            nextCursor=None,
+        )
+    client = mock_client_cls.return_value
+    client.callbacks = None
+    client.tool_interceptors = []
+
+    def session(name):
+        @asynccontextmanager
+        async def _cm():
+            sess = MagicMock()
+            sess.list_tools = AsyncMock(**list_tools_kwargs)
+            yield sess
+
+        return _cm()
+
+    client.session = session
+
+
+
+
 class TestDynamicLocalAgentRunnable:
     """Tests for DynamicLocalAgentRunnable."""
 
@@ -483,6 +517,9 @@ class TestDiscoverMcpTools:
 
     @pytest.fixture
     def runnable(self, gateway_config, mock_model):
+        from agent_common.core.tool_catalogue import reset_catalogue_store
+
+        reset_catalogue_store()  # the store is process-wide; don't let one test's catalogue serve the next
         oauth2_client = MagicMock()
         oauth2_client.exchange_token = AsyncMock(return_value="gateway-token")
         return DynamicLocalAgentRunnable(
@@ -500,7 +537,7 @@ class TestDiscoverMcpTools:
         inside the discovery try block must propagate, not be silently
         reported to the user as "temporarily unavailable" forever."""
         with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
-            mock_client_cls.return_value.get_tools = AsyncMock(side_effect=ValueError("schema bug"))
+            _install_list_tools(mock_client_cls, side_effect=ValueError("schema bug"))
 
             with pytest.raises(ValueError, match="schema bug"):
                 await runnable._discover_mcp_tools()
@@ -510,7 +547,7 @@ class TestDiscoverMcpTools:
     @pytest.mark.asyncio
     async def test_non_retryable_gateway_error_degrades_to_empty_list(self, runnable):
         with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
-            mock_client_cls.return_value.get_tools = AsyncMock(
+            _install_list_tools(mock_client_cls, 
                 side_effect=ExceptionGroup("boom", [_http_error(400)])
             )
             tools = await runnable._discover_mcp_tools()
@@ -524,7 +561,7 @@ class TestDiscoverMcpTools:
         # The exact shape the pre-fix single-level unwrap missed.
         nested = ExceptionGroup("outer", [ExceptionGroup("inner", [_http_error(403)])])
         with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
-            mock_client_cls.return_value.get_tools = AsyncMock(side_effect=nested)
+            _install_list_tools(mock_client_cls, side_effect=nested)
             tools = await runnable._discover_mcp_tools()
 
         assert tools == []
@@ -565,14 +602,14 @@ class TestDiscoverMcpTools:
     @pytest.mark.asyncio
     async def test_stale_discovery_error_cleared_on_next_call(self, runnable):
         with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
-            mock_client_cls.return_value.get_tools = AsyncMock(
+            _install_list_tools(mock_client_cls, 
                 side_effect=ExceptionGroup("boom", [_http_error(400)])
             )
             await runnable._discover_mcp_tools()
         assert runnable._mcp_discovery_error is not None
 
         with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
-            mock_client_cls.return_value.get_tools = AsyncMock(return_value=[])
+            _install_list_tools(mock_client_cls, return_value=[])
             await runnable._discover_mcp_tools()
         assert runnable._mcp_discovery_error is None
 
@@ -586,7 +623,7 @@ class TestDiscoverMcpTools:
         meant to allow (this is the within-turn "stale pin" the reset-at-entry
         version of this method was vulnerable to)."""
         with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
-            mock_client_cls.return_value.get_tools = AsyncMock(
+            _install_list_tools(mock_client_cls, 
                 side_effect=ExceptionGroup("boom", [_http_error(400)])
             )
             await runnable._discover_mcp_tools()
@@ -613,7 +650,7 @@ class TestDiscoverMcpTools:
             patch("agent_common.agents.dynamic_agent.build_sub_agent_graph", return_value=mock_graph),
             patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls,
         ):
-            mock_client_cls.return_value.get_tools = AsyncMock(
+            _install_list_tools(mock_client_cls, 
                 side_effect=ExceptionGroup("boom", [_http_error(400)])
             )
             await runnable._ensure_agent()
@@ -622,12 +659,148 @@ class TestDiscoverMcpTools:
 
             # Second call must retry discovery (not short-circuit on the
             # _cached_tools guard) and, on success, actually resolve.
-            mock_client_cls.return_value.get_tools = AsyncMock(return_value=[fake_tool("some_gateway_tool")])
+            _install_list_tools(mock_client_cls, return_value=[fake_tool("some_gateway_tool")])
             await runnable._ensure_agent()
 
         assert runnable._mcp_discovery_error is None
         assert [t.name for t in runnable._discovered_tools] == ["some_gateway_tool"]
         assert "tool_availability_warning" not in runnable._cached_system_prompt
+
+    @pytest.mark.asyncio
+    async def test_whitelist_is_served_from_shared_catalogue_store_without_tools_list(self, runnable):
+        """A sub-agent whose whitelist is already held by the process-wide catalogue store
+        (filled by the orchestrator's discovery) must not open its own tools/list."""
+        from agent_common.core.tool_catalogue import (
+            LazyMcpTool,
+            build_server_catalogue,
+            get_catalogue_store,
+            make_catalogue_tool,
+        )
+
+        store = get_catalogue_store()
+        store.intern(
+            build_server_catalogue(
+                "some-server",
+                [
+                    make_catalogue_tool(
+                        server_name="some-server",
+                        name="some_gateway_tool",
+                        description="from the store",
+                        input_schema={"type": "object", "properties": {"q": {"type": "string"}}},
+                    )
+                ],
+                source="stateless",
+            )
+        )
+        with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
+            _install_list_tools(mock_client_cls, side_effect=AssertionError("tools/list must not be called"))
+            tools = await runnable._discover_mcp_tools()
+
+        assert [t.name for t in tools] == ["some_gateway_tool"]
+        assert isinstance(tools[0], LazyMcpTool)
+        assert tools[0].description == "from the store"
+        # Bound to *this* agent's gateway connection (its own exchanged token), not the orchestrator's.
+        assert tools[0]._connection["headers"]["Authorization"] == "Bearer gateway-token"
+        assert runnable._mcp_discovery_error is None
+
+    @pytest.mark.asyncio
+    async def test_missing_names_fall_back_to_tools_list_and_are_interned(self, runnable):
+        """Names the store does not hold are fetched once over MCP and then served from the store."""
+        from agent_common.core.tool_catalogue import get_catalogue_store
+
+        with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
+            _install_list_tools(
+                mock_client_cls,
+                return_value=[Tool(name="some_gateway_tool", description="fetched", func=lambda x: x)],
+            )
+            tools = await runnable._discover_mcp_tools()
+        assert [t.name for t in tools] == ["some_gateway_tool"]
+        # Interned under the connection name (gateway-wide listing) for the next delegation.
+        held = get_catalogue_store().interned("gatana")
+        assert held is not None and "some_gateway_tool" in held.tools
+        assert held.source == "mcp"
+
+    @pytest.mark.asyncio
+    async def test_pre_resolved_tools_skip_exchange_and_discovery_entirely(self, gateway_config, mock_model):
+        """When the orchestrator hands over its already-authenticated tools, a delegation must
+        perform no token exchange, build no MCP client and open no tools/list."""
+        from agent_common.core.tool_catalogue import (
+            LazyMcpTool,
+            build_server_catalogue,
+            make_catalogue_tool,
+            make_lazy_tool,
+        )
+
+        entry = make_catalogue_tool(
+            server_name="some-server",
+            name="some_gateway_tool",
+            description="orchestrator's",
+            input_schema={"type": "object", "properties": {"q": {"type": "string"}}},
+        )
+        build_server_catalogue("some-server", [entry], source="stateless")
+        orch_tool = make_lazy_tool(
+            entry, server_name="some-server", connection={"url": "gw", "headers": {"Authorization": "Bearer orch"}}
+        )
+        oauth2_client = MagicMock()
+        oauth2_client.exchange_token = AsyncMock(side_effect=AssertionError("must not exchange"))
+        runnable = DynamicLocalAgentRunnable(
+            config=gateway_config,
+            model=mock_model,
+            oauth2_client=oauth2_client,
+            user_token="user-token",
+            mcp_gateway_url="https://gateway.example/mcp",
+            mcp_gateway_client_id="gatana",
+            pre_resolved_tools={"some_gateway_tool": orch_tool},
+        )
+        with patch(
+            "agent_common.agents.dynamic_agent.MultiServerMCPClient", side_effect=AssertionError("no MCP client")
+        ):
+            tools = await runnable._discover_mcp_tools()
+
+        assert [t.name for t in tools] == ["some_gateway_tool"]
+        assert isinstance(tools[0], LazyMcpTool)
+        assert tools[0] is not orch_tool, "a private copy — schema validation must not touch the registry entry"
+        assert tools[0].catalogue_entry is orch_tool.catalogue_entry, "…but the bytes are shared"
+        assert tools[0]._connection["headers"]["Authorization"] == "Bearer orch"
+        oauth2_client.exchange_token.assert_not_called()
+        assert runnable._mcp_discovery_error is None
+
+    @pytest.mark.asyncio
+    async def test_only_names_missing_from_pre_resolved_are_discovered(self, mock_model):
+        from agent_common.core.tool_catalogue import reset_catalogue_store
+
+        reset_catalogue_store()
+        config = LocalLangGraphSubAgentConfig(
+            type="langgraph",
+            name="gateway-agent",
+            description="x",
+            system_prompt="x",
+            mcp_tools=["have_this", "need_this"],
+        )
+        oauth2_client = MagicMock()
+        oauth2_client.exchange_token = AsyncMock(return_value="gateway-token")
+        runnable = DynamicLocalAgentRunnable(
+            config=config,
+            model=mock_model,
+            oauth2_client=oauth2_client,
+            user_token="user-token",
+            mcp_gateway_url="https://gateway.example/mcp",
+            mcp_gateway_client_id="gatana",
+            pre_resolved_tools={"have_this": Tool(name="have_this", description="d", func=lambda x: x)},
+        )
+        with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
+            _install_list_tools(
+                mock_client_cls,
+                return_value=[
+                    Tool(name="need_this", description="d", func=lambda x: x),
+                    Tool(name="have_this", description="dup", func=lambda x: x),
+                ],
+            )
+            tools = await runnable._discover_mcp_tools()
+
+        assert sorted(t.name for t in tools) == ["have_this", "need_this"]
+        assert next(t for t in tools if t.name == "have_this").description == "d", "pre-resolved wins"
+        assert oauth2_client.exchange_token.await_count == 1  # one exchange for the one connection still needed
 
     def test_tool_availability_addendum_empty_when_no_error(self, runnable):
         assert runnable._build_tool_availability_addendum() == ""

--- a/packages/agent-common/tests/test_dynamic_agent.py
+++ b/packages/agent-common/tests/test_dynamic_agent.py
@@ -721,6 +721,54 @@ class TestDiscoverMcpTools:
         assert held.source == "mcp"
 
     @pytest.mark.asyncio
+    async def test_store_hits_bind_to_the_gateway_connection_by_key_not_position(self, gateway_config, mock_model):
+        """The gateway connection is looked up by mcp_gateway_client_id; a console tool by 'console'.
+        Dict order must not matter (regression for a positional gateway[0] pick)."""
+        from agent_common.core.tool_catalogue import (
+            build_server_catalogue,
+            get_catalogue_store,
+            make_catalogue_tool,
+            reset_catalogue_store,
+        )
+
+        reset_catalogue_store()
+        store = get_catalogue_store()
+        store.intern(
+            build_server_catalogue(
+                "github",
+                [make_catalogue_tool(server_name="github", name="some_gateway_tool", description="", input_schema={"type": "object"})],
+                source="stateless",
+            )
+        )
+        store.intern(
+            build_server_catalogue(
+                "console",
+                [make_catalogue_tool(server_name="console", name="console_create_skill", description="", input_schema={"type": "object"})],
+                source="mcp",
+            )
+        )
+        config = LocalLangGraphSubAgentConfig(
+            type="langgraph", name="g", description="x", system_prompt="x", mcp_tools=["some_gateway_tool", "console_create_skill"]
+        )
+        oauth2_client = MagicMock()
+        oauth2_client.exchange_token = AsyncMock(side_effect=lambda **kw: f"tok-{kw['target_client_id']}")
+        runnable = DynamicLocalAgentRunnable(
+            config=config,
+            model=mock_model,
+            oauth2_client=oauth2_client,
+            user_token="user-token",
+            mcp_gateway_url="https://gateway.example/mcp",
+            mcp_gateway_client_id="gatana",
+        )
+        runnable.console_backend_mcp_url = "https://console.example/mcp"
+        with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
+            _install_list_tools(mock_client_cls, side_effect=AssertionError("store must serve both"))
+            tools = {t.name: t for t in await runnable._discover_mcp_tools()}
+
+        assert tools["some_gateway_tool"]._connection["headers"]["Authorization"] == "Bearer tok-gatana"
+        assert tools["console_create_skill"]._connection["headers"]["Authorization"] == "Bearer tok-agent-console"
+
+    @pytest.mark.asyncio
     async def test_pre_resolved_tools_skip_exchange_and_discovery_entirely(self, gateway_config, mock_model):
         """When the orchestrator hands over its already-authenticated tools, a delegation must
         perform no token exchange, build no MCP client and open no tools/list."""

--- a/packages/agent-common/tests/test_dynamic_agent.py
+++ b/packages/agent-common/tests/test_dynamic_agent.py
@@ -1,5 +1,6 @@
 """Unit tests for DynamicLocalAgentRunnable and LocalSubAgentConfig."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -767,6 +768,64 @@ class TestDiscoverMcpTools:
 
         assert tools["some_gateway_tool"]._connection["headers"]["Authorization"] == "Bearer tok-gatana"
         assert tools["console_create_skill"]._connection["headers"]["Authorization"] == "Bearer tok-agent-console"
+
+    @pytest.mark.asyncio
+    async def test_with_a_token_provider_tools_are_token_free_and_mint_per_call(self, gateway_config, mock_model):
+        """Given the orchestrator's UserTokenProvider, the sub-agent exchanges through it and the
+        tools it discovers itself carry no bearer — an interceptor mints one per call."""
+        from agent_common.core.token_provider import UserTokenProvider
+        from agent_common.core.tool_catalogue import reset_catalogue_store
+
+        reset_catalogue_store()
+        exchanges: list[str] = []
+
+        import base64
+        import json
+        import time
+
+        def _jwt(aud: str) -> str:
+            seg = lambda o: base64.urlsafe_b64encode(json.dumps(o).encode()).rstrip(b"=").decode()  # noqa: E731
+            return f"{seg({'alg': 'none'})}.{seg({'exp': time.time() + 900, 'aud': aud})}.sig"
+
+        minted: dict[str, str] = {}
+
+        async def exchange(*, subject_token, target_client_id, requested_scopes):
+            exchanges.append(target_client_id)
+            return minted.setdefault(target_client_id, _jwt(target_client_id))
+
+        provider = UserTokenProvider("user-token", exchange)
+        oauth2_client = MagicMock()
+        oauth2_client.exchange_token = AsyncMock(side_effect=AssertionError("must go through the provider"))
+        runnable = DynamicLocalAgentRunnable(
+            config=gateway_config,
+            model=mock_model,
+            oauth2_client=oauth2_client,
+            user_token="user-token",
+            mcp_gateway_url="https://gateway.example/mcp",
+            mcp_gateway_client_id="gatana",
+            token_provider=provider,
+        )
+        with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
+            _install_list_tools(mock_client_cls, return_value=[Tool(name="some_gateway_tool", description="d", func=lambda x: x)])
+            (tool,) = await runnable._discover_mcp_tools()
+            listing_connection = mock_client_cls.call_args.kwargs["connections"]["gatana"]
+
+        assert exchanges == ["gatana"], "one exchange, via the provider"
+        assert listing_connection["headers"] == {"Authorization": f"Bearer {minted['gatana']}"}, "listing used the bearer"
+        assert not (tool._connection.get("headers") or {}), "the tool's connection carries no credential"
+        assert tool._interceptors and len(tool._interceptors) == 1
+        seen = {}
+
+        class Req(SimpleNamespace):
+            def override(self, **kw):
+                return Req(**{**self.__dict__, **kw})
+
+        async def handler(req):
+            seen.update(req.headers)
+            return "ok"
+
+        await tool._interceptors[0](Req(server_name="gatana", headers=None), handler)
+        assert seen == {"Authorization": f"Bearer {minted['gatana']}"} and exchanges == ["gatana"], "memoised: no second exchange"
 
     @pytest.mark.asyncio
     async def test_pre_resolved_tools_skip_exchange_and_discovery_entirely(self, gateway_config, mock_model):

--- a/packages/agent-common/tests/test_ptc_top_level_return.py
+++ b/packages/agent-common/tests/test_ptc_top_level_return.py
@@ -1,0 +1,181 @@
+"""``eval`` self-correction: top-level ``return`` (prompt rule + IIFE retry) and ``tools.<x> is not a function`` hints."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import StructuredTool
+
+import agent_common.core.graph_utils as gu
+
+RETURN_ERROR = (
+    '<error type="SyntaxError">source parse error in &lt;eval&gt;: '
+    "A 'return' statement can only be used within a function body.</error>"
+)
+
+
+class _Request:
+    """Minimal ToolCallRequest stand-in with the immutable ``override`` used by the middleware."""
+
+    def __init__(self, tool_call, runtime=None):
+        self.tool_call = tool_call
+        self.runtime = runtime
+        self.tools = []
+        self.state = {}
+
+    def override(self, **kw):
+        new = _Request(kw.get("tool_call", self.tool_call), self.runtime)
+        return new
+
+
+def _base_tool(name: str) -> StructuredTool:
+    async def _fn() -> str:
+        return "ok"
+
+    return StructuredTool.from_function(coroutine=_fn, name=name, description=name)
+
+
+def _mw():
+    return gu._PTCToleranceCodeInterpreterMiddleware(
+        static_ptc_tools=[_base_tool("read_file")],
+        broaden_baseline_tools=[],
+        ptc_enabled=True,
+        broaden_exposure=True,
+        backend_supports_execution=False,
+    )
+
+
+def _msg(content: str) -> ToolMessage:
+    return ToolMessage(content=content, tool_call_id="c1", name="eval")
+
+
+@pytest.mark.asyncio
+async def test_top_level_return_is_retried_wrapped_in_an_async_iife():
+    mw = _mw()
+    seen: list[str] = []
+
+    async def handler(req):
+        seen.append(req.tool_call["args"]["code"])
+        return _msg(RETURN_ERROR) if len(seen) == 1 else _msg('<result kind="number">1</result>')
+
+    req = _Request({"name": mw._tool_name, "args": {"code": "const x = 1;\nreturn x;"}, "id": "c1"})
+    out = await mw.awrap_tool_call(req, handler)
+
+    assert len(seen) == 2
+    assert seen[0] == "const x = 1;\nreturn x;"
+    assert seen[1] == "(async () => {\nconst x = 1;\nreturn x;\n})()"
+    assert "<result" in out.content
+
+
+@pytest.mark.asyncio
+async def test_other_errors_and_successes_are_not_retried():
+    mw = _mw()
+    for content in ('<error type="ReferenceError">x is not defined</error>', '<result kind="number">1</result>'):
+        handler = AsyncMock(return_value=_msg(content))
+        req = _Request({"name": mw._tool_name, "args": {"code": "x"}, "id": "c1"})
+        out = await mw.awrap_tool_call(req, handler)
+        assert handler.await_count == 1
+        assert out.content == content
+
+
+@pytest.mark.asyncio
+async def test_non_eval_tools_pass_straight_through():
+    mw = _mw()
+    handler = AsyncMock(return_value=_msg(RETURN_ERROR))
+    req = _Request({"name": "some_other_tool", "args": {"code": "return 1"}, "id": "c1"})
+    await mw.awrap_tool_call(req, handler)
+    assert handler.await_count == 1
+
+
+def test_detector_handles_block_content_and_non_messages():
+    assert gu._is_top_level_return_parse_error(_msg(RETURN_ERROR))
+    assert gu._is_top_level_return_parse_error(ToolMessage(content=[{"type": "text", "text": RETURN_ERROR}], tool_call_id="c"))
+    assert not gu._is_top_level_return_parse_error(_msg('<error type="SyntaxError">unexpected token</error>'))
+    assert not gu._is_top_level_return_parse_error(None)
+    assert not gu._is_top_level_return_parse_error(SimpleNamespace(content=42))
+
+
+def test_prompt_states_the_script_rule():
+    mw = _mw()
+    mw._ptc = None  # no PTC tools attached this turn → base prompt path
+    prompt = mw._prepare_for_call(SimpleNamespace(state={}))
+    assert "top-level `return` is a SyntaxError" in prompt
+
+
+NOT_A_FUNCTION = '<error type="TypeError">not a function\n    at &lt;eval&gt; (eval_script:1:12)\n</error>'
+
+
+def _mcp_tool(name: str) -> StructuredTool:
+    async def _fn() -> str:
+        return "ok"
+
+    return StructuredTool.from_function(coroutine=_fn, name=name, description=name, metadata={"server_name": "github"})
+
+
+@pytest.mark.asyncio
+async def test_not_a_function_hint_with_discovery_attached(monkeypatch):
+    """Core-only mode (tools.search exposed): snake_case → camelCase, synonyms → search, unknown → search."""
+    mw = _mw()
+    monkeypatch.setattr(gu, "resolve_ptc_thread_id", lambda runtime: "t1")
+    mw._ptc_tools_by_thread["t1"] = (_mcp_tool("github_get_me"), _mcp_tool("github_list_commits"), _mcp_tool("search"))
+    handler = AsyncMock(return_value=_msg(NOT_A_FUNCTION))
+    code = "const me = await tools.github_get_me({});\nawait tools.search_tools({query: 'x'});\nawait tools.githubListCommits({});\nawait tools.frobnicate({})"
+    req = _Request({"name": mw._tool_name, "args": {"code": code}, "id": "c1"})
+
+    out = await mw.awrap_tool_call(req, handler)
+
+    assert handler.await_count == 1  # no retry, just annotation
+    assert out.content.startswith(NOT_A_FUNCTION) and "<hint>" in out.content
+    hint = out.content.split("<hint>")[1]
+    assert "`tools.github_get_me` does not exist — tool names are camelCase here: use `tools.githubGetMe`" in hint
+    assert "`tools.search_tools` does not exist — use `tools.search`" in hint
+    assert "`tools.githubListCommits`" not in hint  # valid access not flagged
+    assert "`tools.frobnicate` is not exposed in this eval" in hint and "tools.search({ query" in hint
+
+
+@pytest.mark.asyncio
+async def test_not_a_function_hint_without_discovery_lists_callables_and_points_to_task(monkeypatch):
+    """Inline mode (the orchestrator): no tools.search — never suggest it; list what is callable."""
+    mw = _mw()
+    monkeypatch.setattr(gu, "resolve_ptc_thread_id", lambda runtime: "t1")
+    mw._ptc_tools_by_thread["t1"] = (_mcp_tool("read_file"), _mcp_tool("get_current_time"))
+    handler = AsyncMock(return_value=_msg(NOT_A_FUNCTION))
+    code = "await tools.console_grep_mcp_tools({ query: 'github' });\nawait tools.github_get_me({});\nawait tools.search_tools({})"
+    req = _Request({"name": mw._tool_name, "args": {"code": code}, "id": "c1"})
+
+    out = await mw.awrap_tool_call(req, handler)
+
+    hint = out.content.split("<hint>")[1]
+    assert "tools.search(" not in hint, "must not advertise a discovery helper this eval does not have"
+    assert "`tools.console_grep_mcp_tools` is not available inside eval. Call `console_grep_mcp_tools` as a regular tool call" in hint
+    assert "delegate work that needs them with `task`" in hint
+    assert "`tools.github_get_me` is not available inside eval." in hint
+    assert "Callable here: `tools.getCurrentTime`, `tools.readFile`" in hint
+    assert "`tools.search_tools` does not exist and this eval has no discovery helper" in hint
+
+
+@pytest.mark.asyncio
+async def test_not_a_function_without_tools_access_is_left_alone(monkeypatch):
+    mw = _mw()
+    monkeypatch.setattr(gu, "resolve_ptc_thread_id", lambda runtime: "t1")
+    handler = AsyncMock(return_value=_msg(NOT_A_FUNCTION))
+    req = _Request({"name": mw._tool_name, "args": {"code": "const f = 1; f()"}, "id": "c1"})
+    out = await mw.awrap_tool_call(req, handler)
+    assert out.content == NOT_A_FUNCTION
+
+
+def test_raw_mcp_listers_are_never_in_the_eval_namespace():
+    mw = _mw()
+    grep = _mcp_tool("console_grep_mcp_tools")
+    small = [grep, _mcp_tool("console_list_mcp_servers"), _mcp_tool("github_get_me")]
+    names_small = {t.name for t in mw._collect_ptc_tools(SimpleNamespace(tools=small, state={}))}
+    assert "console_grep_mcp_tools" not in names_small and "console_list_mcp_servers" not in names_small
+    assert "github_get_me" in names_small, "only the listers are removed"
+
+    big = [grep] + [_mcp_tool(f"github_tool_{i}") for i in range(gu.PTC_INLINE_RENDER_THRESHOLD + 1)]
+    names_big = {t.name for t in mw._collect_ptc_tools(SimpleNamespace(tools=big, state={}))}
+    assert "console_grep_mcp_tools" not in names_big
+    assert {"search", "describe"} <= names_big, "core-only mode adds in-sandbox discovery"

--- a/packages/agent-common/tests/test_token_provider.py
+++ b/packages/agent-common/tests/test_token_provider.py
@@ -1,0 +1,153 @@
+"""UserTokenProvider: per-user exchanged bearers minted at call time, with expiry-aware reuse."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agent_common.core.token_provider import UserTokenProvider, bearer_interceptor, jwt_exp
+
+
+def _jwt(exp: float, **claims) -> str:
+    def seg(obj):
+        return base64.urlsafe_b64encode(json.dumps(obj).encode()).rstrip(b"=").decode()
+
+    return f"{seg({'alg': 'none'})}.{seg({'exp': exp, **claims})}.sig"
+
+
+def _exchange(lifetime: float = 900):
+    """An exchange stub minting a JWT per audience, counting calls."""
+    calls: list[str] = []
+
+    async def exchange(*, subject_token, target_client_id, requested_scopes):
+        calls.append(target_client_id)
+        return _jwt(time.time() + lifetime, aud=target_client_id, n=len(calls))
+
+    return exchange, calls
+
+
+def test_jwt_exp_reads_or_returns_none():
+    assert jwt_exp(_jwt(1234.0)) == 1234.0
+    assert jwt_exp("opaque") is None
+    assert jwt_exp(_jwt(1.0).rsplit(".", 1)[0] + ".x") == 1.0  # signature is irrelevant
+
+
+@pytest.mark.asyncio
+async def test_memoises_per_audience_and_reuses_while_fresh():
+    exchange, calls = _exchange()
+    p = UserTokenProvider(_jwt(time.time() + 3600), exchange)
+    a1 = await p.get("gatana")
+    a2 = await p.get("gatana")
+    c1 = await p.get("agent-console")
+    assert a1 == a2 and a1 != c1
+    assert calls == ["gatana", "agent-console"]
+
+
+@pytest.mark.asyncio
+async def test_reminted_inside_the_leeway_window():
+    exchange, calls = _exchange(lifetime=120)
+    p = UserTokenProvider(_jwt(time.time() + 3600), exchange, leeway_seconds=90)
+    t1 = await p.get("gatana")
+    with patch("agent_common.core.token_provider.time.time", return_value=time.time() + 40):  # 80 s left < leeway
+        t2 = await p.get("gatana")
+    assert t1 != t2 and calls == ["gatana", "gatana"]
+
+
+@pytest.mark.asyncio
+async def test_never_reused_past_the_subject_tokens_expiry():
+    exchange, calls = _exchange(lifetime=3600)
+    p = UserTokenProvider(_jwt(time.time() + 100), exchange, leeway_seconds=90)  # user token nearly done
+    await p.get("gatana")
+    with patch("agent_common.core.token_provider.time.time", return_value=time.time() + 20):  # 80 s of user token left
+        await p.get("gatana")
+    assert calls == ["gatana", "gatana"]
+
+
+@pytest.mark.asyncio
+async def test_unparseable_token_is_reminted_every_time():
+    calls = []
+
+    async def exchange(**kw):
+        calls.append(1)
+        return "opaque-token"
+
+    p = UserTokenProvider(_jwt(time.time() + 3600), exchange)
+    assert await p.get("gatana") == await p.get("gatana") == "opaque-token"
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_new_subject_token_invalidates_minted_tokens():
+    exchange, calls = _exchange()
+    subject = _jwt(time.time() + 3600, sub="u")
+    p = UserTokenProvider(subject, exchange)
+    await p.get("gatana")
+    p.update_subject_token(subject)  # identical → keep
+    await p.get("gatana")
+    assert calls == ["gatana"]
+    p.update_subject_token(_jwt(time.time() + 7200, sub="u"))  # rotated → re-mint
+    await p.get("gatana")
+    assert calls == ["gatana", "gatana"]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_callers_share_one_exchange():
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = []
+
+    async def exchange(**kw):
+        calls.append(1)
+        started.set()
+        await release.wait()
+        return _jwt(time.time() + 900)
+
+    p = UserTokenProvider(_jwt(time.time() + 3600), exchange)
+    tasks = [asyncio.create_task(p.get("gatana")) for _ in range(5)]
+    await started.wait()
+    release.set()
+    tokens = await asyncio.gather(*tasks)
+    assert len(set(tokens)) == 1 and len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_interceptor_injects_a_bearer_for_the_servers_audience():
+    exchange, calls = _exchange()
+    p = UserTokenProvider(_jwt(time.time() + 3600), exchange)
+    intercept = bearer_interceptor(p, lambda server: "agent-console" if server == "console" else "gatana")
+    seen = {}
+
+    class Req(SimpleNamespace):
+        def override(self, **kw):
+            return Req(**{**self.__dict__, **kw})
+
+    async def handler(req):
+        seen[req.server_name] = req.headers
+        return "ok"
+
+    await intercept(Req(server_name="github", headers={"x-nannos-context": "c1"}), handler)
+    await intercept(Req(server_name="console", headers=None), handler)
+    assert seen["github"]["x-nannos-context"] == "c1"  # existing headers preserved
+    assert seen["github"]["Authorization"].startswith("Bearer ") and "gatana" in _claims(seen["github"]["Authorization"])["aud"]
+    assert _claims(seen["console"]["Authorization"])["aud"] == "agent-console"
+    assert calls == ["gatana", "agent-console"]
+
+
+def _claims(bearer: str) -> dict:
+    seg = bearer.removeprefix("Bearer ").split(".")[1]
+    return json.loads(base64.urlsafe_b64decode(seg + "=" * (-len(seg) % 4)))
+
+
+@pytest.mark.asyncio
+async def test_exchange_failure_propagates_and_caches_nothing():
+    exchange = AsyncMock(side_effect=RuntimeError("keycloak down"))
+    p = UserTokenProvider(_jwt(time.time() + 3600), exchange)
+    with pytest.raises(RuntimeError):
+        await p.get("gatana")
+    assert p._minted == {}

--- a/packages/agent-common/tests/test_tool_catalogue.py
+++ b/packages/agent-common/tests/test_tool_catalogue.py
@@ -220,6 +220,12 @@ class TestStatelessIngest:
         assert tools[1].card.param_names == ("tools",)
         assert tools[1].output_schema_bytes is not None
 
+    def test_parse_reply_tolerates_empty_or_odd_result_shapes(self):
+        assert parse_tools_list_reply("srv", '{"jsonrpc": "2.0", "id": 1, "result": {}}') == ([], None)
+        assert parse_tools_list_reply("srv", '{"result": {"tools": []}}') == ([], None)
+        assert parse_tools_list_reply("srv", '{"result": {"tools": [], "nextCursor": ""}}') == ([], None)
+        assert parse_tools_list_reply("srv", '{"other": {"deep": {"tools": [1]}}}') == ([], None)
+
     def test_parse_reply_maps_rpc_errors(self):
         with pytest.raises(StatelessListUnsupported):
             parse_tools_list_reply("srv", json.dumps({"jsonrpc": "2.0", "id": 1, "error": {"code": -32600, "message": "Bad Request: No valid session ID"}}))

--- a/packages/agent-common/tests/test_tool_catalogue.py
+++ b/packages/agent-common/tests/test_tool_catalogue.py
@@ -1,0 +1,367 @@
+"""Tests for the raw-bytes tool catalogue (representation, lazy tools, ingest paths, store)."""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+from langchain_core.tools import BaseTool
+from langchain_core.utils.function_calling import convert_to_openai_tool
+from mcp.types import ListToolsResult, Tool as MCPTool, ToolAnnotations
+
+from agent_common.core.catalogue_ingest import (
+    StatelessListError,
+    StatelessListUnsupported,
+    fetch_catalogue_mcp,
+    fetch_catalogue_stateless,
+    iter_array_at,
+    parse_tools_list_reply,
+)
+from agent_common.core.tool_catalogue import (
+    CatalogueStore,
+    ServerCatalogue,
+    build_lazy_tools,
+    build_server_catalogue,
+    compute_interface_hash,
+    make_catalogue_tool,
+)
+
+SCHEMA = {
+    "type": "object",
+    "properties": {"q": {"type": "string", "description": "query"}},
+    "required": ["q"],
+}
+
+
+def _catalogue(*names: str, server: str = "srv") -> ServerCatalogue:
+    tools = [
+        make_catalogue_tool(server_name=server, name=n, description=f"desc {n}", input_schema=SCHEMA) for n in names
+    ]
+    return build_server_catalogue(server, tools, source="mcp")
+
+
+# --------------------------------------------------------------------------------------
+# Representation
+# --------------------------------------------------------------------------------------
+
+
+class TestRepresentation:
+    def test_card_holds_names_and_params_but_no_schema(self):
+        tool = make_catalogue_tool(
+            server_name="s",
+            name="t",
+            description="line one\nline two",
+            input_schema=SCHEMA,
+        )
+        assert tool.card.param_names == ("q",)
+        assert tool.card.first_line == "line one"
+        assert isinstance(tool.schema_bytes, bytes)
+        assert json.loads(tool.schema_bytes) == SCHEMA
+
+    def test_interface_hash_is_order_independent_and_schema_sensitive(self):
+        a = _catalogue("x", "y")
+        b = _catalogue("y", "x")
+        assert a.interface_hash == b.interface_hash
+        changed = build_server_catalogue(
+            "srv",
+            [
+                make_catalogue_tool(
+                    server_name="srv",
+                    name="x",
+                    description="desc x",
+                    input_schema={"type": "object"},
+                )
+            ],
+            source="mcp",
+        )
+        assert changed.interface_hash != _catalogue("x").interface_hash
+        # Same interface from either ingest path hashes the same.
+        assert compute_interface_hash(a.tools.values()) == a.interface_hash
+
+    def test_duplicate_names_keep_first(self):
+        tools = [
+            make_catalogue_tool(server_name="s", name="dup", description="first", input_schema=SCHEMA),
+            make_catalogue_tool(server_name="s", name="dup", description="second", input_schema=SCHEMA),
+        ]
+        cat = build_server_catalogue("s", tools, source="stateless")
+        assert cat.tools["dup"].card.description == "first"
+
+
+class TestLazyMcpTool:
+    def test_listing_attributes_never_decode(self):
+        (tool,) = build_lazy_tools(_catalogue("t"), connection={"transport": "streamable_http", "url": "u"})
+        assert isinstance(tool, BaseTool)
+        assert tool.name == "t"
+        assert tool.description == "desc t"
+        assert tool.metadata["server_name"] == "srv"
+        assert not tool.schema_decoded
+
+    def test_schema_decodes_once_on_first_use(self):
+        (tool,) = build_lazy_tools(_catalogue("t"), connection={"transport": "streamable_http", "url": "u"})
+        params = convert_to_openai_tool(tool)["function"]["parameters"]
+        assert params == SCHEMA
+        assert tool.schema_decoded
+        first = tool.args_schema
+        assert tool.args_schema is first  # cached, not re-decoded
+        assert tool.args == SCHEMA["properties"]
+
+    def test_metadata_mirrors_adapter_shape_and_extra(self):
+        entry = make_catalogue_tool(
+            server_name="s",
+            name="t",
+            description="d",
+            input_schema=SCHEMA,
+            annotations={"readOnlyHint": True},
+            meta={"k": "v"},
+        )
+        cat = build_server_catalogue("s", [entry], source="stateless")
+        (tool,) = build_lazy_tools(cat, connection={}, extra_metadata={"compression_enabled": True})
+        assert tool.metadata == {
+            "readOnlyHint": True,
+            "_meta": {"k": "v"},
+            "server_name": "s",
+            "compression_enabled": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_invoke_delegates_to_adapter_tool_for_that_one_tool(self):
+        connection = {
+            "transport": "streamable_http",
+            "url": "https://gw/mcp",
+            "headers": {"Authorization": "Bearer x"},
+        }
+        (tool,) = build_lazy_tools(_catalogue("t"), connection=connection, tool_interceptors=["icpt"])
+        seen: dict = {}
+
+        async def fake_coroutine(runtime=None, **arguments):
+            seen["args"] = arguments
+            return ("result text", None)
+
+        def fake_convert(session, mcp_tool, **kwargs):
+            seen["mcp_tool"] = mcp_tool
+            seen["kwargs"] = kwargs
+            delegate = Mock()
+            delegate.coroutine = fake_coroutine
+            return delegate
+
+        with patch(
+            "langchain_mcp_adapters.tools.convert_mcp_tool_to_langchain_tool",
+            side_effect=fake_convert,
+        ):
+            out = await tool.ainvoke({"q": "hi"})
+            await tool.ainvoke({"q": "again"})
+
+        assert out == "result text"
+        assert seen["args"] == {"q": "again"}
+        assert seen["mcp_tool"].name == "t" and seen["mcp_tool"].inputSchema == SCHEMA
+        assert seen["kwargs"]["connection"] is connection
+        assert seen["kwargs"]["tool_interceptors"] == ["icpt"]
+        assert seen["kwargs"]["server_name"] == "srv"
+        assert tool._get_delegate() is tool._get_delegate(), "delegate is built once per tool"
+
+
+# --------------------------------------------------------------------------------------
+# Stateless tools/list ingest
+# --------------------------------------------------------------------------------------
+
+TOOLS_PAGE_1 = [
+    {
+        "name": "srv_plain",
+        "description": "plain desc",
+        "inputSchema": SCHEMA,
+        "annotations": {"readOnlyHint": True},
+        "_meta": {"k": "v"},
+    },
+    {
+        "name": "srv_tricky",
+        "description": 'has "tools": [ in the description',
+        # A schema with a property literally named "tools" must not derail the scan.
+        "inputSchema": {"type": "object", "properties": {"tools": {"type": "array", "items": {"type": "string"}}}},
+        "outputSchema": {"type": "object"},
+    },
+    {"description": "no name → skipped", "inputSchema": SCHEMA},
+]
+TOOLS_PAGE_2 = [{"name": "srv_second_page", "inputSchema": {"type": "object"}}]
+
+
+def _envelope(tools, cursor=None, *, id_="catalogue-tools-list"):
+    result = {"tools": tools}
+    if cursor:
+        result["nextCursor"] = cursor
+    return {"jsonrpc": "2.0", "id": id_, "result": result}
+
+
+class TestScanner:
+    def test_iter_array_at_walks_nested_path_and_keeps_siblings(self):
+        text = json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"nextCursor": "c2", "tools": [1, {"a": 1}], "x": 3}})
+        siblings: dict = {}
+        items = list(iter_array_at(text, ("result", "tools"), siblings, keep=frozenset({"nextCursor", "id"})))
+        assert items == [1, {"a": 1}]
+        assert siblings["1.nextCursor"] == "c2" and siblings["0.id"] == 1
+
+    def test_iter_array_at_handles_empty_and_missing(self):
+        assert list(iter_array_at('{"result": {"tools": []}}', ("result", "tools"))) == []
+        assert list(iter_array_at('{"result": {"other": 1}}', ("result", "tools"))) == []
+        with pytest.raises(ValueError):
+            list(iter_array_at("[1,2]", ("result", "tools")))
+        with pytest.raises(IndexError):
+            list(iter_array_at('{"result": {"tools": [{"a": 1}', ("result", "tools")))  # truncated body
+
+
+class TestStatelessIngest:
+    def test_parse_reply_flattens_tools_and_reads_cursor(self):
+        tools, cursor = parse_tools_list_reply("srv", json.dumps(_envelope(TOOLS_PAGE_1, cursor="p2")))
+        assert [t.name for t in tools] == ["srv_plain", "srv_tricky"]
+        assert cursor == "p2"
+        assert tools[0].annotations == {"readOnlyHint": True} and tools[0].meta == {"k": "v"}
+        assert tools[1].card.param_names == ("tools",)
+        assert tools[1].output_schema_bytes is not None
+
+    def test_parse_reply_maps_rpc_errors(self):
+        with pytest.raises(StatelessListUnsupported):
+            parse_tools_list_reply("srv", json.dumps({"jsonrpc": "2.0", "id": 1, "error": {"code": -32600, "message": "Bad Request: No valid session ID"}}))
+        with pytest.raises(StatelessListError):
+            parse_tools_list_reply("srv", json.dumps({"jsonrpc": "2.0", "id": 1, "error": {"code": -32603, "message": "upstream down"}}))
+        with pytest.raises(ValueError):
+            parse_tools_list_reply("srv", "{not json")
+
+    @pytest.mark.asyncio
+    async def test_fetch_stateless_json_reply_with_pagination(self):
+        calls: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(request)
+            body = json.loads(request.content)
+            assert body["method"] == "tools/list" and body["jsonrpc"] == "2.0"
+            if body["params"].get("cursor") == "p2":
+                return httpx.Response(200, json=_envelope(TOOLS_PAGE_2, id_=body["id"]))
+            return httpx.Response(200, json=_envelope(TOOLS_PAGE_1, cursor="p2", id_=body["id"]))
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            cat = await fetch_catalogue_stateless(
+                client, url="https://gw/mcp?includeOnlyServerSlugs=srv", headers={"Authorization": "Bearer tok"}, server_slug="srv"
+            )
+        assert cat.source == "stateless"
+        assert set(cat.tools) == {"srv_plain", "srv_tricky", "srv_second_page"}
+        assert len(calls) == 2
+        assert calls[0].headers["Authorization"] == "Bearer tok"
+        assert calls[0].headers["Accept"] == "application/json, text/event-stream"
+        assert str(calls[0].url) == "https://gw/mcp?includeOnlyServerSlugs=srv"
+
+    @pytest.mark.asyncio
+    async def test_fetch_stateless_sse_reply_skips_notifications(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            frames = [
+                'data: {"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info"}}',
+                "data: " + json.dumps(_envelope(TOOLS_PAGE_1, id_=body["id"])),
+            ]
+            return httpx.Response(200, text="\n\n".join(frames) + "\n\n", headers={"content-type": "text/event-stream"})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            cat = await fetch_catalogue_stateless(client, url="https://gw/mcp", headers=None, server_slug="srv")
+        assert set(cat.tools) == {"srv_plain", "srv_tricky"}
+
+    @pytest.mark.asyncio
+    async def test_fetch_stateless_status_mapping(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            slug = request.url.params.get("includeOnlyServerSlugs")
+            if slug == "refuses":
+                return httpx.Response(400, text="Bad Request: No valid session ID provided")
+            if slug == "denied":
+                return httpx.Response(403, text="forbidden")
+            if slug == "flaky":
+                return httpx.Response(502, text="bad gateway")
+            if slug == "moved":
+                return httpx.Response(307, headers={"location": "https://gw/mcp/"})
+            return httpx.Response(200, text="{not json")
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            for slug, exc in (
+                ("refuses", StatelessListUnsupported),
+                ("denied", StatelessListError),
+                ("flaky", StatelessListError),
+                ("moved", StatelessListError),  # redirect not followed → per-server fallback, not a refusal
+                ("garbage", StatelessListError),
+            ):
+                with pytest.raises(exc):
+                    await fetch_catalogue_stateless(
+                        client, url=f"https://gw/mcp?includeOnlyServerSlugs={slug}", headers=None, server_slug=slug
+                    )
+
+
+# --------------------------------------------------------------------------------------
+# MCP fallback ingest
+# --------------------------------------------------------------------------------------
+
+
+class TestMcpIngest:
+    @pytest.mark.asyncio
+    async def test_paginated_tools_list_is_flattened(self):
+        pages = [
+            ListToolsResult(
+                tools=[
+                    MCPTool(
+                        name="a",
+                        description="A",
+                        inputSchema=SCHEMA,
+                        annotations=ToolAnnotations(readOnlyHint=True),
+                        _meta={"x": 1},
+                    )
+                ],
+                nextCursor="p2",
+            ),
+            ListToolsResult(
+                tools=[MCPTool(name="b", inputSchema={"type": "object"})],
+                nextCursor=None,
+            ),
+        ]
+        session = Mock()
+        session.list_tools = AsyncMock(side_effect=pages)
+
+        @asynccontextmanager
+        async def factory():
+            yield session
+
+        cat = await fetch_catalogue_mcp(factory, server_slug="srv")
+        assert cat.source == "mcp"
+        assert set(cat.tools) == {"a", "b"}
+        assert cat.tools["a"].annotations == {"readOnlyHint": True}
+        assert cat.tools["a"].meta == {"x": 1}
+        assert cat.tools["b"].card.description == ""
+        assert session.list_tools.await_args_list[1].kwargs == {"cursor": "p2"}
+
+
+# --------------------------------------------------------------------------------------
+# Store
+# --------------------------------------------------------------------------------------
+
+
+class TestCatalogueStore:
+    def test_intern_shares_identical_catalogues(self):
+        store = CatalogueStore()
+        first = store.intern(_catalogue("a"))
+        again = store.intern(_catalogue("a"))
+        assert again is first, "same (server, hash) → same object, bytes shared"
+        newer = store.intern(_catalogue("a", "b"))
+        assert newer is not first
+        assert store.interned("srv") is newer
+
+    def test_resolve_finds_names_across_interned_catalogues(self):
+        store = CatalogueStore()
+        store.intern(_catalogue("a", "b", server="one"))
+        store.intern(_catalogue("c", server="two"))
+        found = store.resolve(["a", "c", "nope"])
+        assert set(found) == {"a", "c"}
+        assert found["a"][0].server_name == "one" and found["c"][0].server_name == "two"
+
+    def test_capability_memo(self):
+        store = CatalogueStore()
+        assert store.stateless_supported("https://gw/mcp") is None
+        store.set_stateless_supported("https://gw/mcp", False)
+        assert store.stateless_supported("https://gw/mcp") is False
+        store.clear()
+        assert store.stateless_supported("https://gw/mcp") is None

--- a/packages/console-backend/app.py
+++ b/packages/console-backend/app.py
@@ -246,7 +246,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     app.state.mcp_session_manager = StreamableHTTPSessionManager(
         app=mcp.server,
         json_response=False,  # SSE so intermediate keepalive notifications stream
-        stateless=False,  # keep optional session support, matching fastapi_mcp's mount_http
+        # Stateless: no Mcp-Session-Id required, so a bare `POST tools/list` (the
+        # orchestrator's raw-bytes catalogue fast path) is served, and requests are not
+        # pinned to one ECS task behind the ALB. Progress/keepalive notifications still
+        # stream on the calling request's SSE response; we never push notifications
+        # between requests, so nothing depends on session state.
+        stateless=True,
     )
     app.state.mcp_sm_stack = AsyncExitStack()
     await app.state.mcp_sm_stack.enter_async_context(app.state.mcp_session_manager.run())

--- a/packages/console-backend/tests/test_mcp_streaming_keepalive.py
+++ b/packages/console-backend/tests/test_mcp_streaming_keepalive.py
@@ -11,11 +11,13 @@ no notification arrives before the final result.
 """
 
 import asyncio
+import json
 import os
 import socket
 import threading
 import time
 
+import httpx
 import pytest
 import uvicorn
 
@@ -58,7 +60,7 @@ def _build_app(interval: float = 0.4) -> FastAPI:
 
     mcp._execute_api_tool = _with_keepalive
 
-    session_manager = StreamableHTTPSessionManager(app=mcp.server, json_response=False, stateless=False)
+    session_manager = StreamableHTTPSessionManager(app=mcp.server, json_response=False, stateless=True)
 
     async def _mcp_asgi(scope, receive, send):
         await session_manager.handle_request(scope, receive, send)
@@ -115,6 +117,39 @@ async def test_keepalive_notifications_stream_before_result():
         )
         assert any(kind == "progress" for _, kind in notifications)
         assert any(kind == "log" for _, kind in notifications)
+    finally:
+        server.should_exit = True
+        thread.join(timeout=10)
+
+
+@pytest.mark.asyncio
+async def test_bare_tools_list_without_session_id_is_served():
+    """The orchestrator's raw-bytes catalogue fast path POSTs ``tools/list`` with no
+    ``initialize`` handshake and no ``Mcp-Session-Id``. With ``stateless=False`` the SDK
+    answers ``400 Missing session ID`` and our own server falls back to the slow path."""
+    port = _free_port()
+    config = uvicorn.Config(_build_app(), host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    try:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline and not server.started:
+            await asyncio.sleep(0.05)
+        assert server.started, "uvicorn did not start"
+
+        async with httpx.AsyncClient(follow_redirects=True) as client:
+            resp = await client.post(
+                f"http://127.0.0.1:{port}/mcp",
+                json={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+                headers={"Accept": "application/json, text/event-stream"},
+            )
+        assert resp.status_code == 200, resp.text
+        # SSE transport: the result is the data payload of the first event.
+        payload = next(line for line in resp.text.splitlines() if line.startswith("data:"))
+        body = json.loads(payload[len("data:"):])
+        assert body["id"] == 1 and "error" not in body, body
+        assert [t["name"] for t in body["result"]["tools"]] == ["slow_tool"]
     finally:
         server.should_exit = True
         thread.join(timeout=10)

--- a/packages/orchestrator-agent/.env.template
+++ b/packages/orchestrator-agent/.env.template
@@ -69,6 +69,10 @@ MCP_GATEWAY_CLIENT_ID=gatana
 # memory peak scale with the size of the gateway catalogue. Lower this if the
 # pod is memory-constrained, raise it to trade memory for cold-start latency.
 MCP_DISCOVERY_CONCURRENCY=5
+# List each server's tools with a single stateless JSON-RPC tools/list POST (no SDK
+# handshake, no pydantic parse; same URL/token/entitlements as the SDK path). Probed once
+# per endpoint, falls back to the SDK session automatically. Set false to force the SDK path.
+MCP_CATALOGUE_STATELESS_LIST=true
 
 # ===================================
 # A2A Client Timeout Configuration

--- a/packages/orchestrator-agent/.env.template
+++ b/packages/orchestrator-agent/.env.template
@@ -73,6 +73,9 @@ MCP_DISCOVERY_CONCURRENCY=5
 # handshake, no pydantic parse; same URL/token/entitlements as the SDK path). Probed once
 # per endpoint, falls back to the SDK session automatically. Set false to force the SDK path.
 MCP_CATALOGUE_STATELESS_LIST=true
+# Reuse an exchanged MCP bearer only while it keeps at least this many seconds of validity;
+# set it above the token lifetime (e.g. 100000) to force a fresh exchange on every tool call.
+MCP_TOKEN_LEEWAY_SECONDS=90
 
 # ===================================
 # A2A Client Timeout Configuration

--- a/packages/orchestrator-agent/app/core/discovery.py
+++ b/packages/orchestrator-agent/app/core/discovery.py
@@ -36,6 +36,7 @@ from agent_common.core.catalogue_ingest import (
     fetch_catalogue_mcp,
     fetch_catalogue_stateless,
 )
+from agent_common.core.token_provider import UserTokenProvider, bearer_interceptor
 from agent_common.core.tool_catalogue import CatalogueStore, ServerCatalogue, build_lazy_tools, get_catalogue_store
 
 logger = logging.getLogger(__name__)
@@ -406,35 +407,47 @@ class ToolDiscoveryService:
         # Should never reach here, but just in case
         raise last_error or Exception(f"Failed to load MCP tools from {server_name}")
 
+    def make_token_provider(self, token: str) -> UserTokenProvider:
+        """A per-user provider of exchanged MCP bearer tokens (see agent_common.core.token_provider)."""
+        return UserTokenProvider(token, self.oauth2_client.exchange_token)
+
+    def _audience_for_server(self, server_name: str) -> str:
+        """OAuth audience a server's calls must carry: console-backend's client id for the
+        console MCP server, the gateway client for everything else."""
+        return self.config.CONSOLE_BACKEND_CLIENT_ID if server_name == "console" else "gatana"
+
     async def discover_tools(
         self,
         token: str,
         white_list: Optional[List[str]] = None,
         include_server_slugs: Optional[List[str]] = None,
+        token_provider: UserTokenProvider | None = None,
     ) -> List[BaseTool]:
         """Discover available MCP tools with optional server filtering.
 
-        Performs token exchange to obtain a token for the gatana client
-        in the same Keycloak realm, then uses that token to authenticate with
-        MCP services.
+        Tokens: the user's token is exchanged for the gateway / console audiences through a
+        per-user :class:`UserTokenProvider`. The exchanged token is used to *list* tools now;
+        the tools themselves are built on token-free connections and mint a fresh bearer on
+        every call via an interceptor, so a tool's credential is never older than the
+        provider's leeway — however long the tool object lives (discovery cache, sub-agent
+        hand-over).
 
         Args:
             token: User's access token from the orchestrator
             white_list: Optional list of tool names to filter to (post-discovery filtering)
             include_server_slugs: Optional list of server slugs to include tools from
+            token_provider: The user's provider (created here when not given; the executor
+                passes the one it keeps across turns)
 
         Returns:
             List of discovered tools with server_name in metadata
         """
         logger.debug("Discovering tools for orchestrator deep agent")
         try:
+            provider = token_provider or self.make_token_provider(token)
             # Exchange user token for gatana token
             # The target client is 'gatana' in the same Keycloak realm
-            mcp_gateway_token = await self.oauth2_client.exchange_token(
-                subject_token=token,
-                target_client_id="gatana",
-                requested_scopes=["openid", "profile", "offline_access"],
-            )
+            mcp_gateway_token = await provider.get("gatana")
             logger.info("Successfully exchanged token for gatana")
 
             # Fetch available servers to create per-server connections
@@ -462,19 +475,24 @@ class ToolDiscoveryService:
                 logger.debug(f"Filtered to {len(servers)} servers: {[s.get('slug') for s in servers]}")
 
             # Create one connection per MCP server
-            # This allows MultiServerMCPClient to naturally track which tools come from which server
-            connections = {}
+            # This allows MultiServerMCPClient to naturally track which tools come from which server.
+            # `connections` carry the bearer for *listing* (this request); `call_connections` are the
+            # same URLs without credentials — the tools built on them mint a bearer per call.
+            connections: dict[str, Any] = {}
+            call_connections: dict[str, Any] = {}
             for server in servers:
                 server_slug = server.get("slug")
                 if not server_slug:
                     continue
 
                 # Each connection uses the gateway URL but filtered to one server
+                url = f"{self.config.MCP_GATEWAY_URL}?includeOnlyServerSlugs={server_slug}"
                 connections[server_slug] = StreamableHttpConnection(
                     transport="streamable_http",
-                    url=f"{self.config.MCP_GATEWAY_URL}?includeOnlyServerSlugs={server_slug}",
+                    url=url,
                     headers={"Authorization": f"Bearer {mcp_gateway_token}"},
                 )
+                call_connections[server_slug] = StreamableHttpConnection(transport="streamable_http", url=url)
 
             if not connections:
                 logger.warning("No valid server connections created, returning empty tool list")
@@ -484,16 +502,13 @@ class ToolDiscoveryService:
             # Exchange token for agent-console audience (separate from gatana)
             if self.config.CONSOLE_BACKEND_URL:
                 console_mcp_url = f"{self.config.CONSOLE_BACKEND_URL}/mcp"
-                console_token = await self.oauth2_client.exchange_token(
-                    subject_token=token,
-                    target_client_id=self.config.CONSOLE_BACKEND_CLIENT_ID,
-                    requested_scopes=["openid", "profile", "offline_access"],
-                )
+                console_token = await provider.get(self.config.CONSOLE_BACKEND_CLIENT_ID)
                 connections["console"] = StreamableHttpConnection(
                     transport="streamable_http",
                     url=console_mcp_url,
                     headers={"Authorization": f"Bearer {console_token}"},
                 )
+                call_connections["console"] = StreamableHttpConnection(transport="streamable_http", url=console_mcp_url)
                 logger.debug(f"Added agent-console MCP connection: {console_mcp_url}")
 
             logger.debug(f"Created {len(connections)} MCP server connections: {list(connections.keys())}")
@@ -505,11 +520,15 @@ class ToolDiscoveryService:
             client = MultiServerMCPClient(
                 connections=connections,
                 callbacks=Callbacks(on_progress=on_mcp_progress),
-                # Stamp x-nannos-context (conversation_id, …) on every console tool call so
-                # console-backend tools that hit the gateway (console_web_search) bill to the right
-                # conversation instead of "Direct API Calls". Scoped to the console server inside.
-                tool_interceptors=[_console_attribution_interceptor],
             )
+            # Per-call interceptors for the tools: a fresh bearer for the server's audience, then
+            # x-nannos-context (conversation_id, …) on console tool calls so console-backend tools
+            # that hit the gateway (console_web_search) bill to the right conversation instead of
+            # "Direct API Calls" (scoped to the console server inside).
+            tool_interceptors = [
+                bearer_interceptor(provider, self._audience_for_server),
+                _console_attribution_interceptor,
+            ]
 
             # Gather tools from all servers with retry logic.
             # Use asyncio.gather with return_exceptions=True to handle partial failures gracefully.
@@ -561,9 +580,9 @@ class ToolDiscoveryService:
                     tools.extend(
                         build_lazy_tools(
                             result,
-                            connection=connections[slug],
+                            connection=call_connections[slug],
                             callbacks=client.callbacks,
-                            tool_interceptors=client.tool_interceptors,
+                            tool_interceptors=tool_interceptors,
                             extra_metadata=extra_metadata,
                         )
                     )

--- a/packages/orchestrator-agent/app/core/discovery.py
+++ b/packages/orchestrator-agent/app/core/discovery.py
@@ -569,7 +569,7 @@ class ToolDiscoveryService:
 
             # Process results - filter out exceptions and log failures. Each catalogue
             # is wrapped into per-user LazyMcpTools bound to this user's connection
-            # (which carries the exchanged token); the catalogue bytes themselves are
+            # (token-free: a bearer is minted per call via the interceptors); the catalogue bytes themselves are
             # shared across users via the store.
             tools: list[BaseTool] = []
             failed_servers = []

--- a/packages/orchestrator-agent/app/core/discovery.py
+++ b/packages/orchestrator-agent/app/core/discovery.py
@@ -408,8 +408,15 @@ class ToolDiscoveryService:
         raise last_error or Exception(f"Failed to load MCP tools from {server_name}")
 
     def make_token_provider(self, token: str) -> UserTokenProvider:
-        """A per-user provider of exchanged MCP bearer tokens (see agent_common.core.token_provider)."""
-        return UserTokenProvider(token, self.oauth2_client.exchange_token)
+        """A per-user provider of exchanged MCP bearer tokens (see agent_common.core.token_provider).
+
+        ``MCP_TOKEN_LEEWAY_SECONDS`` sets how much validity a memoised token must keep to be
+        reused. Setting it above the exchanged tokens' lifetime forces a fresh exchange on
+        *every* call — a QA lever to watch the call-time path work without waiting for expiry.
+        """
+        return UserTokenProvider(
+            token, self.oauth2_client.exchange_token, leeway_seconds=self.config.MCP_TOKEN_LEEWAY_SECONDS
+        )
 
     def _audience_for_server(self, server_name: str) -> str:
         """OAuth audience a server's calls must carry: console-backend's client id for the

--- a/packages/orchestrator-agent/app/core/discovery.py
+++ b/packages/orchestrator-agent/app/core/discovery.py
@@ -29,6 +29,14 @@ from ringier_a2a_sdk.utils.mcp_errors import (
 from ringier_a2a_sdk.utils.mcp_progress import on_mcp_progress
 
 from ..models.config import AgentSettings
+from agent_common.core.catalogue_ingest import (
+    STATELESS_TIMEOUT_S,
+    StatelessListError,
+    StatelessListUnsupported,
+    fetch_catalogue_mcp,
+    fetch_catalogue_stateless,
+)
+from agent_common.core.tool_catalogue import CatalogueStore, ServerCatalogue, build_lazy_tools, get_catalogue_store
 
 logger = logging.getLogger(__name__)
 
@@ -219,6 +227,15 @@ class ToolDiscoveryService:
         self.config = config
         self.oauth2_client = oauth2_client
 
+    @property
+    def catalogue_store(self) -> CatalogueStore:
+        """Process-wide catalogue store (bytes shared across users; capability memo)."""
+        return get_catalogue_store()
+
+    def _gateway_base_url(self) -> str:
+        # Strip the trailing slash first: removesuffix("/mcp") is a no-op on ".../mcp/".
+        return self.config.MCP_GATEWAY_URL.rstrip("/").removesuffix("/mcp")
+
     async def fetch_available_servers(self, token: str) -> List[Dict[str, Any]]:
         """Fetch list of available MCP servers from the gateway.
 
@@ -235,10 +252,7 @@ class ToolDiscoveryService:
         logger.debug("Fetching available MCP servers from gateway")
         try:
             # Call the MCP gateway API to get server list
-            # Extract base URL from MCP_GATEWAY_URL (remove /mcp path). Strip the
-            # trailing slash first: removesuffix("/mcp") is a no-op on ".../mcp/".
-            base_url = self.config.MCP_GATEWAY_URL.rstrip("/").removesuffix("/mcp")
-            servers_url = f"{base_url}/api/v1/mcp-servers"
+            servers_url = f"{self._gateway_base_url()}/api/v1/mcp-servers"
 
             logger.debug(f"Fetching servers from: {servers_url}")
 
@@ -284,26 +298,67 @@ class ToolDiscoveryService:
             _DISCOVERY_SEMAPHORE_LIMIT = limit
         return _DISCOVERY_SEMAPHORE
 
-    async def _get_tools_with_retry(
+    async def _ingest_server(
+        self,
+        server_name: str,
+        client: MultiServerMCPClient,
+        connection: StreamableHttpConnection,
+        *,
+        http_client: httpx.AsyncClient | None,
+    ) -> ServerCatalogue:
+        """Fetch one server's catalogue: stateless ``tools/list`` POST → SDK session.
+
+        Both paths hit the same MCP URL with the same bearer token (the server's
+        connection), so the result is the same per-user listing; the stateless path just
+        skips the SDK handshake and the pydantic parse. Whether an endpoint serves a
+        stateless request is probed once per URL: a rejection marks it unsupported for the
+        process lifetime; any other failure falls back for this server only. Whatever the
+        path, the result is interned in the process-wide store so identical catalogues
+        share bytes across users.
+        """
+        store = self.catalogue_store
+        url = connection["url"]
+        if http_client is not None and self.config.MCP_CATALOGUE_STATELESS_LIST and store.stateless_supported(url) is not False:
+            try:
+                catalogue = await fetch_catalogue_stateless(
+                    http_client, url=url, headers=connection.get("headers"), server_slug=server_name
+                )
+            except StatelessListUnsupported as e:
+                store.set_stateless_supported(url, False)
+                logger.warning(f"MCP endpoint refuses stateless tools/list — using SDK session for '{server_name}' ({e})")
+            except StatelessListError as e:
+                logger.warning(f"Stateless tools/list failed for '{server_name}', falling back to SDK session: {e}")
+            else:
+                store.set_stateless_supported(url, True)
+                return store.intern(catalogue)
+        catalogue = await fetch_catalogue_mcp(lambda: client.session(server_name), server_slug=server_name)
+        return store.intern(catalogue)
+
+    async def _get_catalogue_with_retry(
         self,
         client: MultiServerMCPClient,
         server_name: str,
+        connection: StreamableHttpConnection,
+        *,
+        http_client: httpx.AsyncClient | None = None,
         max_retries: int = 3,
         initial_delay: float = 1.0,
-    ) -> list:
-        """Get tools from MCP server with exponential backoff retry for transient errors.
+    ) -> ServerCatalogue:
+        """Fetch a server's catalogue with exponential backoff retry for transient errors.
 
         Retries on HTTP 502, 503, 504 errors with exponential backoff.
         Non-retryable errors (4xx, connection refused, etc.) fail immediately.
 
         Args:
-            client: MultiServerMCPClient instance
+            client: MultiServerMCPClient instance (owns the per-server MCP connections)
             server_name: Name of the server to get tools from
+            connection: The server's MCP connection (URL + auth headers)
+            http_client: Shared httpx client for the stateless fast path (None = SDK only)
             max_retries: Maximum number of retry attempts (default: 3)
             initial_delay: Initial delay between retries in seconds (default: 1.0)
 
         Returns:
-            List of tools from the server
+            The server's catalogue (bytes + cards)
 
         Raises:
             Exception: If all retries are exhausted or a non-retryable error occurs
@@ -317,16 +372,11 @@ class ToolDiscoveryService:
                 # backoff sleep below would let a few flaky servers idle away the
                 # whole budget while healthy ones wait on a user-facing path.
                 async with self._discovery_semaphore():
-                    server_tools = await client.get_tools(server_name=server_name)
-                # Tag tools with server_name metadata
-                for tool in server_tools:
-                    if tool.metadata is None:
-                        tool.metadata = {}
-                    tool.metadata["server_name"] = server_name
+                    catalogue = await self._ingest_server(server_name, client, connection, http_client=http_client)
 
                 if attempt > 0:
                     logger.info(f"Successfully loaded MCP tools from {server_name} on attempt {attempt + 1}")
-                return server_tools
+                return catalogue
 
             except Exception as e:
                 last_error = e
@@ -479,26 +529,56 @@ class ToolDiscoveryService:
                 f"Discovering tools from {len(connections)} MCP servers "
                 f"(max {self.config.MCP_DISCOVERY_CONCURRENCY} concurrent, process-wide)"
             )
-            results = await asyncio.gather(
-                *[self._get_tools_with_retry(client, slug) for slug in connections], return_exceptions=True
-            )
+            # follow_redirects: a mount such as console-backend's ``/mcp`` answers ``307 → /mcp/``;
+            # the SDK transport follows it, so the stateless path must too or it falls back for
+            # the wrong reason.
+            async with httpx.AsyncClient(timeout=STATELESS_TIMEOUT_S, follow_redirects=True) as http_client:
+                results = await asyncio.gather(
+                    *[
+                        self._get_catalogue_with_retry(client, slug, connection, http_client=http_client)
+                        for slug, connection in connections.items()
+                    ],
+                    return_exceptions=True,
+                )
 
-            # Process results - filter out exceptions and log failures
-            tools = []
+            # Process results - filter out exceptions and log failures. Each catalogue
+            # is wrapped into per-user LazyMcpTools bound to this user's connection
+            # (which carries the exchanged token); the catalogue bytes themselves are
+            # shared across users via the store.
+            tools: list[BaseTool] = []
             failed_servers = []
+            source_by_server: dict[str, str] = {}
             for slug, result in zip(connections.keys(), results):
-                if isinstance(result, Exception):
-                    error_msg = format_mcp_error(result)
+                if isinstance(result, BaseException):
+                    error_msg = format_mcp_error(result) if isinstance(result, Exception) else str(result)
                     logger.error(f"Failed to discover tools from server '{slug}': {error_msg}")
                     failed_servers.append(slug)
-                elif isinstance(result, list):
-                    # Tag tools from compression-enabled servers
-                    if compression_server_slugs and slug in compression_server_slugs:
-                        for tool in result:
-                            if tool.metadata is None:
-                                tool.metadata = {}
-                            tool.metadata["compression_enabled"] = True
-                    tools.extend(result)
+                elif isinstance(result, ServerCatalogue):
+                    source_by_server[slug] = result.source
+                    extra_metadata = (
+                        {"compression_enabled": True} if compression_server_slugs and slug in compression_server_slugs else None
+                    )
+                    tools.extend(
+                        build_lazy_tools(
+                            result,
+                            connection=connections[slug],
+                            callbacks=client.callbacks,
+                            tool_interceptors=client.tool_interceptors,
+                            extra_metadata=extra_metadata,
+                        )
+                    )
+
+            # Which ingest path each server took must be visible: a silent fall-back to
+            # the slow path would look like the optimisation simply not working.
+            fast = sorted(s for s, src in source_by_server.items() if src == "stateless")
+            slow = sorted(s for s, src in source_by_server.items() if src == "mcp")
+            logger.info(
+                "Tool catalogue ingest: %d server(s) via stateless tools/list %s, %d via SDK session %s",
+                len(fast),
+                fast,
+                len(slow),
+                slow,
+            )
 
             if failed_servers:
                 logger.warning(

--- a/packages/orchestrator-agent/app/core/discovery_cache.py
+++ b/packages/orchestrator-agent/app/core/discovery_cache.py
@@ -32,18 +32,14 @@ and every entry is recomputed.
 
 Token-expiry safety
 -------------------
-Discovered tools embed an *exchanged* bearer token (gatana/console) in their MCP connection,
-and the registry data was fetched with the user token, so a cache entry must not outlive
-those tokens. Each entry is bounded by ``min(ttl, user_token.exp - margin)``.
-
-The user token's ``exp`` is used as the bound because the exchanged tokens are not available
-at ``put`` time. This is safe **only while** the exchanged gatana/console tokens are minted
-with a lifetime at least as long as the user token's remaining validity — which holds when
-those OIDC clients use (at least) the realm's default access-token lifespan. To keep that
-assumption robust the default TTL is kept well below a typical realm access-token lifespan,
-so an entry can never outlive a freshly-minted exchanged token even if a client is
-configured with a shorter lifespan. If you shorten the gatana/console token lifespan below
-``AGENT_DISCOVERY_CACHE_TTL``, lower the TTL to match.
+Discovered tools carry **no** bearer token: each call mints one through the user's
+``UserTokenProvider`` (``agent_common.core.token_provider``), which is cached alongside the
+tools and given the user's current token at the start of every turn. The registry data,
+however, was fetched with the user token and reflects entitlements tied to it, so a cache
+entry is still bounded by ``min(ttl, user_token.exp - margin)``: it never outlives the user
+token it was built for. The TTL itself is therefore purely a *catalogue-freshness* knob (how
+long before a changed gateway catalogue or group→server policy is picked up), not a
+credential bound.
 """
 
 from __future__ import annotations

--- a/packages/orchestrator-agent/app/core/discovery_cache.py
+++ b/packages/orchestrator-agent/app/core/discovery_cache.py
@@ -18,8 +18,8 @@ entitled to *and* that the cached value actually depends on::
 
 Note that the per-user *tool whitelist* (``tool_names``) is deliberately NOT part of the
 key: discovery runs unfiltered (``white_list=None``) and the whitelist is applied later in
-``build_runtime_context``, so the cached ``(tools, sub_agents)`` value does not depend on
-it. Keying on it would only fragment the cache. A whitelist change (or any other per-user
+``build_runtime_context``, so the cached ``(tools, sub_agents, token_provider)`` value does not depend
+on it. Keying on it would only fragment the cache. A whitelist change (or any other per-user
 entitlement field carried on the cached ``User`` — role, bypass rules, catalog access) is
 propagated by console-backend calling ``invalidate_users`` for the affected user(s); see
 ``main.invalidate_discovery_cache``.
@@ -165,7 +165,7 @@ _user_cache: TtlTokenCache | None = None
 
 
 def get_discovery_cache(ttl_seconds: float | None = None) -> TtlTokenCache:
-    """Process-wide cache of discovered (tools, sub_agents) tuples."""
+    """Process-wide cache of discovered ``(tools, sub_agents, token_provider)`` tuples."""
     global _discovery_cache
     if _discovery_cache is None:
         _discovery_cache = TtlTokenCache(ttl_seconds if ttl_seconds is not None else 300.0, name="DISCOVERY-CACHE")

--- a/packages/orchestrator-agent/app/core/executor.py
+++ b/packages/orchestrator-agent/app/core/executor.py
@@ -270,8 +270,13 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
             policy_version=AgentSettings.ENTITLEMENT_POLICY_VERSION,
         )
         cached = cache.get(dkey)
+        user_token_value = user_config.access_token.get_secret_value()
         if cached is not None:
-            tools, sub_agents = cached
+            tools, sub_agents, token_provider = cached
+            # The provider mints this user's MCP bearers at call time; hand it the token the
+            # user presented *this* turn so exchanges never run against a rotated-out one.
+            if token_provider is not None:
+                token_provider.update_subject_token(user_token_value)
             logger.info(
                 "[DISCOVERY-CACHE] hit for user_sub=%s (%d tools, %d sub-agents) — skipping discovery",
                 user_config.user_sub,
@@ -287,14 +292,17 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
             # Discover ALL tools (without whitelist)
             # The whitelist will be applied later in build_runtime_context for orchestrator binding
             # Server info is stored in tool.metadata["server_name"] by MultiServerMCPClient
-            tools = await self.agent.tool_discovery_service.discover_tools(
-                user_config.access_token.get_secret_value(),
+            discovery = self.agent.tool_discovery_service
+            token_provider = discovery.make_token_provider(user_token_value) if discovery.oauth2_client else None
+            tools = await discovery.discover_tools(
+                user_token_value,
                 white_list=None,  # Don't filter here - GP agent needs access to all tools
+                token_provider=token_provider,
             )
             cache.put(
                 dkey,
-                (tools, sub_agents),
-                user_config.access_token.get_secret_value(),
+                (tools, sub_agents, token_provider),
+                user_token_value,
                 owner=user_config.user_sub,
             )
             logger.info(
@@ -309,6 +317,7 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
         # Update user_config with discovered data
         user_config.tools = tools
         user_config.sub_agents = sub_agents
+        user_config.token_provider = token_provider
 
         logger.debug(f"Built complete UserConfig with {len(user_config.sub_agents)} sub-agents")
 

--- a/packages/orchestrator-agent/app/middleware/error_classification_middleware.py
+++ b/packages/orchestrator-agent/app/middleware/error_classification_middleware.py
@@ -67,7 +67,7 @@ def classify_error(content: str) -> str | None:
     Returns one of: ``"auth"``, ``"transient"``, ``"user_fixable"``,
     ``"capability_gap"``, ``"system_error"``, or ``None``.
     """
-    if not content:
+    if not content or _is_structured_success(content):
         return None
 
     # Check for structured JSON errors first
@@ -93,9 +93,20 @@ def classify_error(content: str) -> str | None:
     return None
 
 
+def _is_structured_success(content: str) -> bool:
+    """A PTC ``eval`` reply is a ``<result …>`` block on success and an ``<error type=…>``
+    block on failure. A successful result routinely *contains* the words "error",
+    "required", "failed" … (tool descriptions, JSON schemas, log lines the program
+    printed), so keyword heuristics must not run on it: a grep over the tool catalogue
+    was being stamped ``[ERROR_TYPE: user_fixable]`` because its schemas say
+    ``"required": [...]``, and the model then treated a good result as a failure.
+    """
+    return "<result" in content and "<error type=" not in content
+
+
 def _looks_like_error(content: str) -> bool:
     """Heuristic: does this content look like an error response?"""
-    if not content:
+    if not content or _is_structured_success(content):
         return False
     lower = content.lower()
     return any(

--- a/packages/orchestrator-agent/app/models/config.py
+++ b/packages/orchestrator-agent/app/models/config.py
@@ -262,6 +262,11 @@ class UserConfig(BaseModel):
         description="Discovered remote A2A sub-agents (CompiledSubAgent TypedDicts with name, description, runnable)",
     )
     tools: Optional[list] = Field(default=None, description="Discovered MCP tools")
+    token_provider: Optional[Any] = Field(
+        default=None,
+        description="Per-user UserTokenProvider that mints MCP bearer tokens at call time (shared with sub-agents)",
+        exclude=True,
+    )
     local_subagents: Optional[list[LocalSubAgentConfig]] = Field(
         default=None,
         description="User-configured local sub-agents",

--- a/packages/orchestrator-agent/app/models/config.py
+++ b/packages/orchestrator-agent/app/models/config.py
@@ -323,11 +323,13 @@ class AgentSettings:
     # No env var or hardcoded alias: models are registered at runtime.
 
     # Cache configuration.
-    # Per-user discovery + registry cache TTL (seconds). Kept well below a typical realm
-    # access-token lifespan so a cache entry can never outlive the exchanged gatana/console
-    # tokens embedded in the discovered tools (see discovery_cache "Token-expiry safety"),
-    # and so an entitlement *revocation* that only reaches one replica (the invalidation POST
-    # is in-process / single-replica) self-heals fleet-wide within the TTL.
+    # Per-user discovery + registry cache TTL (seconds). Discovered tools carry no credential
+    # (bearers are minted at call time by the per-user token provider), so this is purely a
+    # freshness bound: how long a catalogue change made *outside* the console (on the MCP
+    # gateway itself) may go unnoticed, and how long an entitlement change may lag on replicas
+    # the console's invalidation POST did not reach (it is in-process, one replica). Changes
+    # made through the console invalidate the receiving replica immediately. Entries are
+    # additionally bounded by the user token's expiry.
     AGENT_DISCOVERY_CACHE_TTL = _int_env("AGENT_DISCOVERY_CACHE_TTL", 60)
     # Cross-cutting invalidation lever for the discovery/registry caches: bump this (env)
     # or call discovery_cache.invalidate_all() when a group→server/tool access policy

--- a/packages/orchestrator-agent/app/models/config.py
+++ b/packages/orchestrator-agent/app/models/config.py
@@ -375,7 +375,7 @@ class AgentSettings:
     # MCP bearer tokens are minted at call time by a per-user provider and reused only while at
     # least this many seconds of validity remain (bounded by the user token's exp). Raise it
     # above the exchanged tokens' lifetime to force an exchange on every call (QA lever).
-    MCP_TOKEN_LEEWAY_SECONDS = _int_env("MCP_TOKEN_LEEWAY_SECONDS", 90)
+    MCP_TOKEN_LEEWAY_SECONDS = max(0, _int_env("MCP_TOKEN_LEEWAY_SECONDS", 90))
 
     # Gatana compression: slug of the MCP server that provides compression utilities.
     # When tools from compression-enabled servers are in use, all tools from this

--- a/packages/orchestrator-agent/app/models/config.py
+++ b/packages/orchestrator-agent/app/models/config.py
@@ -372,6 +372,11 @@ class AgentSettings:
     # SDK session everywhere (bisecting lever).
     MCP_CATALOGUE_STATELESS_LIST = os.getenv("MCP_CATALOGUE_STATELESS_LIST", "true").strip().lower() in {"1", "true", "yes"}
 
+    # MCP bearer tokens are minted at call time by a per-user provider and reused only while at
+    # least this many seconds of validity remain (bounded by the user token's exp). Raise it
+    # above the exchanged tokens' lifetime to force an exchange on every call (QA lever).
+    MCP_TOKEN_LEEWAY_SECONDS = _int_env("MCP_TOKEN_LEEWAY_SECONDS", 90)
+
     # Gatana compression: slug of the MCP server that provides compression utilities.
     # When tools from compression-enabled servers are in use, all tools from this
     # server are automatically included so agents can access compressed outputs.

--- a/packages/orchestrator-agent/app/models/config.py
+++ b/packages/orchestrator-agent/app/models/config.py
@@ -355,6 +355,18 @@ class AgentSettings:
     # no longer scales with the size of the gateway catalogue.
     MCP_DISCOVERY_CONCURRENCY = max(1, _int_env("MCP_DISCOVERY_CONCURRENCY", 5))
 
+    # Tool-catalogue ingest (agent_common.core.tool_catalogue / catalogue_ingest).
+    #
+    # The catalogue is always held as raw bytes + cards; this only selects how it is
+    # *fetched*. When true (default), discovery lists each server with a single stateless
+    # JSON-RPC ``tools/list`` POST — the standard MCP method, same URL and token as the
+    # SDK path, so the gateway applies per-user entitlements/overrides exactly as usual —
+    # but without the SDK handshake or its pydantic parse (~0.5 s instead of ~3 s for ~30
+    # servers). Whether an endpoint accepts a stateless request is probed once per URL;
+    # refusal or any other failure falls back to the SDK session. Set false to force the
+    # SDK session everywhere (bisecting lever).
+    MCP_CATALOGUE_STATELESS_LIST = os.getenv("MCP_CATALOGUE_STATELESS_LIST", "true").strip().lower() in {"1", "true", "yes"}
+
     # Gatana compression: slug of the MCP server that provides compression utilities.
     # When tools from compression-enabled servers are in use, all tools from this
     # server are automatically included so agents can access compressed outputs.

--- a/packages/orchestrator-agent/app/utils.py
+++ b/packages/orchestrator-agent/app/utils.py
@@ -67,6 +67,10 @@ def _pre_resolved_tools_for(config: Any, tool_registry: dict[str, Any]) -> dict[
     token exchanges and a gateway-wide ``tools/list``. Hand them over instead: the
     whitelist (``config.mcp_tools``) plus the console self-improvement tools every
     sub-agent gets. Names not in the registry are left for the sub-agent to discover.
+
+    ``tool_registry`` must be the registry *before* the orchestrator wraps the skill tools
+    with ``agent_name="orchestrator"``: the sub-agent applies its own default, and a raw
+    tool without one behaves exactly like the tool it used to discover itself.
     """
     from langchain_core.tools import BaseTool
 
@@ -299,6 +303,11 @@ def build_runtime_context(
         "console_import_skill",
         "console_activate_skill",
     }
+    # Snapshot BEFORE the orchestrator-specific wrap below: sub-agents get the raw tools
+    # (see _pre_resolved_tools_for) and apply their own agent_name default, otherwise a
+    # sub-agent whose whitelist names a skill tool would silently edit the orchestrator's
+    # skills/playbook.
+    unwrapped_registry = dict(tool_registry)
     for tool_name in _SKILL_TOOLS_NEEDING_AGENT_NAME:
         if tool_name in tool_registry:
             tool_registry[tool_name] = _wrap_tool_with_agent_name(tool_registry[tool_name], "orchestrator")
@@ -506,7 +515,7 @@ def build_runtime_context(
                         config=config,
                         model=subagent_model,
                         orchestrator_tools=orchestrator_tools,
-                        pre_resolved_tools=_pre_resolved_tools_for(config, tool_registry),
+                        pre_resolved_tools=_pre_resolved_tools_for(config, unwrapped_registry),
                         oauth2_client=oauth2_client,
                         user_token=user_config.access_token.get_secret_value() if user_config.access_token else None,
                         checkpointer=checkpointer,

--- a/packages/orchestrator-agent/app/utils.py
+++ b/packages/orchestrator-agent/app/utils.py
@@ -516,6 +516,7 @@ def build_runtime_context(
                         model=subagent_model,
                         orchestrator_tools=orchestrator_tools,
                         pre_resolved_tools=_pre_resolved_tools_for(config, unwrapped_registry),
+                        token_provider=user_config.token_provider,
                         oauth2_client=oauth2_client,
                         user_token=user_config.access_token.get_secret_value() if user_config.access_token else None,
                         checkpointer=checkpointer,

--- a/packages/orchestrator-agent/app/utils.py
+++ b/packages/orchestrator-agent/app/utils.py
@@ -62,9 +62,9 @@ def _pre_resolved_tools_for(config: Any, tool_registry: dict[str, Any]) -> dict[
     """The orchestrator's already-authenticated tools a sub-agent can reuse, by name.
 
     A delegated sub-agent runs as the same user against the same MCP gateway/console, so
-    the tools the orchestrator discovered this turn (connections carrying this user's
-    exchanged tokens) are exactly what the sub-agent would rebuild with two or three more
-    token exchanges and a gateway-wide ``tools/list``. Hand them over instead: the
+    the tools the orchestrator discovered this turn (token-free connections whose calls are
+    authenticated by this user's token provider) are exactly what the sub-agent would rebuild
+    with two or three more token exchanges and a gateway-wide ``tools/list``. Hand them over instead: the
     whitelist (``config.mcp_tools``) plus the console self-improvement tools every
     sub-agent gets. Names not in the registry are left for the sub-agent to discover.
 

--- a/packages/orchestrator-agent/app/utils.py
+++ b/packages/orchestrator-agent/app/utils.py
@@ -58,6 +58,24 @@ def _wrap_tool_with_agent_name(tool: Any, agent_name: str) -> Any:
     )
 
 
+def _pre_resolved_tools_for(config: Any, tool_registry: dict[str, Any]) -> dict[str, Any]:
+    """The orchestrator's already-authenticated tools a sub-agent can reuse, by name.
+
+    A delegated sub-agent runs as the same user against the same MCP gateway/console, so
+    the tools the orchestrator discovered this turn (connections carrying this user's
+    exchanged tokens) are exactly what the sub-agent would rebuild with two or three more
+    token exchanges and a gateway-wide ``tools/list``. Hand them over instead: the
+    whitelist (``config.mcp_tools``) plus the console self-improvement tools every
+    sub-agent gets. Names not in the registry are left for the sub-agent to discover.
+    """
+    from langchain_core.tools import BaseTool
+
+    from agent_common.agents.dynamic_agent import DynamicLocalAgentRunnable
+
+    wanted = set(config.mcp_tools or []) | set(DynamicLocalAgentRunnable._CONSOLE_SELF_IMPROVEMENT_TOOLS)
+    return {name: tool_registry[name] for name in wanted if isinstance(tool_registry.get(name), BaseTool)}
+
+
 def _gp_tool_catalog_enabled() -> bool:
     """Whether the GP agent gets its registry as a lazy catalog (default on).
 
@@ -483,6 +501,7 @@ def build_runtime_context(
                         config=config,
                         model=subagent_model,
                         orchestrator_tools=orchestrator_tools,
+                        pre_resolved_tools=_pre_resolved_tools_for(config, tool_registry),
                         oauth2_client=oauth2_client,
                         user_token=user_config.access_token.get_secret_value() if user_config.access_token else None,
                         checkpointer=checkpointer,

--- a/packages/orchestrator-agent/app/utils.py
+++ b/packages/orchestrator-agent/app/utils.py
@@ -241,11 +241,16 @@ def build_runtime_context(
 
     # Auto-include scheduler tools and console tools (always available from MCP)
     # These are essential for the orchestrator to delegate to task-scheduler sub-agent
+    #
+    # Deliberately NOT here: console_list_mcp_servers / console_grep_mcp_tools. They date
+    # from when the orchestrator ran the scheduler itself and needed tool names for job
+    # configs; that moved into the task-scheduler sub-agent (#108), whose seed whitelists
+    # both listers (agent-creator's too). On the orchestrator they only tempted the model
+    # to discover tools it cannot call — the right move for anything outside its own
+    # whitelist is a `task` delegation, and it knows the sub-agents from the task enum.
     allowed_orchestrator_tools = {
         "console_list_sub_agents",
         "console_update_sub_agent",
-        "console_list_mcp_servers",
-        "console_grep_mcp_tools",
         "console_create_bug_report",
         "console_create_skill",
         "console_update_skill",

--- a/packages/orchestrator-agent/main.py
+++ b/packages/orchestrator-agent/main.py
@@ -444,7 +444,8 @@ async def invalidate_discovery_cache(request: Request) -> JSONResponse:
     issuer configured, dev only) there is no token to check and the call is allowed.
 
     Multi-replica note: the cache is in-process, so one call flushes one replica. Behind a
-    load balancer the other replicas fall back to the TTL (kept short for this reason) or a
+    load balancer the other replicas fall back to the TTL (which bounds that lag; fan-out to
+    every replica is tracked in #171) or a
     ``ENTITLEMENT_POLICY_VERSION`` bump for a fleet-wide flush. A fan-out/pub-sub broadcast
     is the follow-up for instant fleet-wide invalidation.
     """

--- a/packages/orchestrator-agent/tests/test_catalogue_discovery.py
+++ b/packages/orchestrator-agent/tests/test_catalogue_discovery.py
@@ -42,6 +42,7 @@ def _settings(stateless: bool) -> Mock:
     config.CONSOLE_BACKEND_URL = None
     config.MCP_DISCOVERY_CONCURRENCY = 5
     config.MCP_CATALOGUE_STATELESS_LIST = stateless
+    config.MCP_TOKEN_LEEWAY_SECONDS = 90
     return config
 
 

--- a/packages/orchestrator-agent/tests/test_catalogue_discovery.py
+++ b/packages/orchestrator-agent/tests/test_catalogue_discovery.py
@@ -1,0 +1,178 @@
+"""Orchestrator discovery wiring over the shared tool catalogue (agent_common.core.tool_catalogue)."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from langchain_core.tools import BaseTool
+from mcp.types import ListToolsResult, Tool as MCPTool
+
+from agent_common.core.catalogue_ingest import (
+    StatelessListError,
+    StatelessListUnsupported,
+)
+from app.core.discovery import ToolDiscoveryService
+from agent_common.core.tool_catalogue import (
+    LazyMcpTool,
+    build_server_catalogue,
+    make_catalogue_tool,
+    reset_catalogue_store,
+)
+from app.models.config import AgentSettings
+
+SCHEMA = {
+    "type": "object",
+    "properties": {"q": {"type": "string", "description": "query"}},
+    "required": ["q"],
+}
+
+
+"""Discovery wiring for the catalogue ingest paths (fast path, fallback, cache sharing)."""
+
+# --------------------------------------------------------------------------------------
+# Discovery wiring: fast path, fallback, cache sharing
+# --------------------------------------------------------------------------------------
+
+
+def _settings(stateless: bool) -> Mock:
+    config = Mock(spec=AgentSettings)
+    config.MCP_GATEWAY_URL = "https://gw/mcp"
+    config.CONSOLE_BACKEND_URL = None
+    config.MCP_DISCOVERY_CONCURRENCY = 5
+    config.MCP_CATALOGUE_STATELESS_LIST = stateless
+    return config
+
+
+def _mcp_client(list_calls: list[str]) -> Mock:
+    client = Mock()
+    client.callbacks = None
+    client.tool_interceptors = []
+
+    def session(server_name: str):
+        @asynccontextmanager
+        async def _cm():
+            list_calls.append(server_name)
+            sess = Mock()
+            sess.list_tools = AsyncMock(
+                return_value=ListToolsResult(tools=[MCPTool(name=f"mcp_{server_name}", inputSchema=SCHEMA)], nextCursor=None)
+            )
+            yield sess
+
+        return _cm()
+
+    client.session = session
+    return client
+
+
+def _fast_catalogue(slug: str):
+    return build_server_catalogue(
+        slug, [make_catalogue_tool(server_name=slug, name=f"fast_{slug}", description="", input_schema=SCHEMA)], source="stateless"
+    )
+
+
+async def _discover(config: Mock, client: Mock, servers: list[dict]) -> list[BaseTool]:
+    oauth2 = AsyncMock()
+    oauth2.exchange_token = AsyncMock(return_value="gw_token")
+    service = ToolDiscoveryService(config, oauth2)
+    service.fetch_available_servers = AsyncMock(return_value=servers)
+    with patch("app.core.discovery.MultiServerMCPClient", return_value=client):
+        return await service.discover_tools("user_token")
+
+
+class TestDiscoveryIngestPaths:
+    def setup_method(self):
+        reset_catalogue_store()
+
+    @pytest.mark.asyncio
+    async def test_flag_off_uses_sdk_session_only(self):
+        list_calls: list[str] = []
+        with patch("app.core.discovery.fetch_catalogue_stateless", new_callable=AsyncMock) as fast:
+            tools = await _discover(_settings(stateless=False), _mcp_client(list_calls), [{"slug": "s1"}])
+        fast.assert_not_awaited()
+        assert list_calls == ["s1"]
+        assert [t.name for t in tools] == ["mcp_s1"]
+
+    @pytest.mark.asyncio
+    async def test_stateless_path_uses_the_servers_own_connection(self):
+        """Same URL and token the SDK would use → same per-user listing, no handshake."""
+        list_calls: list[str] = []
+        with patch(
+            "app.core.discovery.fetch_catalogue_stateless", new_callable=AsyncMock, side_effect=lambda *a, **kw: _fast_catalogue(kw["server_slug"])
+        ) as fast:
+            tools = await _discover(_settings(stateless=True), _mcp_client(list_calls), [{"slug": "s1"}, {"slug": "s2"}])
+        assert list_calls == [], "no SDK session on the fast path"
+        assert sorted(t.name for t in tools) == ["fast_s1", "fast_s2"]
+        for call in fast.await_args_list:
+            slug = call.kwargs["server_slug"]
+            assert call.kwargs["url"] == f"https://gw/mcp?includeOnlyServerSlugs={slug}"
+            assert call.kwargs["headers"] == {"Authorization": "Bearer gw_token"}
+        assert all(isinstance(t, LazyMcpTool) and not t.schema_decoded for t in tools)
+
+    @pytest.mark.asyncio
+    async def test_identical_catalogues_share_bytes_across_users(self):
+        list_calls: list[str] = []
+        with patch(
+            "app.core.discovery.fetch_catalogue_stateless", new_callable=AsyncMock, side_effect=lambda *a, **kw: _fast_catalogue(kw["server_slug"])
+        ) as fast:
+            a = await _discover(_settings(stateless=True), _mcp_client(list_calls), [{"slug": "s1"}])
+            b = await _discover(_settings(stateless=True), _mcp_client(list_calls), [{"slug": "s1"}])
+        assert fast.await_count == 2, "per-user listing: fetched for each user"
+        assert a[0].catalogue_entry is b[0].catalogue_entry, "…but identical bytes are interned once"
+        assert a[0] is not b[0], "per-user tool objects (they carry the user's connection)"
+
+    @pytest.mark.asyncio
+    async def test_refusal_falls_back_and_is_remembered_per_url(self):
+        list_calls: list[str] = []
+        with patch(
+            "app.core.discovery.fetch_catalogue_stateless", new_callable=AsyncMock, side_effect=StatelessListUnsupported("400 no session")
+        ) as fast:
+            tools = await _discover(_settings(stateless=True), _mcp_client(list_calls), [{"slug": "s1"}])
+            await _discover(_settings(stateless=True), _mcp_client(list_calls), [{"slug": "s1"}])
+        assert fast.await_count == 1, "the URL is remembered as unsupported; never probed again"
+        assert list_calls == ["s1", "s1"]
+        assert [t.name for t in tools] == ["mcp_s1"]
+
+    @pytest.mark.asyncio
+    async def test_transient_error_falls_back_for_that_server_only(self):
+        list_calls: list[str] = []
+
+        async def fast(client, *, url, headers, server_slug):
+            if server_slug == "s1":
+                raise StatelessListError("502")
+            return _fast_catalogue(server_slug)
+
+        with patch("app.core.discovery.fetch_catalogue_stateless", side_effect=fast):
+            tools = await _discover(_settings(stateless=True), _mcp_client(list_calls), [{"slug": "s1"}, {"slug": "s2"}])
+        assert list_calls == ["s1"]
+        assert sorted(t.name for t in tools) == ["fast_s2", "mcp_s1"]
+
+    @pytest.mark.asyncio
+    async def test_http_client_follows_redirects(self):
+        """console-backend mounts /mcp with a 307 → /mcp/; the fast path must follow it like the SDK does."""
+        seen: dict = {}
+
+        async def fast(client, *, url, headers, server_slug):
+            seen["follow_redirects"] = client.follow_redirects
+            return _fast_catalogue(server_slug)
+
+        with patch("app.core.discovery.fetch_catalogue_stateless", side_effect=fast):
+            await _discover(_settings(stateless=True), _mcp_client([]), [{"slug": "s1"}])
+        assert seen["follow_redirects"] is True
+
+    @pytest.mark.asyncio
+    async def test_console_server_takes_the_fast_path_too(self):
+        list_calls: list[str] = []
+        config = _settings(stateless=True)
+        config.CONSOLE_BACKEND_URL = "https://console"
+        config.CONSOLE_BACKEND_CLIENT_ID = "agent-console"
+        with patch(
+            "app.core.discovery.fetch_catalogue_stateless", new_callable=AsyncMock, side_effect=lambda *a, **kw: _fast_catalogue(kw["server_slug"])
+        ) as fast:
+            tools = await _discover(config, _mcp_client(list_calls), [{"slug": "s1"}])
+        assert sorted(c.kwargs["server_slug"] for c in fast.await_args_list) == ["console", "s1"]
+        console_call = next(c for c in fast.await_args_list if c.kwargs["server_slug"] == "console")
+        assert console_call.kwargs["url"] == "https://console/mcp"
+        assert list_calls == []
+        assert sorted(t.name for t in tools) == ["fast_console", "fast_s1"]

--- a/packages/orchestrator-agent/tests/test_discovery.py
+++ b/packages/orchestrator-agent/tests/test_discovery.py
@@ -1,15 +1,63 @@
 """Unit tests for discovery services."""
 
 import asyncio
-
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import pytest
+from mcp.types import ListToolsResult, Tool as MCPTool
 
 import app.core.discovery as discovery_module
 from app.core.discovery import AgentDiscoveryService, ToolDiscoveryService
 from app.models.config import AgentSettings
+from agent_common.core.tool_catalogue import LazyMcpTool, reset_catalogue_store
+
+
+def _mcp_tool(name: str, description: str = "") -> MCPTool:
+    return MCPTool(name=name, description=description, inputSchema={"type": "object", "properties": {}})
+
+
+def _mock_mcp_client(tools_by_server=None, on_list=None):
+    """A MultiServerMCPClient stand-in whose ``session(name)`` yields a session with ``list_tools``.
+
+    ``tools_by_server`` maps slug -> list[MCPTool] (default: one tool named after the slug);
+    ``on_list(server_name)`` is awaited before each list for instrumentation.
+    """
+    client = Mock()
+    client.callbacks = None
+    client.tool_interceptors = []
+
+    def session(server_name: str):
+        @asynccontextmanager
+        async def _cm():
+            if on_list is not None:
+                await on_list(server_name)
+            sess = Mock()
+            tools = (tools_by_server or {}).get(server_name, [_mcp_tool(f"tool_{server_name}")])
+            sess.list_tools = AsyncMock(return_value=ListToolsResult(tools=tools, nextCursor=None))
+            yield sess
+
+        return _cm()
+
+    client.session = session
+    return client
+
+
+def _settings(**overrides):
+    config = Mock(spec=AgentSettings)
+    config.get_oidc_client_id.return_value = "test_client_id"
+    config.get_oidc_client_secret.return_value = Mock()
+    config.get_oidc_client_secret.return_value.get_secret_value.return_value = "test_secret"
+    config.get_oidc_issuer.return_value = "https://test.oidc.com"
+    config.MCP_GATEWAY_URL = "https://mock-gateway/mcp"
+    config.CONSOLE_BACKEND_URL = None
+    config.MCP_DISCOVERY_CONCURRENCY = 5
+    config.MCP_CATALOGUE_STATELESS_LIST = False
+    for k, v in overrides.items():
+        setattr(config, k, v)
+    return config
+
 
 
 class TestAgentDiscoveryService:
@@ -189,10 +237,7 @@ class TestToolDiscoveryService:
         service = ToolDiscoveryService(config, oauth2_client)
 
         with patch("app.core.discovery.MultiServerMCPClient") as mock_client:
-            # Mock MCP client
-            mock_client_instance = Mock()
-            mock_client_instance.get_tools = AsyncMock(return_value=[])
-            mock_client.return_value = mock_client_instance
+            mock_client.return_value = _mock_mcp_client()
 
             token = "test_token"
             result = await service.discover_tools(token)
@@ -212,27 +257,17 @@ class TestToolDiscoveryService:
         config.MCP_GATEWAY_URL = "https://mock-gateway/mcp"
         config.CONSOLE_BACKEND_URL = None
         config.MCP_DISCOVERY_CONCURRENCY = 5
+        config.MCP_CATALOGUE_STATELESS_LIST = False
 
         oauth2_client = AsyncMock()
         oauth2_client.exchange_token = AsyncMock(return_value="mcp_token")
         service = ToolDiscoveryService(config, oauth2_client)
 
-        # Mock tools from MCP
-        mock_tool1 = Mock()
-        mock_tool1.name = "allowed_tool"
-        mock_tool1.description = "This tool is allowed"
-        mock_tool1.metadata = None
-
-        mock_tool2 = Mock()
-        mock_tool2.name = "blocked_tool"
-        mock_tool2.description = "This tool is blocked"
-        mock_tool2.metadata = None
+        reset_catalogue_store()
+        tools = [_mcp_tool("allowed_tool", "This tool is allowed"), _mcp_tool("blocked_tool", "This tool is blocked")]
 
         with patch("app.core.discovery.MultiServerMCPClient") as mock_client:
-            mock_client_instance = Mock()
-            # Called as: await client.get_tools(server_name=slug)
-            mock_client_instance.get_tools = AsyncMock(return_value=[mock_tool1, mock_tool2])
-            mock_client.return_value = mock_client_instance
+            mock_client.return_value = _mock_mcp_client({"mock-server": tools})
 
             # Mock fetch_available_servers so no real HTTP call is made
             service.fetch_available_servers = AsyncMock(return_value=[{"slug": "mock-server"}])
@@ -243,6 +278,9 @@ class TestToolDiscoveryService:
 
             assert len(result) == 1
             assert result[0].name == "allowed_tool"
+            assert isinstance(result[0], LazyMcpTool)
+            assert result[0].metadata["server_name"] == "mock-server"
+            assert not result[0].schema_decoded, "discovery must not decode any schema"
             oauth2_client.exchange_token.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -264,6 +302,7 @@ class TestToolDiscoveryService:
         config.MCP_GATEWAY_URL = "https://mock-gateway/mcp"
         config.CONSOLE_BACKEND_URL = None
         config.MCP_DISCOVERY_CONCURRENCY = 3
+        config.MCP_CATALOGUE_STATELESS_LIST = False
 
         oauth2_client = AsyncMock()
         oauth2_client.exchange_token = AsyncMock(return_value="mcp_token")
@@ -279,7 +318,7 @@ class TestToolDiscoveryService:
         max_in_flight = 0
         visited: list[str] = []
 
-        async def fake_get_tools(server_name: str):
+        async def on_list(server_name: str):
             nonlocal in_flight, max_in_flight
             in_flight += 1
             max_in_flight = max(max_in_flight, in_flight)
@@ -289,15 +328,10 @@ class TestToolDiscoveryService:
             # would pass even with an unbounded gather.
             await asyncio.sleep(0)
             in_flight -= 1
-            tool = Mock()
-            tool.name = f"tool_{server_name}"
-            tool.metadata = None
-            return [tool]
 
+        reset_catalogue_store()
         with patch("app.core.discovery.MultiServerMCPClient") as mock_client:
-            mock_client_instance = Mock()
-            mock_client_instance.get_tools = AsyncMock(side_effect=fake_get_tools)
-            mock_client.return_value = mock_client_instance
+            mock_client.return_value = _mock_mcp_client(on_list=on_list)
             service.fetch_available_servers = AsyncMock(return_value=servers)
 
             result = await service.discover_tools("test_token")
@@ -351,10 +385,7 @@ class TestDiscoveryIntegration:
         token = "test_token"
 
         with patch("app.core.discovery.MultiServerMCPClient") as mock_mcp_client:
-            # Mock MCP client
-            mock_mcp_instance = Mock()
-            mock_mcp_instance.get_tools = AsyncMock(return_value=[])
-            mock_mcp_client.return_value = mock_mcp_instance
+            mock_mcp_client.return_value = _mock_mcp_client()
 
             # Run both discoveries concurrently
             import asyncio

--- a/packages/orchestrator-agent/tests/test_discovery.py
+++ b/packages/orchestrator-agent/tests/test_discovery.py
@@ -54,6 +54,7 @@ def _settings(**overrides):
     config.CONSOLE_BACKEND_URL = None
     config.MCP_DISCOVERY_CONCURRENCY = 5
     config.MCP_CATALOGUE_STATELESS_LIST = False
+    config.MCP_TOKEN_LEEWAY_SECONDS = 90
     for k, v in overrides.items():
         setattr(config, k, v)
     return config
@@ -258,6 +259,7 @@ class TestToolDiscoveryService:
         config.CONSOLE_BACKEND_URL = None
         config.MCP_DISCOVERY_CONCURRENCY = 5
         config.MCP_CATALOGUE_STATELESS_LIST = False
+        config.MCP_TOKEN_LEEWAY_SECONDS = 90
 
         oauth2_client = AsyncMock()
         oauth2_client.exchange_token = AsyncMock(return_value="mcp_token")
@@ -303,6 +305,7 @@ class TestToolDiscoveryService:
         config.CONSOLE_BACKEND_URL = None
         config.MCP_DISCOVERY_CONCURRENCY = 3
         config.MCP_CATALOGUE_STATELESS_LIST = False
+        config.MCP_TOKEN_LEEWAY_SECONDS = 90
 
         oauth2_client = AsyncMock()
         oauth2_client.exchange_token = AsyncMock(return_value="mcp_token")

--- a/packages/orchestrator-agent/tests/test_error_classification_middleware.py
+++ b/packages/orchestrator-agent/tests/test_error_classification_middleware.py
@@ -269,3 +269,23 @@ async def test_auth_takes_priority_over_transient(middleware):
     result = await middleware.awrap_tool_call(request, handler)
     # 401 matches auth first
     assert result.additional_kwargs["error_classification"] == "auth"
+
+
+class TestStructuredEvalResults:
+    """A successful PTC ``eval`` ``<result>`` must never be classified, whatever words it contains."""
+
+    def test_successful_result_with_error_words_is_not_classified(self):
+        from app.middleware.error_classification_middleware import classify_error
+
+        grep_output = (
+            '<result>[{type: "text", text: "{\n  \"tools\": [{\"name\": \"github_search_users\", '
+            '\"description\": \"Find users. Returns an error if the query is invalid\", '
+            '\"input_schema\": {\"required\": [\"query\"], \"properties\": {}}}]}"}]</result>'
+        )
+        assert classify_error(grep_output) is None
+
+    def test_structured_eval_error_is_still_classified(self):
+        from app.middleware.error_classification_middleware import classify_error
+
+        assert classify_error('<error type="TypeError">not a function</error>') == "system_error"
+        assert classify_error('<error type="Error">Missing required field: owner</error>') == "user_fixable"

--- a/packages/orchestrator-agent/tests/test_utils_pre_resolved.py
+++ b/packages/orchestrator-agent/tests/test_utils_pre_resolved.py
@@ -34,3 +34,17 @@ def test_no_whitelist_still_hands_over_self_improvement_tools():
     registry["github_get_me"] = _tool("github_get_me")
     handed = _pre_resolved_tools_for(SimpleNamespace(mcp_tools=None), registry)
     assert set(handed) == set(DynamicLocalAgentRunnable._CONSOLE_SELF_IMPROVEMENT_TOOLS)
+
+
+def test_build_runtime_context_hands_sub_agents_the_unwrapped_skill_tools():
+    """The orchestrator wraps skill tools with agent_name="orchestrator" for itself; sub-agents
+    must receive the raw tool so their own agent_name default applies (round-2 review B)."""
+    import inspect
+
+    from app import utils
+
+    src = inspect.getsource(utils.build_runtime_context)
+    wrap_at = src.index('_wrap_tool_with_agent_name(tool_registry[tool_name], "orchestrator")')
+    snapshot_at = src.index("unwrapped_registry = dict(tool_registry)")
+    handover_at = src.index("_pre_resolved_tools_for(config, unwrapped_registry)")
+    assert snapshot_at < wrap_at < handover_at

--- a/packages/orchestrator-agent/tests/test_utils_pre_resolved.py
+++ b/packages/orchestrator-agent/tests/test_utils_pre_resolved.py
@@ -1,0 +1,36 @@
+"""``_pre_resolved_tools_for``: which orchestrator tools a sub-agent gets handed instead of re-discovering."""
+
+from types import SimpleNamespace
+
+from langchain_core.tools import Tool
+
+from agent_common.agents.dynamic_agent import DynamicLocalAgentRunnable
+from app.utils import _pre_resolved_tools_for
+
+
+def _tool(name: str) -> Tool:
+    return Tool(name=name, description=name, func=lambda x: x)
+
+
+def test_whitelist_and_self_improvement_tools_present_in_registry_are_handed_over():
+    registry = {
+        "github_get_me": _tool("github_get_me"),
+        "unrelated": _tool("unrelated"),
+        "console_create_skill": _tool("console_create_skill"),
+        "not_a_tool": {"name": "dict entry"},
+    }
+    config = SimpleNamespace(mcp_tools=["github_get_me", "missing_from_registry", "not_a_tool"])
+
+    handed = _pre_resolved_tools_for(config, registry)
+
+    assert set(handed) == {"github_get_me", "console_create_skill"}
+    assert handed["github_get_me"] is registry["github_get_me"]
+    assert "missing_from_registry" not in handed  # left for the sub-agent to discover
+    assert "unrelated" not in handed  # only what the sub-agent is entitled to
+
+
+def test_no_whitelist_still_hands_over_self_improvement_tools():
+    registry = {name: _tool(name) for name in DynamicLocalAgentRunnable._CONSOLE_SELF_IMPROVEMENT_TOOLS}
+    registry["github_get_me"] = _tool("github_get_me")
+    handed = _pre_resolved_tools_for(SimpleNamespace(mcp_tools=None), registry)
+    assert set(handed) == set(DynamicLocalAgentRunnable._CONSOLE_SELF_IMPROVEMENT_TOOLS)


### PR DESCRIPTION
closes #154

Eleven commits (six feature/fix commits, then review-driven fixes and the call-time token provider), each reviewable alone. Measured locally on 34 servers / ~514 tools: **cold discovery 3.2–4.6 s → ~1.5 s**, **sub-agent delegation overhead 2.4 s + 3 token exchanges → 0**; the remaining time-to-first-token is ~1 s auth/registry + the model's own ~4 s.

## 1. `feat(agent-common): raw-bytes tool catalogue with lazy schema decode`
The catalogue is held as per-tool canonical JSON **bytes** + a lightweight card (name, description, parameter names, server). Tools are `LazyMcpTool` — a real `BaseTool` whose `args_schema` decodes from those bytes on first access — so `convert_to_openai_tool`, `tool.args`, `describe`, PTC signature rendering, ToolsetSelector and dispatch are unchanged, and only the tools actually bound/described/invoked ever decode. Invocation delegates to `langchain_mcp_adapters` for that single tool (interceptors, progress callbacks, result conversion identical).

Ingest is a strategy behind that representation:
- **Stateless JSON-RPC `tools/list`** over plain httpx to the server's own MCP URL with the caller's token — the standard MCP method/result shape, so the gateway applies overrides, disabled flags and **per-user entitlements** exactly as for the SDK — but no `initialize`/session handshake and no pydantic parse (bounded `raw_decode` scan, `nextCursor` paging, JSON or SSE frame). Same pattern console-backend runs in production (`mcp_tool_client`). Probed once per URL; refusal → SDK for that URL, any other failure → SDK for that server.
- **SDK session** as universal fallback, each `mcp.types.Tool` flattened to bytes and dropped.

`CatalogueStore` interns catalogues by `(server, interface_hash)` (hash on bytes) so identical catalogues share bytes across users, and resolves names across everything interned.

*Rejected on the way:* the Gatana REST route `GET /api/v1/mcp-servers/{slug}/tools` — vendor-specific, **server-level** (683 tools vs 373 over MCP for the same user: it ignores per-profile entitlements), and named by raw `toolName` rather than the dispatchable `universalName`. Also tried and dropped: an SDK-level exchanged-token cache (a second token lifecycle the discovery cache's invalidation doesn't know about) — superseded by commit 3.

## 2. `feat(orchestrator): discover tools through the shared catalogue`
`ToolDiscoveryService` uses the ingest above (same semaphore bound), interns, and wraps per-user `LazyMcpTool`s bound to the user's connection — tokens stay on connections, never on shared bytes. Return type/metadata unchanged. Logs which path each server took. `MCP_CATALOGUE_STATELESS_LIST` (default true) forces the SDK when false. Console-backend's own MCP server is session-based and correctly takes the SDK path.

## 3. `feat: delegated sub-agents reuse the orchestrator's authenticated tools`
`build_runtime_context` hands each dynamic sub-agent the registry tools for its whitelist + the console self-improvement tools (`pre_resolved_tools`); the runnable takes private `model_copy`s and only discovers names it wasn't handed (store first, then its own `tools/list`). No token copied or cached anywhere new.

## 4. `fix(orchestrator): stop auto-including the MCP catalogue listers`
`console_grep_mcp_tools` / `console_list_mcp_servers` on the orchestrator were a leftover from pre-#108 in-orchestrator scheduling; task-scheduler and agent-creator carry them in their own seeds. On the orchestrator they only led the model to discover tools it cannot call before delegating.

## 5. `fix(agent-common): make PTC eval self-correcting`
Two errors that cost up to 50 graph steps on flash-lite: top-level `return` (prompt rule + one-shot async-IIFE retry on exactly that parse error) and `tools.github_get_me` / `tools.search_tools` (`TypeError: not a function` without the member name → a hint derived from what the sandbox actually exposes: camelCase spelling, `tools.search`/`describe`, or in inline mode the callable list + "regular tool call or `task`"). No aliases; raw catalogue listers are kept out of the eval namespace in every mode.

## 6. `fix(orchestrator): never classify a successful eval result as an error`
`ErrorClassificationMiddleware` stamped `[ERROR_TYPE: user_fixable]` on a successful `<result>` whose schemas contain `"required"`. Structured results without an `<error type=…>` block are no longer classified.

## 7. `feat: mint MCP bearer tokens at call time through a per-user provider` (+ 3 review fixes before it)
Discovery used to bake an exchanged bearer into every tool's connection, tying token freshness to the discovery-cache TTL and to how long a tool object lived (sub-agent hand-over). Now a per-user `UserTokenProvider` (`agent_common/core/token_provider.py`) is the only place that mints exchanged tokens — memoised per audience, re-minted within 90 s of `exp` (bounded by the user token's `exp`), one exchange under concurrency, refreshed with the user's current token every turn. Tools are built on **token-free** connections and a `bearer_interceptor` injects `Authorization` per call (the same `request.override(headers=…)` hook the console attribution uses). Sub-agents share the provider. Consequences: no credential older than the leeway however long a tool lives; a mid-turn exchanged-token expiry re-mints transparently (a mid-turn *user*-token expiry still surfaces as auth, correctly); `AGENT_DISCOVERY_CACHE_TTL` is now purely a catalogue-freshness knob. Review-driven fixes in between: scanner tolerates `{"result": {}}`; sub-agents get the *unwrapped* skill tools (their own `agent_name` default applies); sub-agent connections are picked by key, not position.

## Also found, not in this PR
- `AGENT_DISCOVERY_CACHE_TTL` defaults to **60 s** (the issue says 5 min) and no environment overrides it — in low-traffic dev every turn is cold; a TTL bump is the cheapest remaining TTFT win.
- The UI is blank for the whole pre-model window; a "working" status emitted before discovery would fix perceived TTFT.

## Tests
agent-common 730 · orchestrator 684 · sdk 359 (baseline) — `ruff` and `mypy` add no findings over `main`. Automatic review: round 1 → #1 #2 #3 #5 fixed, #4/#6/#7 deferred with reasons, #9–11 rejected with reasons; round 2 → 2 findings fixed; rounds 3–5 clean.

## Checklist
- [x] I have performed a self-review of my code
- [x] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨 — no: `discover_tools` keeps its signature and return type; tool names/metadata identical; `MCP_CATALOGUE_STATELESS_LIST=false` restores the SDK-only listing; the cache entry tuple gained a third element (`token_provider`) with a single consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

