### PR TITLE
feat(agent-runner): adopt the shared tool catalogue and call-time bearer tokens; remove CatalogueStore

### DIFF
--- a/packages/agent-common/agent_common/agents/dynamic_agent.py
+++ b/packages/agent-common/agent_common/agents/dynamic_agent.py
@@ -92,7 +92,7 @@ from agent_common.core.model_factory import get_model_input_capabilities
 from agent_common.core.catalogue_ingest import fetch_catalogue_mcp
 from agent_common.core.token_provider import UserTokenProvider, bearer_interceptor
 from agent_common.core.tool_catalog import TOOL_CATALOG_PROMPT_ADDENDUM, ToolCatalogMiddleware
-from agent_common.core.tool_catalogue import get_catalogue_store, make_lazy_tool
+from agent_common.core.tool_catalogue import make_lazy_tool
 from agent_common.middleware.conversation_context_tools_middleware import ContextGatedTool
 from agent_common.utils import get_language_display_name
 
@@ -896,19 +896,17 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
         connections: Mapping[str, Any],
         wanted: set[str],
     ) -> List[BaseTool]:
-        """Resolve a whitelist of tool names to tools, reusing catalogues already in the process.
+        """Resolve whitelisted names by listing this agent's own connection(s).
 
-        The orchestrator's discovery interns every server's catalogue (bytes + cards) in the
-        process-wide :class:`CatalogueStore`; a sub-agent only needs a handful of names from
-        it, so first look them up there — no network at all. Only names the store does not
-        hold trigger an MCP ``tools/list`` on this agent's own connection(s), and that
-        result is interned too (flattened to bytes, pydantic objects dropped) so the next
-        delegation is served from the store. Every returned tool is a :class:`LazyMcpTool`
-        bound to *this agent's* connection, whatever the source — token-free with a per-call
-        bearer interceptor when a token provider is configured, else carrying this agent's own
-        exchanged token (standalone execution).
+        Only names the orchestrator did not already hand over (``pre_resolved_tools`` — the
+        user's own discovered view) reach here. A ``tools/list`` is a per-user view: a Gatana
+        profile may hide tools of a server from one user and not another, so it is always
+        made on this agent's connection with this user's token and never served from another
+        run's listing. Each page is flattened to bytes as it arrives (pydantic objects
+        dropped) and every returned tool is a :class:`LazyMcpTool` bound to *this agent's*
+        connection — token-free with a per-call bearer interceptor when a token provider is
+        configured, else carrying this agent's own exchanged token (standalone execution).
         """
-        store = get_catalogue_store()
         callbacks = client.callbacks
         tools: list[BaseTool] = []
         # With a provider, tools must not embed the listing bearer: strip it from the connection
@@ -931,74 +929,33 @@ class DynamicLocalAgentRunnable(StructuredResponseMixin, LocalA2ARunnable):
             headers = {k: v for k, v in connection["headers"].items() if k.lower() != "authorization"}
             return {**connection, "headers": headers or None}
 
-        def _connection_for(tool_name: str, server_name: str | None = None) -> Any | None:
-            """Pick the connection that can reach ``tool_name`` — by key, never by position.
+        # Console-backend names (console_*/scheduler_*) come from the ``console`` connection,
+        # everything else from the gateway connection(s); a connection that can serve none of
+        # the wanted names is not listed at all.
+        for conn_name, connection in connections.items():
+            is_console = conn_name == "console"
+            server_wanted = sorted(n for n in wanted if is_console_backend_tool(n) == is_console)
+            if not server_wanted:
+                continue
 
-            Console-backend tools go to the ``console`` connection. Everything else is a
-            gateway tool: prefer a connection keyed by the tool's own server slug (an agent
-            wired with per-server connections), else the gateway-wide connection keyed by
-            ``mcp_gateway_client_id`` (how this runnable builds it). ``None`` means this agent
-            has no connection that can reach the tool, so it is skipped rather than guessed.
-            """
-            if is_console_backend_tool(tool_name):
-                return connections.get("console")
-            if server_name and server_name != "console" and server_name in connections:
-                return connections[server_name]
-            gateway_key = self.mcp_gateway_client_id
-            return connections.get(gateway_key) if gateway_key else None
+            def _open_session(name: str = conn_name) -> Any:
+                return client.session(name)
 
-        resolved = store.resolve(wanted)
-        for name, (held, held_entry) in resolved.items():
-            connection = _connection_for(name, held.server_name)
-            if connection is None:
-                continue  # whitelisted but this agent has no connection that can reach it
-            tools.append(
-                make_lazy_tool(
-                    held_entry,
-                    server_name=held.server_name,
-                    connection=_call_connection(connection),
-                    callbacks=callbacks,
-                    tool_interceptors=interceptors,
-                )
-            )
-        missing = {n for n in wanted if n not in resolved and _connection_for(n) is not None}
-
-        fetched = 0
-        if missing:
-            # Which connections can still contribute: console for console_*/scheduler_*
-            # names, the gateway-wide connection for everything else.
-            need_console = any(is_console_backend_tool(n) for n in missing)
-            need_gateway = any(not is_console_backend_tool(n) for n in missing)
-            for conn_name, connection in connections.items():
-                is_console = conn_name == "console"
-                if (is_console and not need_console) or (not is_console and not need_gateway):
-                    continue
-                def _open_session(name: str = conn_name) -> Any:
-                    return client.session(name)
-
-                catalogue = store.intern(await fetch_catalogue_mcp(_open_session, server_slug=conn_name))
-                for name in sorted(missing):
-                    entry = catalogue.tools.get(name)
-                    if entry is None:
-                        continue
-                    tools.append(
-                        make_lazy_tool(
-                            entry,
-                            server_name=catalogue.server_name,
-                            connection=_call_connection(connection),
-                            callbacks=callbacks,
-                            tool_interceptors=interceptors,
-                        )
+            catalogue = await fetch_catalogue_mcp(_open_session, server_slug=conn_name)
+            for name in server_wanted:
+                entry = catalogue.tools.get(name)
+                if entry is None:
+                    continue  # not offered to this user by this server
+                tools.append(
+                    make_lazy_tool(
+                        entry,
+                        server_name=catalogue.server_name,
+                        connection=_call_connection(connection),
+                        callbacks=callbacks,
+                        tool_interceptors=interceptors,
                     )
-                    fetched += 1
-        logger.info(
-            "Resolved %d/%d MCP tools for %s: %d from the shared catalogue store, %d via tools/list",
-            len(tools),
-            len(wanted),
-            self.name,
-            len(tools) - fetched,
-            fetched,
-        )
+                )
+        logger.info("Resolved %d/%d MCP tools for %s via tools/list", len(tools), len(wanted), self.name)
         return tools
 
     def _wrap_with_agent_name(self, tool: BaseTool) -> BaseTool:

--- a/packages/agent-common/agent_common/core/catalogue_ingest.py
+++ b/packages/agent-common/agent_common/core/catalogue_ingest.py
@@ -348,3 +348,41 @@ async def fetch_catalogue_mcp(
         else:
             raise RuntimeError(f"tools/list on '{server_slug}' exceeded {_MAX_LIST_PAGES} pages")
     return build_server_catalogue(server_slug, tools, source="mcp")
+
+
+# --------------------------------------------------------------------------------------
+# Strategy: stateless first (feature-detected per URL), SDK session as fallback
+# --------------------------------------------------------------------------------------
+
+
+async def fetch_catalogue(
+    *,
+    server_slug: str,
+    url: str,
+    headers: Mapping[str, str] | None,
+    http_client: httpx.AsyncClient | None,
+    session_factory: Callable[[], AbstractAsyncContextManager[Any]],
+    stateless: bool = True,
+) -> ServerCatalogue:
+    """One server's catalogue: stateless ``tools/list`` POST first, SDK session as fallback.
+
+    Both paths hit the same MCP ``url`` with the same ``headers`` (the caller's bearer), so
+    the result is the same per-user listing; the stateless path just skips the SDK
+    handshake and the pydantic parse. Whether an endpoint serves a stateless request is
+    probed once per URL (see :func:`stateless_supported`): a refusal marks it unsupported
+    for the process lifetime, any other failure falls back for this fetch only, and every
+    fallback is logged. ``stateless=False`` (or no ``http_client``) forces the SDK path.
+    The returned catalogue's ``source`` says which path was taken.
+    """
+    if http_client is not None and stateless and stateless_supported(url) is not False:
+        try:
+            catalogue = await fetch_catalogue_stateless(http_client, url=url, headers=headers, server_slug=server_slug)
+        except StatelessListUnsupported as e:
+            set_stateless_supported(url, False)
+            logger.warning("MCP endpoint refuses stateless tools/list — using SDK session for '%s' (%s)", server_slug, e)
+        except StatelessListError as e:
+            logger.warning("Stateless tools/list failed for '%s', falling back to SDK session: %s", server_slug, e)
+        else:
+            set_stateless_supported(url, True)
+            return catalogue
+    return await fetch_catalogue_mcp(session_factory, server_slug=server_slug)

--- a/packages/agent-common/agent_common/core/catalogue_ingest.py
+++ b/packages/agent-common/agent_common/core/catalogue_ingest.py
@@ -61,6 +61,26 @@ _MAX_LIST_PAGES = 1000
 _UNSUPPORTED_RPC_CODES = {-32600, -32601, -32602}
 
 
+# Whether an MCP endpoint serves a stateless ``tools/list``, probed once per URL for the
+# process lifetime. A property of the endpoint, not of any user — the only thing about a
+# catalogue fetch that is legitimately process-wide.
+_stateless_supported: dict[str, bool] = {}
+
+
+def stateless_supported(url: str) -> bool | None:
+    """``True``/``False`` once ``url`` has been probed, ``None`` before."""
+    return _stateless_supported.get(url)
+
+
+def set_stateless_supported(url: str, supported: bool) -> None:
+    _stateless_supported[url] = supported
+
+
+def reset_stateless_memo() -> None:
+    """Test hook."""
+    _stateless_supported.clear()
+
+
 class StatelessListUnsupported(Exception):
     """The MCP endpoint does not serve ``tools/list`` without a session — fall back for good."""
 

--- a/packages/agent-common/agent_common/core/tool_catalogue.py
+++ b/packages/agent-common/agent_common/core/tool_catalogue.py
@@ -18,9 +18,11 @@ actually touches.
 
 Ingest is a strategy (see :mod:`catalogue_ingest`): a stateless JSON-RPC ``tools/list``
 over plain HTTP, or the same call through the MCP SDK session. Both produce the same
-:class:`ServerCatalogue`, and a process-wide :class:`CatalogueStore` interns catalogues
-by ``(server, interface_hash)`` so identical catalogues share one set of bytes across
-users.
+:class:`ServerCatalogue`. A catalogue is a **per-user view** — the gateway answers
+``tools/list`` per bearer and a profile may hide tools of a server from one user and not
+another — so there is deliberately no process-wide catalogue registry: each user's tools
+own their catalogue's bytes for as long as the per-user discovery cache holds them, and
+nothing may answer *which tools exist* except a listing made with that user's own token.
 
 Dispatch delegates to ``langchain_mcp_adapters`` on first invocation: the one tool
 being called is rebuilt as an ``mcp.types.Tool`` (a single small pydantic object) and
@@ -33,7 +35,6 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import threading
 import time
 from collections.abc import Awaitable, Callable, Iterable, Mapping
 from dataclasses import dataclass, field
@@ -350,94 +351,3 @@ def make_lazy_tool(
     tool._callbacks = callbacks
     tool._interceptors = tool_interceptors
     return tool
-
-
-class CatalogueStore:
-    """Process-wide home for server catalogues.
-
-    * **Interning** by ``(server, interface_hash)``: whichever ingest path produced a
-      catalogue, an identical one already held is returned instead, so N users of the
-      same server share one set of schema bytes. One entry per server is kept (the
-      latest interface); superseded catalogues stay alive only as long as tools built
-      from them do. Catalogues are per-user-token views, so they are never *served*
-      from here in place of a fetch — only deduplicated.
-    * **Lookup by name** (:meth:`resolve`) for consumers that hold only tool names.
-    * **Capability memo**: whether an MCP endpoint serves a stateless ``tools/list``
-      (probed once per URL).
-    """
-
-    def __init__(self) -> None:
-        self._lock = threading.Lock()
-        self._interned: dict[str, ServerCatalogue] = {}  # server -> latest catalogue
-        self._stateless_supported: dict[str, bool] = {}  # mcp url -> supported
-
-    # -- interning -----------------------------------------------------------------
-    def intern(self, catalogue: ServerCatalogue) -> ServerCatalogue:
-        with self._lock:
-            held = self._interned.get(catalogue.server_name)
-            if held is not None and held.interface_hash == catalogue.interface_hash:
-                return held
-            self._interned[catalogue.server_name] = catalogue
-            return catalogue
-
-    def interned(self, server_name: str) -> ServerCatalogue | None:
-        with self._lock:
-            return self._interned.get(server_name)
-
-    def resolve(self, names: Iterable[str]) -> dict[str, tuple[ServerCatalogue, CatalogueTool]]:
-        """Look up tools by name across every interned catalogue.
-
-        Lets a consumer that knows only tool *names* (a sub-agent's whitelist) reuse the
-        catalogues discovery already fetched in this process instead of opening its own
-        ``tools/list``. Returns only the names found; the caller fetches the rest.
-        Gateway tool names are unique across servers (they carry the server prefix), so
-        the first catalogue holding a name wins.
-        """
-        wanted = set(names)
-        found: dict[str, tuple[ServerCatalogue, CatalogueTool]] = {}
-        if not wanted:
-            return found
-        with self._lock:
-            catalogues = list(self._interned.values())
-        for catalogue in catalogues:
-            for name in wanted - found.keys():
-                entry = catalogue.tools.get(name)
-                if entry is not None:
-                    found[name] = (catalogue, entry)
-            if len(found) == len(wanted):
-                break
-        return found
-
-    # -- capability memo -----------------------------------------------------------
-    def stateless_supported(self, url: str) -> bool | None:
-        with self._lock:
-            return self._stateless_supported.get(url)
-
-    def set_stateless_supported(self, url: str, supported: bool) -> None:
-        with self._lock:
-            self._stateless_supported[url] = supported
-
-    def clear(self) -> None:
-        with self._lock:
-            self._interned.clear()
-            self._stateless_supported.clear()
-
-
-_store: CatalogueStore | None = None
-_store_lock = threading.Lock()
-
-
-def get_catalogue_store() -> CatalogueStore:
-    """Process-wide singleton."""
-    global _store
-    with _store_lock:
-        if _store is None:
-            _store = CatalogueStore()
-        return _store
-
-
-def reset_catalogue_store() -> None:
-    """Test hook."""
-    global _store
-    with _store_lock:
-        _store = None

--- a/packages/agent-common/tests/test_dynamic_agent.py
+++ b/packages/agent-common/tests/test_dynamic_agent.py
@@ -518,9 +518,6 @@ class TestDiscoverMcpTools:
 
     @pytest.fixture
     def runnable(self, gateway_config, mock_model):
-        from agent_common.core.tool_catalogue import reset_catalogue_store
-
-        reset_catalogue_store()  # the store is process-wide; don't let one test's catalogue serve the next
         oauth2_client = MagicMock()
         oauth2_client.exchange_token = AsyncMock(return_value="gateway-token")
         return DynamicLocalAgentRunnable(
@@ -668,46 +665,10 @@ class TestDiscoverMcpTools:
         assert "tool_availability_warning" not in runnable._cached_system_prompt
 
     @pytest.mark.asyncio
-    async def test_whitelist_is_served_from_shared_catalogue_store_without_tools_list(self, runnable):
-        """A sub-agent whose whitelist is already held by the process-wide catalogue store
-        (filled by the orchestrator's discovery) must not open its own tools/list."""
-        from agent_common.core.tool_catalogue import (
-            LazyMcpTool,
-            build_server_catalogue,
-            get_catalogue_store,
-            make_catalogue_tool,
-        )
-
-        store = get_catalogue_store()
-        store.intern(
-            build_server_catalogue(
-                "some-server",
-                [
-                    make_catalogue_tool(
-                        server_name="some-server",
-                        name="some_gateway_tool",
-                        description="from the store",
-                        input_schema={"type": "object", "properties": {"q": {"type": "string"}}},
-                    )
-                ],
-                source="stateless",
-            )
-        )
-        with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
-            _install_list_tools(mock_client_cls, side_effect=AssertionError("tools/list must not be called"))
-            tools = await runnable._discover_mcp_tools()
-
-        assert [t.name for t in tools] == ["some_gateway_tool"]
-        assert isinstance(tools[0], LazyMcpTool)
-        assert tools[0].description == "from the store"
-        # Bound to *this* agent's gateway connection (its own exchanged token), not the orchestrator's.
-        assert tools[0]._connection["headers"]["Authorization"] == "Bearer gateway-token"
-        assert runnable._mcp_discovery_error is None
-
-    @pytest.mark.asyncio
-    async def test_missing_names_fall_back_to_tools_list_and_are_interned(self, runnable):
-        """Names the store does not hold are fetched once over MCP and then served from the store."""
-        from agent_common.core.tool_catalogue import get_catalogue_store
+    async def test_names_not_pre_resolved_are_listed_on_the_agents_own_connection(self, runnable):
+        """A name the orchestrator did not hand over is resolved by a tools/list on this agent's
+        connection with this user's token — a listing is a per-user view, never reused."""
+        from agent_common.core.tool_catalogue import LazyMcpTool
 
         with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
             _install_list_tools(
@@ -716,38 +677,14 @@ class TestDiscoverMcpTools:
             )
             tools = await runnable._discover_mcp_tools()
         assert [t.name for t in tools] == ["some_gateway_tool"]
-        # Interned under the connection name (gateway-wide listing) for the next delegation.
-        held = get_catalogue_store().interned("gatana")
-        assert held is not None and "some_gateway_tool" in held.tools
-        assert held.source == "mcp"
+        assert isinstance(tools[0], LazyMcpTool) and tools[0].catalogue_entry.card.description == "fetched"
+        assert tools[0]._connection["headers"]["Authorization"] == "Bearer gateway-token"
+        assert runnable._mcp_discovery_error is None
 
     @pytest.mark.asyncio
-    async def test_store_hits_bind_to_the_gateway_connection_by_key_not_position(self, gateway_config, mock_model):
-        """The gateway connection is looked up by mcp_gateway_client_id; a console tool by 'console'.
-        Dict order must not matter (regression for a positional gateway[0] pick)."""
-        from agent_common.core.tool_catalogue import (
-            build_server_catalogue,
-            get_catalogue_store,
-            make_catalogue_tool,
-            reset_catalogue_store,
-        )
-
-        reset_catalogue_store()
-        store = get_catalogue_store()
-        store.intern(
-            build_server_catalogue(
-                "github",
-                [make_catalogue_tool(server_name="github", name="some_gateway_tool", description="", input_schema={"type": "object"})],
-                source="stateless",
-            )
-        )
-        store.intern(
-            build_server_catalogue(
-                "console",
-                [make_catalogue_tool(server_name="console", name="console_create_skill", description="", input_schema={"type": "object"})],
-                source="mcp",
-            )
-        )
+    async def test_listed_tools_bind_to_the_connection_by_key_not_position(self, gateway_config, mock_model):
+        """Console names are listed on and bound to 'console'; gateway names to the connection keyed by
+        mcp_gateway_client_id. Dict order must not matter (regression for a positional gateway[0] pick)."""
         config = LocalLangGraphSubAgentConfig(
             type="langgraph", name="g", description="x", system_prompt="x", mcp_tools=["some_gateway_tool", "console_create_skill"]
         )
@@ -763,9 +700,16 @@ class TestDiscoverMcpTools:
         )
         runnable.console_backend_mcp_url = "https://console.example/mcp"
         with patch("agent_common.agents.dynamic_agent.MultiServerMCPClient") as mock_client_cls:
-            _install_list_tools(mock_client_cls, side_effect=AssertionError("store must serve both"))
+            _install_list_tools(
+                mock_client_cls,
+                return_value=[
+                    Tool(name="some_gateway_tool", description="", func=lambda x: x),
+                    Tool(name="console_create_skill", description="", func=lambda x: x),
+                ],
+            )
             tools = {t.name: t for t in await runnable._discover_mcp_tools()}
 
+        assert set(tools) == {"some_gateway_tool", "console_create_skill"}
         assert tools["some_gateway_tool"]._connection["headers"]["Authorization"] == "Bearer tok-gatana"
         assert tools["console_create_skill"]._connection["headers"]["Authorization"] == "Bearer tok-agent-console"
 
@@ -774,9 +718,6 @@ class TestDiscoverMcpTools:
         """Given the orchestrator's UserTokenProvider, the sub-agent exchanges through it and the
         tools it discovers itself carry no bearer — an interceptor mints one per call."""
         from agent_common.core.token_provider import UserTokenProvider
-        from agent_common.core.tool_catalogue import reset_catalogue_store
-
-        reset_catalogue_store()
         exchanges: list[str] = []
 
         import base64
@@ -874,9 +815,6 @@ class TestDiscoverMcpTools:
 
     @pytest.mark.asyncio
     async def test_only_names_missing_from_pre_resolved_are_discovered(self, mock_model):
-        from agent_common.core.tool_catalogue import reset_catalogue_store
-
-        reset_catalogue_store()
         config = LocalLangGraphSubAgentConfig(
             type="langgraph",
             name="gateway-agent",

--- a/packages/agent-common/tests/test_tool_catalogue.py
+++ b/packages/agent-common/tests/test_tool_catalogue.py
@@ -355,3 +355,87 @@ def test_stateless_capability_memo_is_per_url():
     assert stateless_supported("https://other/mcp") is None
     reset_stateless_memo()
     assert stateless_supported("https://gw/mcp") is None
+
+
+class TestFetchCatalogueStrategy:
+    """stateless → per-URL memo → SDK fallback, shared by orchestrator discovery and agent-runner."""
+
+    def setup_method(self):
+        from agent_common.core.catalogue_ingest import reset_stateless_memo
+
+        reset_stateless_memo()
+
+    @staticmethod
+    def _session_factory(*names: str):
+        from contextlib import asynccontextmanager
+        from unittest.mock import AsyncMock, MagicMock
+
+        from mcp.types import ListToolsResult, Tool as MCPTool
+
+        session = MagicMock()
+        session.list_tools = AsyncMock(
+            return_value=ListToolsResult(tools=[MCPTool(name=n, inputSchema=SCHEMA) for n in names], nextCursor=None)
+        )
+
+        @asynccontextmanager
+        async def _cm():
+            yield session
+
+        return _cm, session
+
+    @pytest.mark.asyncio
+    async def test_stateless_success_is_remembered_and_skips_the_sdk(self):
+        from unittest.mock import patch
+
+        from agent_common.core.catalogue_ingest import fetch_catalogue, stateless_supported
+
+        factory, session = self._session_factory("via_sdk")
+        with patch("agent_common.core.catalogue_ingest.fetch_catalogue_stateless", return_value=_catalogue("fast")) as fast:
+            cat = await fetch_catalogue(
+                server_slug="srv", url="https://gw/mcp", headers={"Authorization": "Bearer t"}, http_client=object(), session_factory=factory
+            )
+        assert cat.tools.keys() == {"fast"}
+        assert fast.await_args.kwargs == {"url": "https://gw/mcp", "headers": {"Authorization": "Bearer t"}, "server_slug": "srv"}
+        assert stateless_supported("https://gw/mcp") is True
+        session.list_tools.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_refusal_marks_url_and_falls_back_for_good(self):
+        from unittest.mock import patch
+
+        from agent_common.core.catalogue_ingest import fetch_catalogue, stateless_supported
+
+        factory, session = self._session_factory("via_sdk")
+        with patch(
+            "agent_common.core.catalogue_ingest.fetch_catalogue_stateless", side_effect=StatelessListUnsupported("400")
+        ) as fast:
+            first = await fetch_catalogue(server_slug="srv", url="https://gw/mcp", headers=None, http_client=object(), session_factory=factory)
+            second = await fetch_catalogue(server_slug="srv", url="https://gw/mcp", headers=None, http_client=object(), session_factory=factory)
+        assert first.source == second.source == "mcp" and first.tools.keys() == {"via_sdk"}
+        assert fast.await_count == 1, "never probed again once refused"
+        assert stateless_supported("https://gw/mcp") is False
+        assert session.list_tools.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_transient_error_falls_back_without_marking_the_url(self):
+        from unittest.mock import patch
+
+        from agent_common.core.catalogue_ingest import fetch_catalogue, stateless_supported
+
+        factory, _ = self._session_factory("via_sdk")
+        with patch("agent_common.core.catalogue_ingest.fetch_catalogue_stateless", side_effect=StatelessListError("502")):
+            cat = await fetch_catalogue(server_slug="srv", url="https://gw/mcp", headers=None, http_client=object(), session_factory=factory)
+        assert cat.source == "mcp"
+        assert stateless_supported("https://gw/mcp") is None
+
+    @pytest.mark.asyncio
+    async def test_stateless_disabled_or_no_http_client_goes_straight_to_sdk(self):
+        from unittest.mock import patch
+
+        from agent_common.core.catalogue_ingest import fetch_catalogue
+
+        factory, _ = self._session_factory("via_sdk")
+        with patch("agent_common.core.catalogue_ingest.fetch_catalogue_stateless", side_effect=AssertionError("must not probe")):
+            a = await fetch_catalogue(server_slug="srv", url="https://gw/mcp", headers=None, http_client=object(), session_factory=factory, stateless=False)
+            b = await fetch_catalogue(server_slug="srv", url="https://gw/mcp", headers=None, http_client=None, session_factory=factory)
+        assert a.source == b.source == "mcp"

--- a/packages/agent-common/tests/test_tool_catalogue.py
+++ b/packages/agent-common/tests/test_tool_catalogue.py
@@ -21,7 +21,6 @@ from agent_common.core.catalogue_ingest import (
     parse_tools_list_reply,
 )
 from agent_common.core.tool_catalogue import (
-    CatalogueStore,
     ServerCatalogue,
     build_lazy_tools,
     build_server_catalogue,
@@ -342,32 +341,17 @@ class TestMcpIngest:
 
 
 # --------------------------------------------------------------------------------------
-# Store
+# Endpoint capability memo
 # --------------------------------------------------------------------------------------
 
 
-class TestCatalogueStore:
-    def test_intern_shares_identical_catalogues(self):
-        store = CatalogueStore()
-        first = store.intern(_catalogue("a"))
-        again = store.intern(_catalogue("a"))
-        assert again is first, "same (server, hash) → same object, bytes shared"
-        newer = store.intern(_catalogue("a", "b"))
-        assert newer is not first
-        assert store.interned("srv") is newer
+def test_stateless_capability_memo_is_per_url():
+    from agent_common.core.catalogue_ingest import reset_stateless_memo, set_stateless_supported, stateless_supported
 
-    def test_resolve_finds_names_across_interned_catalogues(self):
-        store = CatalogueStore()
-        store.intern(_catalogue("a", "b", server="one"))
-        store.intern(_catalogue("c", server="two"))
-        found = store.resolve(["a", "c", "nope"])
-        assert set(found) == {"a", "c"}
-        assert found["a"][0].server_name == "one" and found["c"][0].server_name == "two"
-
-    def test_capability_memo(self):
-        store = CatalogueStore()
-        assert store.stateless_supported("https://gw/mcp") is None
-        store.set_stateless_supported("https://gw/mcp", False)
-        assert store.stateless_supported("https://gw/mcp") is False
-        store.clear()
-        assert store.stateless_supported("https://gw/mcp") is None
+    reset_stateless_memo()
+    assert stateless_supported("https://gw/mcp") is None
+    set_stateless_supported("https://gw/mcp", False)
+    assert stateless_supported("https://gw/mcp") is False
+    assert stateless_supported("https://other/mcp") is None
+    reset_stateless_memo()
+    assert stateless_supported("https://gw/mcp") is None

--- a/packages/agent-runner/.env.template
+++ b/packages/agent-runner/.env.template
@@ -19,6 +19,13 @@ CONSOLE_BACKEND_URL=http://localhost:5001
 # MCP Gateway (for tool execution)
 MCP_GATEWAY_URL=https://alloych.gatana.ai/mcp
 MCP_TIMEOUT_SECONDS=300
+# OAuth audience (client id) tool-call bearers are exchanged for on the gateway.
+# MCP_GATEWAY_CLIENT_ID=gatana
+# Stateless JSON-RPC tools/list (no SDK handshake); false = always list through the SDK session.
+# MCP_CATALOGUE_STATELESS_LIST=true
+# Seconds of validity a memoised exchanged bearer must keep to be reused for a tool call.
+# Set above the tokens' lifetime (e.g. 100000) to force one exchange per call (QA lever).
+# MCP_TOKEN_LEEWAY_SECONDS=90
 
 # Model Gateway (LiteLLM proxy) — REQUIRED. All LLM calls route through it;
 # no per-provider fallback. Locally set by start-local.sh; in k8s the in-cluster service.

--- a/packages/agent-runner/agent/core.py
+++ b/packages/agent-runner/agent/core.py
@@ -49,6 +49,7 @@ from agent_common.core.model_factory import (
     require_default_model,
 )
 from agent_common.core.stream_watchdog import watch_stream_with_resume
+from agent_common.core.token_provider import DEFAULT_LEEWAY_S, UserTokenProvider
 from google.protobuf.json_format import MessageToDict, ParseDict
 from google.protobuf.struct_pb2 import Struct
 from object_storage import get_object_storage_service
@@ -56,8 +57,6 @@ from object_storage import get_object_storage_service
 if TYPE_CHECKING:
     from agent_common.core.sandbox_pool import SandboxPool
 from langchain_core.messages import HumanMessage
-from langchain_mcp_adapters.client import MultiServerMCPClient
-from langchain_mcp_adapters.sessions import StreamableHttpConnection
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.store.postgres.aio import AsyncPostgresStore
 from psycopg.rows import dict_row
@@ -67,11 +66,19 @@ from ringier_a2a_sdk.models import AgentStreamResponse, UserConfig
 from ringier_a2a_sdk.oauth import OidcOAuth2Client
 from ringier_a2a_sdk.utils.a2a_part_conversion import a2a_parts_to_content
 
+from agent.mcp_tools import McpToolResolver
+
 logger = logging.getLogger(__name__)
 
 _CONSOLE_BACKEND_URL = os.getenv("CONSOLE_BACKEND_URL", "http://localhost:5001")
 _CONSOLE_BACKEND_CLIENT_ID = os.getenv("CONSOLE_BACKEND_CLIENT_ID", "agent-console")
 _MCP_GATEWAY_URL = os.getenv("MCP_GATEWAY_URL", "https://nannos.gatana.nannos.ringier.ch/mcp")
+_MCP_GATEWAY_CLIENT_ID = os.getenv("MCP_GATEWAY_CLIENT_ID", "gatana")
+# Stateless JSON-RPC tools/list (no SDK handshake/parse); off = always list through the SDK.
+_MCP_CATALOGUE_STATELESS_LIST = os.getenv("MCP_CATALOGUE_STATELESS_LIST", "true").lower() not in ("0", "false", "no")
+# How much validity a memoised exchanged bearer must keep to be reused for a tool call. Set it
+# above the exchanged tokens' lifetime to force one exchange per call (QA lever, see #170).
+_MCP_TOKEN_LEEWAY_SECONDS = max(0.0, float(os.getenv("MCP_TOKEN_LEEWAY_SECONDS", str(DEFAULT_LEEWAY_S))))
 _MCP_TIMEOUT_SECONDS = int(os.getenv("MCP_TIMEOUT_SECONDS", "300"))
 _DOCUMENT_STORE_S3_BUCKET = os.getenv("DOCUMENT_STORE_S3_BUCKET", "")
 _MAX_RECURSION_LIMIT = int(os.getenv("MAX_RECURSION_LIMIT", "50"))
@@ -1100,46 +1107,27 @@ class AgentRunner(BaseAgent):
 
         try:
             if mcp_tool_names:
-                # Keep the MCP session open for the entire graph execution so that
-                # tool closures can call back into the session when invoked.
-                allowed = set(mcp_tool_names)
-                has_console_tools = any(name.startswith("console_") for name in allowed)
-                has_gateway_tools = any(not name.startswith("console_") for name in allowed)
-
-                connections: dict[str, StreamableHttpConnection] = {}
-
-                # Add Gatana gateway connection for non-console tools
-                if has_gateway_tools:
-                    gatana_access_token = await (self._get_oauth2_client()).exchange_token(user_access_token, "gatana")
-                    connections["gateway"] = StreamableHttpConnection(
-                        transport="streamable_http",
-                        url=_MCP_GATEWAY_URL,
-                        headers={"Authorization": f"Bearer {gatana_access_token}"},
-                        timeout=mcp_timeout,
-                        sse_read_timeout=mcp_timeout,
-                    )
-
-                # Add console backend MCP connection for console_ tools
-                if has_console_tools:
-                    console_mcp_url = f"{_CONSOLE_BACKEND_URL}/mcp"
-                    console_token = await (self._get_oauth2_client()).exchange_token(
-                        user_access_token, _CONSOLE_BACKEND_CLIENT_ID
-                    )
-                    connections["console"] = StreamableHttpConnection(
-                        transport="streamable_http",
-                        url=console_mcp_url,
-                        headers={"Authorization": f"Bearer {console_token}"},
-                        timeout=mcp_timeout,
-                        sse_read_timeout=mcp_timeout,
-                    )
-
-                mcp_client = MultiServerMCPClient(connections)
-                all_tools = await mcp_client.get_tools()
-                tools = [t for t in all_tools if t.name in allowed]
+                # Tools come from the shared catalogue (stateless tools/list, SDK fallback) as
+                # LazyMcpTools on token-free connections; a per-run UserTokenProvider mints
+                # the bearer at call time, so a token expiring mid-run is re-exchanged.
+                resolver = McpToolResolver(
+                    token_provider=UserTokenProvider(
+                        user_access_token,
+                        self._get_oauth2_client().exchange_token,
+                        leeway_seconds=_MCP_TOKEN_LEEWAY_SECONDS,
+                    ),
+                    gateway_url=_MCP_GATEWAY_URL,
+                    gateway_client_id=_MCP_GATEWAY_CLIENT_ID,
+                    console_mcp_url=f"{_CONSOLE_BACKEND_URL}/mcp",
+                    console_client_id=_CONSOLE_BACKEND_CLIENT_ID,
+                    timeout=mcp_timeout,
+                    stateless_list=_MCP_CATALOGUE_STATELESS_LIST,
+                )
+                tools = await resolver.resolve(mcp_tool_names)
                 logger.info(
                     "Loaded %d/%d MCP tools for job %s: %s",
                     len(tools),
-                    len(all_tools),
+                    len(mcp_tool_names),
                     scheduled_job_id,
                     [t.name for t in tools],
                 )

--- a/packages/agent-runner/agent/core.py
+++ b/packages/agent-runner/agent/core.py
@@ -75,7 +75,11 @@ _CONSOLE_BACKEND_CLIENT_ID = os.getenv("CONSOLE_BACKEND_CLIENT_ID", "agent-conso
 _MCP_GATEWAY_URL = os.getenv("MCP_GATEWAY_URL", "https://nannos.gatana.nannos.ringier.ch/mcp")
 _MCP_GATEWAY_CLIENT_ID = os.getenv("MCP_GATEWAY_CLIENT_ID", "gatana")
 # Stateless JSON-RPC tools/list (no SDK handshake/parse); off = always list through the SDK.
-_MCP_CATALOGUE_STATELESS_LIST = os.getenv("MCP_CATALOGUE_STATELESS_LIST", "true").lower() not in ("0", "false", "no")
+_MCP_CATALOGUE_STATELESS_LIST = os.getenv("MCP_CATALOGUE_STATELESS_LIST", "true").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+}
 # How much validity a memoised exchanged bearer must keep to be reused for a tool call. Set it
 # above the exchanged tokens' lifetime to force one exchange per call (QA lever, see #170).
 _MCP_TOKEN_LEEWAY_SECONDS = max(0.0, float(os.getenv("MCP_TOKEN_LEEWAY_SECONDS", str(DEFAULT_LEEWAY_S))))
@@ -1123,14 +1127,7 @@ class AgentRunner(BaseAgent):
                     timeout=mcp_timeout,
                     stateless_list=_MCP_CATALOGUE_STATELESS_LIST,
                 )
-                tools = await resolver.resolve(mcp_tool_names)
-                logger.info(
-                    "Loaded %d/%d MCP tools for job %s: %s",
-                    len(tools),
-                    len(mcp_tool_names),
-                    scheduled_job_id,
-                    [t.name for t in tools],
-                )
+                tools = await resolver.resolve(mcp_tool_names)  # logs what was resolved and how
                 await _run_graph(tools + docstore_tools)
             else:
                 await _run_graph(docstore_tools)

--- a/packages/agent-runner/agent/mcp_tools.py
+++ b/packages/agent-runner/agent/mcp_tools.py
@@ -28,8 +28,8 @@ from datetime import timedelta
 from typing import Any
 
 import httpx
+from agent_common.agents.dynamic_agent import is_console_backend_tool
 from agent_common.core.catalogue_ingest import (
-    STATELESS_TIMEOUT_S,
     StatelessListError,
     StatelessListUnsupported,
     fetch_catalogue_mcp,
@@ -46,10 +46,15 @@ logger = logging.getLogger(__name__)
 GATEWAY_SERVER = "gateway"
 CONSOLE_SERVER = "console"
 
+# Console-backend tools (``console_*``, ``scheduler_*``) go to the console MCP; the rest to the gateway.
+is_console_tool = is_console_backend_tool
 
-def is_console_tool(name: str) -> bool:
-    """Console-backend MCP tools are ``console_*``; everything else lives on the gateway."""
-    return name.startswith("console_")
+# When each MCP URL was last listed by this process. Catalogues are per-user views and can
+# change on the gateway, so the shared store only serves a whitelist without a fresh
+# ``tools/list`` while the URL was listed within ``catalogue_ttl`` (default: the same 60 s the
+# orchestrator's discovery cache uses).
+_LISTED_AT: dict[str, float] = {}
+DEFAULT_CATALOGUE_TTL_S = 60.0
 
 
 class McpToolResolver:
@@ -69,11 +74,13 @@ class McpToolResolver:
         console_client_id: str,
         timeout: timedelta,
         stateless_list: bool = True,
+        catalogue_ttl_seconds: float = DEFAULT_CATALOGUE_TTL_S,
     ) -> None:
         self.token_provider = token_provider
         self.gateway_client_id = gateway_client_id
         self.console_client_id = console_client_id
         self.stateless_list = stateless_list
+        self.catalogue_ttl = catalogue_ttl_seconds
         self._urls = {GATEWAY_SERVER: gateway_url, CONSOLE_SERVER: console_mcp_url}
         self._timeout = timeout
         # Discovery statistics for the last resolve(); logged and surfaced for measurements.
@@ -121,11 +128,17 @@ class McpToolResolver:
             else:
                 store.set_stateless_supported(url, True)
                 self.stats["source"][server_name] = "stateless"
+                _LISTED_AT[url] = time.monotonic()
                 return store.intern(catalogue)
         client = MultiServerMCPClient({server_name: self._connection(server_name, bearer=bearer)})
         catalogue = await fetch_catalogue_mcp(lambda: client.session(server_name), server_slug=server_name)
         self.stats["source"][server_name] = "mcp"
+        _LISTED_AT[url] = time.monotonic()
         return store.intern(catalogue)
+
+    def _store_is_fresh(self, server_name: str) -> bool:
+        listed_at = _LISTED_AT.get(self._urls[server_name])
+        return listed_at is not None and time.monotonic() - listed_at < self.catalogue_ttl
 
     # -- resolution ----------------------------------------------------------------------
     async def resolve(self, wanted: Iterable[str]) -> list[BaseTool]:
@@ -152,9 +165,17 @@ class McpToolResolver:
         def _server_for(name: str) -> str:
             return CONSOLE_SERVER if is_console_tool(name) else GATEWAY_SERVER
 
+        # Exchange up front for every audience the run needs: discovery used to do this, and
+        # a user token that is expired or revoked must fail the run here, not surface as a
+        # run that "succeeded" without ever being able to call a tool.
+        for server in connections:
+            await self.token_provider.get(self.audience_for(server))
+
         tools: list[BaseTool] = []
         for name, (_held, entry) in store.resolve(names).items():
             server = _server_for(name)
+            if not self._store_is_fresh(server):
+                continue  # the store's copy may be stale for this process; list again below
             tools.append(
                 make_lazy_tool(
                     entry,
@@ -167,7 +188,8 @@ class McpToolResolver:
 
         missing = names - {t.name for t in tools}
         if missing:
-            async with httpx.AsyncClient(timeout=STATELESS_TIMEOUT_S, follow_redirects=True) as http_client:
+            # follow_redirects: console-backend's ``/mcp`` mount answers ``307 → /mcp/``.
+            async with httpx.AsyncClient(timeout=self._timeout.total_seconds(), follow_redirects=True) as http_client:
                 for server, connection in connections.items():
                     server_missing = {n for n in missing if _server_for(n) == server}
                     if not server_missing:

--- a/packages/agent-runner/agent/mcp_tools.py
+++ b/packages/agent-runner/agent/mcp_tools.py
@@ -28,14 +28,7 @@ from typing import Any
 
 import httpx
 from agent_common.agents.dynamic_agent import is_console_backend_tool
-from agent_common.core.catalogue_ingest import (
-    StatelessListError,
-    StatelessListUnsupported,
-    fetch_catalogue_mcp,
-    fetch_catalogue_stateless,
-    set_stateless_supported,
-    stateless_supported,
-)
+from agent_common.core.catalogue_ingest import fetch_catalogue
 from agent_common.core.token_provider import UserTokenProvider, bearer_interceptor
 from agent_common.core.tool_catalogue import ServerCatalogue, make_lazy_tool
 from langchain_core.tools import BaseTool
@@ -100,33 +93,22 @@ class McpToolResolver:
 
     # -- listing -------------------------------------------------------------------------
     async def _list_server(self, server_name: str, http_client: httpx.AsyncClient) -> ServerCatalogue:
-        """``tools/list`` for one server: stateless POST first, SDK session as fallback.
+        """``tools/list`` for one server via ``catalogue_ingest.fetch_catalogue`` (stateless → SDK).
 
         The listing itself needs a bearer (the gateway filters the catalogue per user), so
-        it asks the provider for one — the only place discovery touches a token. Whether an
-        endpoint serves stateless requests is memoised per URL for the process lifetime.
+        it asks the provider for one — the only place discovery touches a token.
         """
-        url = self._urls[server_name]
         bearer = await self.token_provider.get(self.audience_for(server_name))
-        if self.stateless_list and stateless_supported(url) is not False:
-            try:
-                catalogue = await fetch_catalogue_stateless(
-                    http_client, url=url, headers={"Authorization": f"Bearer {bearer}"}, server_slug=server_name
-                )
-            except StatelessListUnsupported as e:
-                set_stateless_supported(url, False)
-                logger.warning(
-                    "MCP endpoint refuses stateless tools/list — using SDK session for '%s' (%s)", server_name, e
-                )
-            except StatelessListError as e:
-                logger.warning("Stateless tools/list failed for '%s', falling back to SDK session: %s", server_name, e)
-            else:
-                set_stateless_supported(url, True)
-                self.stats["source"][server_name] = "stateless"
-                return catalogue
         client = MultiServerMCPClient({server_name: self._connection(server_name, bearer=bearer)})
-        catalogue = await fetch_catalogue_mcp(lambda: client.session(server_name), server_slug=server_name)
-        self.stats["source"][server_name] = "mcp"
+        catalogue = await fetch_catalogue(
+            server_slug=server_name,
+            url=self._urls[server_name],
+            headers={"Authorization": f"Bearer {bearer}"},
+            http_client=http_client,
+            session_factory=lambda: client.session(server_name),
+            stateless=self.stateless_list,
+        )
+        self.stats["source"][server_name] = catalogue.source
         return catalogue
 
     # -- resolution ----------------------------------------------------------------------

--- a/packages/agent-runner/agent/mcp_tools.py
+++ b/packages/agent-runner/agent/mcp_tools.py
@@ -10,8 +10,7 @@ Now a run has the same shape as an orchestrator sub-agent (see ``agent_common``)
 * **Catalogue** — each server the whitelist needs is listed with a stateless JSON-RPC
   ``tools/list`` (:func:`fetch_catalogue_stateless`, no handshake, no pydantic) and the SDK
   session (:func:`fetch_catalogue_mcp`) only as fallback. Either way the result is flattened
-  to bytes and interned in the process-wide :class:`CatalogueStore` (dedup only — a listing
-  is a per-user view); no ``mcp.types.Tool`` survives discovery.
+  to bytes; no ``mcp.types.Tool`` survives discovery.
 * **Tools** — :class:`LazyMcpTool` per whitelisted name, so only the tools the run binds
   pay for schema decoding.
 * **Credentials** — a per-run :class:`UserTokenProvider`; tool connections carry no
@@ -34,9 +33,11 @@ from agent_common.core.catalogue_ingest import (
     StatelessListUnsupported,
     fetch_catalogue_mcp,
     fetch_catalogue_stateless,
+    set_stateless_supported,
+    stateless_supported,
 )
 from agent_common.core.token_provider import UserTokenProvider, bearer_interceptor
-from agent_common.core.tool_catalogue import ServerCatalogue, get_catalogue_store, make_lazy_tool
+from agent_common.core.tool_catalogue import ServerCatalogue, make_lazy_tool
 from langchain_core.tools import BaseTool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_mcp_adapters.sessions import StreamableHttpConnection
@@ -49,10 +50,9 @@ CONSOLE_SERVER = "console"
 # Console-backend tools (``console_*``, ``scheduler_*``) go to the console MCP; the rest to the gateway.
 is_console_tool = is_console_backend_tool
 
-# The process-wide CatalogueStore is used for *interning only*: a listing is a per-user view
-# (a Gatana profile can hide tools of a server from one user and not another), so every run
-# lists with its own token and never binds a name from a catalogue another run fetched. Runs
-# whose views are identical still share one set of schema bytes through the store.
+# A ``tools/list`` is a per-user view (a Gatana profile can hide tools of a server from one
+# user and not another), so every run lists with its own token; nothing is shared between runs
+# except the per-URL "does this endpoint serve stateless requests" memo in catalogue_ingest.
 
 
 class McpToolResolver:
@@ -106,29 +106,28 @@ class McpToolResolver:
         it asks the provider for one — the only place discovery touches a token. Whether an
         endpoint serves stateless requests is memoised per URL for the process lifetime.
         """
-        store = get_catalogue_store()
         url = self._urls[server_name]
         bearer = await self.token_provider.get(self.audience_for(server_name))
-        if self.stateless_list and store.stateless_supported(url) is not False:
+        if self.stateless_list and stateless_supported(url) is not False:
             try:
                 catalogue = await fetch_catalogue_stateless(
                     http_client, url=url, headers={"Authorization": f"Bearer {bearer}"}, server_slug=server_name
                 )
             except StatelessListUnsupported as e:
-                store.set_stateless_supported(url, False)
+                set_stateless_supported(url, False)
                 logger.warning(
                     "MCP endpoint refuses stateless tools/list — using SDK session for '%s' (%s)", server_name, e
                 )
             except StatelessListError as e:
                 logger.warning("Stateless tools/list failed for '%s', falling back to SDK session: %s", server_name, e)
             else:
-                store.set_stateless_supported(url, True)
+                set_stateless_supported(url, True)
                 self.stats["source"][server_name] = "stateless"
-                return store.intern(catalogue)
+                return catalogue
         client = MultiServerMCPClient({server_name: self._connection(server_name, bearer=bearer)})
         catalogue = await fetch_catalogue_mcp(lambda: client.session(server_name), server_slug=server_name)
         self.stats["source"][server_name] = "mcp"
-        return store.intern(catalogue)
+        return catalogue
 
     # -- resolution ----------------------------------------------------------------------
     async def resolve(self, wanted: Iterable[str]) -> list[BaseTool]:

--- a/packages/agent-runner/agent/mcp_tools.py
+++ b/packages/agent-runner/agent/mcp_tools.py
@@ -49,10 +49,14 @@ CONSOLE_SERVER = "console"
 # Console-backend tools (``console_*``, ``scheduler_*``) go to the console MCP; the rest to the gateway.
 is_console_tool = is_console_backend_tool
 
-# When each MCP URL was last listed by this process. Catalogues are per-user views and can
-# change on the gateway, so the shared store only serves a whitelist without a fresh
-# ``tools/list`` while the URL was listed within ``catalogue_ttl`` (default: the same 60 s the
-# orchestrator's discovery cache uses).
+# When each MCP URL was last listed by this process. Catalogues can change on the gateway, so
+# the shared store only serves a whitelist without a fresh ``tools/list`` while the URL was
+# listed within ``catalogue_ttl`` (default: the same 60 s the orchestrator's discovery cache
+# uses). Keyed per URL, not per user, on purpose: the store is what lets runs of different
+# users share one listing (the win over the old per-run ``get_tools()``), and the whitelist is
+# admin-configured. Per-user entitlement is enforced where it matters — every call carries
+# that user's own bearer, so a name the store holds but the user may not call still fails at
+# the gateway. What a user could observe is at most a stale *schema* for up to the TTL.
 _LISTED_AT: dict[str, float] = {}
 DEFAULT_CATALOGUE_TTL_S = 60.0
 

--- a/packages/agent-runner/agent/mcp_tools.py
+++ b/packages/agent-runner/agent/mcp_tools.py
@@ -1,0 +1,203 @@
+"""MCP tool discovery for scheduled runs: shared catalogue + call-time bearer tokens.
+
+Before this module the runner exchanged the user's token once per audience, baked the
+results into ``StreamableHttpConnection.headers`` and ran ``MultiServerMCPClient.get_tools()``
+over the whole gateway — a full SDK parse of ~500 tools into pydantic objects on every run,
+with credentials frozen into every tool at discovery time.
+
+Now a run has the same shape as an orchestrator sub-agent (see ``agent_common``):
+
+* **Catalogue** — names already interned in the process-wide :class:`CatalogueStore` cost
+  nothing; the rest are listed with a stateless JSON-RPC ``tools/list``
+  (:func:`fetch_catalogue_stateless`, no handshake, no pydantic) and the SDK session
+  (:func:`fetch_catalogue_mcp`) only as fallback. Either way the result is flattened to
+  bytes and interned; no ``mcp.types.Tool`` survives discovery.
+* **Tools** — :class:`LazyMcpTool` per whitelisted name, so only the tools the run binds
+  pay for schema decoding.
+* **Credentials** — a per-run :class:`UserTokenProvider`; tool connections carry no
+  ``Authorization`` header, :func:`bearer_interceptor` mints one per call (memoised until
+  ``MCP_TOKEN_LEEWAY_SECONDS`` before ``exp``), so a token expiring mid-run is re-minted.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Iterable
+from datetime import timedelta
+from typing import Any
+
+import httpx
+from agent_common.core.catalogue_ingest import (
+    STATELESS_TIMEOUT_S,
+    StatelessListError,
+    StatelessListUnsupported,
+    fetch_catalogue_mcp,
+    fetch_catalogue_stateless,
+)
+from agent_common.core.token_provider import UserTokenProvider, bearer_interceptor
+from agent_common.core.tool_catalogue import ServerCatalogue, get_catalogue_store, make_lazy_tool
+from langchain_core.tools import BaseTool
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_mcp_adapters.sessions import StreamableHttpConnection
+
+logger = logging.getLogger(__name__)
+
+GATEWAY_SERVER = "gateway"
+CONSOLE_SERVER = "console"
+
+
+def is_console_tool(name: str) -> bool:
+    """Console-backend MCP tools are ``console_*``; everything else lives on the gateway."""
+    return name.startswith("console_")
+
+
+class McpToolResolver:
+    """Resolve a scheduled run's tool whitelist to token-free :class:`LazyMcpTool` instances.
+
+    One instance per run: it owns that run's :class:`UserTokenProvider` and the two
+    possible connections (gateway, console).
+    """
+
+    def __init__(
+        self,
+        *,
+        token_provider: UserTokenProvider,
+        gateway_url: str,
+        gateway_client_id: str,
+        console_mcp_url: str,
+        console_client_id: str,
+        timeout: timedelta,
+        stateless_list: bool = True,
+    ) -> None:
+        self.token_provider = token_provider
+        self.gateway_client_id = gateway_client_id
+        self.console_client_id = console_client_id
+        self.stateless_list = stateless_list
+        self._urls = {GATEWAY_SERVER: gateway_url, CONSOLE_SERVER: console_mcp_url}
+        self._timeout = timeout
+        # Discovery statistics for the last resolve(); logged and surfaced for measurements.
+        self.stats: dict[str, Any] = {}
+
+    # -- audiences / connections -------------------------------------------------------
+    def audience_for(self, server_name: str) -> str:
+        return self.console_client_id if server_name == CONSOLE_SERVER else self.gateway_client_id
+
+    def _connection(self, server_name: str, *, bearer: str | None = None) -> StreamableHttpConnection:
+        """A connection for ``server_name``; token-free unless ``bearer`` is given (listing only)."""
+        connection = StreamableHttpConnection(
+            transport="streamable_http",
+            url=self._urls[server_name],
+            timeout=self._timeout,
+            sse_read_timeout=self._timeout,
+        )
+        if bearer is not None:
+            connection["headers"] = {"Authorization": f"Bearer {bearer}"}
+        return connection
+
+    # -- listing -------------------------------------------------------------------------
+    async def _list_server(self, server_name: str, http_client: httpx.AsyncClient) -> ServerCatalogue:
+        """``tools/list`` for one server: stateless POST first, SDK session as fallback.
+
+        The listing itself needs a bearer (the gateway filters the catalogue per user), so
+        it asks the provider for one — the only place discovery touches a token. Whether an
+        endpoint serves stateless requests is memoised per URL for the process lifetime.
+        """
+        store = get_catalogue_store()
+        url = self._urls[server_name]
+        bearer = await self.token_provider.get(self.audience_for(server_name))
+        if self.stateless_list and store.stateless_supported(url) is not False:
+            try:
+                catalogue = await fetch_catalogue_stateless(
+                    http_client, url=url, headers={"Authorization": f"Bearer {bearer}"}, server_slug=server_name
+                )
+            except StatelessListUnsupported as e:
+                store.set_stateless_supported(url, False)
+                logger.warning(
+                    "MCP endpoint refuses stateless tools/list — using SDK session for '%s' (%s)", server_name, e
+                )
+            except StatelessListError as e:
+                logger.warning("Stateless tools/list failed for '%s', falling back to SDK session: %s", server_name, e)
+            else:
+                store.set_stateless_supported(url, True)
+                self.stats["source"][server_name] = "stateless"
+                return store.intern(catalogue)
+        client = MultiServerMCPClient({server_name: self._connection(server_name, bearer=bearer)})
+        catalogue = await fetch_catalogue_mcp(lambda: client.session(server_name), server_slug=server_name)
+        self.stats["source"][server_name] = "mcp"
+        return store.intern(catalogue)
+
+    # -- resolution ----------------------------------------------------------------------
+    async def resolve(self, wanted: Iterable[str]) -> list[BaseTool]:
+        """Tools for ``wanted`` names, served from the shared store where possible.
+
+        Names the store does not hold trigger one listing per server that can serve them;
+        names that no server lists are logged and skipped (same as the whitelist filter
+        the runner always applied).
+        """
+        started = time.monotonic()
+        names = set(wanted)
+        self.stats = {"source": {}, "from_store": 0, "listed": 0}
+        store = get_catalogue_store()
+        interceptors = [bearer_interceptor(self.token_provider, self.audience_for)]
+        connections = {
+            server: self._connection(server)
+            for server, predicate in (
+                (GATEWAY_SERVER, lambda n: not is_console_tool(n)),
+                (CONSOLE_SERVER, is_console_tool),
+            )
+            if any(predicate(n) for n in names)
+        }
+
+        def _server_for(name: str) -> str:
+            return CONSOLE_SERVER if is_console_tool(name) else GATEWAY_SERVER
+
+        tools: list[BaseTool] = []
+        for name, (_held, entry) in store.resolve(names).items():
+            server = _server_for(name)
+            tools.append(
+                make_lazy_tool(
+                    entry,
+                    server_name=server,
+                    connection=connections[server],
+                    tool_interceptors=interceptors,
+                )
+            )
+            self.stats["from_store"] += 1
+
+        missing = names - {t.name for t in tools}
+        if missing:
+            async with httpx.AsyncClient(timeout=STATELESS_TIMEOUT_S, follow_redirects=True) as http_client:
+                for server, connection in connections.items():
+                    server_missing = {n for n in missing if _server_for(n) == server}
+                    if not server_missing:
+                        continue
+                    catalogue = await self._list_server(server, http_client)
+                    for name in sorted(server_missing):
+                        entry = catalogue.tools.get(name)
+                        if entry is None:
+                            continue
+                        tools.append(
+                            make_lazy_tool(
+                                entry,
+                                server_name=server,
+                                connection=connection,
+                                tool_interceptors=interceptors,
+                            )
+                        )
+                        self.stats["listed"] += 1
+
+        unresolved = names - {t.name for t in tools}
+        self.stats["unresolved"] = sorted(unresolved)
+        self.stats["seconds"] = round(time.monotonic() - started, 3)
+        logger.info(
+            "Resolved %d/%d MCP tools in %.3fs: %d from the shared catalogue store, %d via tools/list (%s)%s",
+            len(tools),
+            len(names),
+            self.stats["seconds"],
+            self.stats["from_store"],
+            self.stats["listed"],
+            ", ".join(f"{s}={src}" for s, src in self.stats["source"].items()) or "no listing",
+            f"; not offered by any server: {sorted(unresolved)}" if unresolved else "",
+        )
+        return tools

--- a/packages/agent-runner/agent/mcp_tools.py
+++ b/packages/agent-runner/agent/mcp_tools.py
@@ -7,11 +7,11 @@ with credentials frozen into every tool at discovery time.
 
 Now a run has the same shape as an orchestrator sub-agent (see ``agent_common``):
 
-* **Catalogue** — names already interned in the process-wide :class:`CatalogueStore` cost
-  nothing; the rest are listed with a stateless JSON-RPC ``tools/list``
-  (:func:`fetch_catalogue_stateless`, no handshake, no pydantic) and the SDK session
-  (:func:`fetch_catalogue_mcp`) only as fallback. Either way the result is flattened to
-  bytes and interned; no ``mcp.types.Tool`` survives discovery.
+* **Catalogue** — each server the whitelist needs is listed with a stateless JSON-RPC
+  ``tools/list`` (:func:`fetch_catalogue_stateless`, no handshake, no pydantic) and the SDK
+  session (:func:`fetch_catalogue_mcp`) only as fallback. Either way the result is flattened
+  to bytes and interned in the process-wide :class:`CatalogueStore` (dedup only — a listing
+  is a per-user view); no ``mcp.types.Tool`` survives discovery.
 * **Tools** — :class:`LazyMcpTool` per whitelisted name, so only the tools the run binds
   pay for schema decoding.
 * **Credentials** — a per-run :class:`UserTokenProvider`; tool connections carry no
@@ -49,16 +49,10 @@ CONSOLE_SERVER = "console"
 # Console-backend tools (``console_*``, ``scheduler_*``) go to the console MCP; the rest to the gateway.
 is_console_tool = is_console_backend_tool
 
-# When each MCP URL was last listed by this process. Catalogues can change on the gateway, so
-# the shared store only serves a whitelist without a fresh ``tools/list`` while the URL was
-# listed within ``catalogue_ttl`` (default: the same 60 s the orchestrator's discovery cache
-# uses). Keyed per URL, not per user, on purpose: the store is what lets runs of different
-# users share one listing (the win over the old per-run ``get_tools()``), and the whitelist is
-# admin-configured. Per-user entitlement is enforced where it matters — every call carries
-# that user's own bearer, so a name the store holds but the user may not call still fails at
-# the gateway. What a user could observe is at most a stale *schema* for up to the TTL.
-_LISTED_AT: dict[str, float] = {}
-DEFAULT_CATALOGUE_TTL_S = 60.0
+# The process-wide CatalogueStore is used for *interning only*: a listing is a per-user view
+# (a Gatana profile can hide tools of a server from one user and not another), so every run
+# lists with its own token and never binds a name from a catalogue another run fetched. Runs
+# whose views are identical still share one set of schema bytes through the store.
 
 
 class McpToolResolver:
@@ -78,13 +72,11 @@ class McpToolResolver:
         console_client_id: str,
         timeout: timedelta,
         stateless_list: bool = True,
-        catalogue_ttl_seconds: float = DEFAULT_CATALOGUE_TTL_S,
     ) -> None:
         self.token_provider = token_provider
         self.gateway_client_id = gateway_client_id
         self.console_client_id = console_client_id
         self.stateless_list = stateless_list
-        self.catalogue_ttl = catalogue_ttl_seconds
         self._urls = {GATEWAY_SERVER: gateway_url, CONSOLE_SERVER: console_mcp_url}
         self._timeout = timeout
         # Discovery statistics for the last resolve(); logged and surfaced for measurements.
@@ -132,30 +124,23 @@ class McpToolResolver:
             else:
                 store.set_stateless_supported(url, True)
                 self.stats["source"][server_name] = "stateless"
-                _LISTED_AT[url] = time.monotonic()
                 return store.intern(catalogue)
         client = MultiServerMCPClient({server_name: self._connection(server_name, bearer=bearer)})
         catalogue = await fetch_catalogue_mcp(lambda: client.session(server_name), server_slug=server_name)
         self.stats["source"][server_name] = "mcp"
-        _LISTED_AT[url] = time.monotonic()
         return store.intern(catalogue)
-
-    def _store_is_fresh(self, server_name: str) -> bool:
-        listed_at = _LISTED_AT.get(self._urls[server_name])
-        return listed_at is not None and time.monotonic() - listed_at < self.catalogue_ttl
 
     # -- resolution ----------------------------------------------------------------------
     async def resolve(self, wanted: Iterable[str]) -> list[BaseTool]:
-        """Tools for ``wanted`` names, served from the shared store where possible.
+        """Tools for ``wanted`` names: one ``tools/list`` per server the whitelist needs.
 
-        Names the store does not hold trigger one listing per server that can serve them;
-        names that no server lists are logged and skipped (same as the whitelist filter
-        the runner always applied).
+        Always listed with this run's own token, so the run only ever binds tools this user
+        is offered; names no server lists are logged and skipped (the whitelist filter the
+        runner always applied).
         """
         started = time.monotonic()
         names = set(wanted)
-        self.stats = {"source": {}, "from_store": 0, "listed": 0}
-        store = get_catalogue_store()
+        self.stats = {"source": {}}
         interceptors = [bearer_interceptor(self.token_provider, self.audience_for)]
         connections = {
             server: self._connection(server)
@@ -176,53 +161,31 @@ class McpToolResolver:
             await self.token_provider.get(self.audience_for(server))
 
         tools: list[BaseTool] = []
-        for name, (_held, entry) in store.resolve(names).items():
-            server = _server_for(name)
-            if not self._store_is_fresh(server):
-                continue  # the store's copy may be stale for this process; list again below
-            tools.append(
-                make_lazy_tool(
-                    entry,
-                    server_name=server,
-                    connection=connections[server],
-                    tool_interceptors=interceptors,
-                )
-            )
-            self.stats["from_store"] += 1
-
-        missing = names - {t.name for t in tools}
-        if missing:
-            # follow_redirects: console-backend's ``/mcp`` mount answers ``307 → /mcp/``.
-            async with httpx.AsyncClient(timeout=self._timeout.total_seconds(), follow_redirects=True) as http_client:
-                for server, connection in connections.items():
-                    server_missing = {n for n in missing if _server_for(n) == server}
-                    if not server_missing:
-                        continue
-                    catalogue = await self._list_server(server, http_client)
-                    for name in sorted(server_missing):
-                        entry = catalogue.tools.get(name)
-                        if entry is None:
-                            continue
-                        tools.append(
-                            make_lazy_tool(
-                                entry,
-                                server_name=server,
-                                connection=connection,
-                                tool_interceptors=interceptors,
-                            )
+        # follow_redirects: console-backend's ``/mcp`` mount answers ``307 → /mcp/``.
+        async with httpx.AsyncClient(timeout=self._timeout.total_seconds(), follow_redirects=True) as http_client:
+            for server, connection in connections.items():
+                catalogue = await self._list_server(server, http_client)
+                for name in sorted(n for n in names if _server_for(n) == server):
+                    entry = catalogue.tools.get(name)
+                    if entry is None:
+                        continue  # not offered to this user by this server
+                    tools.append(
+                        make_lazy_tool(
+                            entry,
+                            server_name=server,
+                            connection=connection,
+                            tool_interceptors=interceptors,
                         )
-                        self.stats["listed"] += 1
+                    )
 
         unresolved = names - {t.name for t in tools}
         self.stats["unresolved"] = sorted(unresolved)
         self.stats["seconds"] = round(time.monotonic() - started, 3)
         logger.info(
-            "Resolved %d/%d MCP tools in %.3fs: %d from the shared catalogue store, %d via tools/list (%s)%s",
+            "Resolved %d/%d MCP tools in %.3fs via tools/list (%s)%s",
             len(tools),
             len(names),
             self.stats["seconds"],
-            self.stats["from_store"],
-            self.stats["listed"],
             ", ".join(f"{s}={src}" for s, src in self.stats["source"].items()) or "no listing",
             f"; not offered by any server: {sorted(unresolved)}" if unresolved else "",
         )

--- a/packages/agent-runner/tests/test_agent_runner_security.py
+++ b/packages/agent-runner/tests/test_agent_runner_security.py
@@ -15,8 +15,7 @@ from a2a.types import Message, Part, Role
 
 @pytest.fixture
 def agent_runner():
-    """Create an AgentRunner instance with minimal mocking.
-    """
+    """Create an AgentRunner instance with minimal mocking."""
     mock_checkpointer = MagicMock(name="checkpointer")
 
     with patch("agent.core._create_checkpointer", return_value=(mock_checkpointer, None)):
@@ -193,9 +192,7 @@ class TestDispatchShapes:
     def _task(sub_agent_id: int | None) -> MagicMock:
         task = MagicMock()
         task.context_id = "ctx-shape"
-        task.history = [
-            MagicMock(metadata={"sub_agent_id": sub_agent_id, "scheduled_job_id": 10})
-        ]
+        task.history = [MagicMock(metadata={"sub_agent_id": sub_agent_id, "scheduled_job_id": 10})]
         return task
 
     @staticmethod
@@ -220,9 +217,7 @@ class TestDispatchShapes:
     @pytest.mark.asyncio
     async def test_no_sub_agent_delivers_the_text_it_was_given(self, agent_runner):
         agent_runner._execute_sub_agent = AsyncMock()
-        items = await self._run(
-            agent_runner, self._task(None), "Campaign 4821 stopped syncing."
-        )
+        items = await self._run(agent_runner, self._task(None), "Campaign 4821 stopped syncing.")
 
         agent_runner._execute_sub_agent.assert_not_awaited()
         success = next(i for i in items if i.get("scheduler_status") == "success")
@@ -238,9 +233,7 @@ class TestDispatchShapes:
 
         prompt = agent_runner._execute_sub_agent.await_args[1]["prompt"]
         assert prompt == "Triage this: {}"  # passed through, not rebuilt here
-        assert next(i for i in items if i.get("scheduler_status") == "success")["agent_message"] == (
-            "Handled it."
-        )
+        assert next(i for i in items if i.get("scheduler_status") == "success")["agent_message"] == ("Handled it.")
 
     @pytest.mark.asyncio
     async def test_an_empty_dispatch_falls_back_to_the_default_instruction(self, agent_runner):
@@ -250,11 +243,7 @@ class TestDispatchShapes:
         agent_runner._execute_sub_agent = AsyncMock(return_value=("done", "completed"))
         await self._run(agent_runner, self._task(5), "")
 
-        assert (
-            agent_runner._execute_sub_agent.await_args[1]["prompt"]
-            == "Execute your configured task."
-        )
-
+        assert agent_runner._execute_sub_agent.await_args[1]["prompt"] == "Execute your configured task."
 
 
 class TestRemoteAgentContextPropagation:

--- a/packages/agent-runner/tests/test_mcp_tools.py
+++ b/packages/agent-runner/tests/test_mcp_tools.py
@@ -57,9 +57,13 @@ class Req(SimpleNamespace):
 
 @pytest.fixture(autouse=True)
 def _fresh_store():
+    import agent.mcp_tools as m
+
     reset_catalogue_store()
+    m._LISTED_AT.clear()
     yield
     reset_catalogue_store()
+    m._LISTED_AT.clear()
 
 
 @pytest.fixture
@@ -169,7 +173,7 @@ class TestStatelessListing:
 
         await tool._interceptors[0](Req(server_name="gateway", headers=None), handler)
         await tool._interceptors[0](Req(server_name="gateway", headers=None), handler)
-        assert exchanges == ["gatana"] * 3, "listing + one exchange per call"
+        assert exchanges == ["gatana"] * 4, "up-front + listing + one exchange per call"
 
     @pytest.mark.asyncio
     async def test_only_needed_servers_are_listed(self, provider, exchanges):
@@ -192,8 +196,52 @@ class TestStatelessListing:
             (tool,) = await resolver.resolve(["jira_list"])
         assert len(seen) == 1, "second run served from the process-wide store"
         assert resolver.stats == {**resolver.stats, "from_store": 1, "listed": 0}
-        assert exchanges == ["gatana"], "no exchange needed when nothing is listed"
+        assert exchanges == ["gatana"], (
+            "the exchange is memoised; still made up front so a bad user token fails the run"
+        )
         assert tool._interceptors and not (tool._connection.get("headers") or {})
+
+    @pytest.mark.asyncio
+    async def test_store_is_relisted_once_the_ttl_expired(self, provider):
+        seen: list[httpx.Request] = []
+        with _patch_http(_serve({GATEWAY_URL: ["github_search"]}, seen)):
+            await _resolver(provider).resolve(["github_search"])
+            resolver = _resolver(provider, catalogue_ttl_seconds=0)
+            (tool,) = await resolver.resolve(["github_search"])
+        assert len(seen) == 2 and resolver.stats["listed"] == 1
+        assert tool.name == "github_search"
+
+    @pytest.mark.asyncio
+    async def test_scheduler_tools_are_console_tools(self, provider, exchanges):
+        seen: list[httpx.Request] = []
+        with _patch_http(_serve({CONSOLE_URL: ["scheduler_list_jobs"]}, seen)):
+            (tool,) = await _resolver(provider).resolve(["scheduler_list_jobs"])
+        assert {str(r.url) for r in seen} == {CONSOLE_URL} and exchanges == ["agent-console"]
+        assert tool._connection["url"] == CONSOLE_URL
+
+    @pytest.mark.asyncio
+    async def test_a_failing_exchange_fails_discovery_even_on_a_store_hit(self, provider):
+        with _patch_http(_serve({GATEWAY_URL: ["github_search"]}, [])):
+            await _resolver(provider).resolve(["github_search"])
+
+        async def broken(**kw: Any) -> str:
+            raise RuntimeError("invalid_grant")
+
+        with pytest.raises(RuntimeError, match="invalid_grant"):
+            await _resolver(UserTokenProvider("user-token", broken)).resolve(["github_search"])
+
+    @pytest.mark.asyncio
+    async def test_listing_honours_the_run_mcp_timeout(self, provider):
+        captured: dict[str, Any] = {}
+        real = httpx.AsyncClient
+
+        def factory(**kw: Any) -> httpx.AsyncClient:
+            captured.update(kw)
+            return real(transport=_serve({GATEWAY_URL: ["github_search"]}, []), **kw)
+
+        with patch("agent.mcp_tools.httpx.AsyncClient", factory):
+            await _resolver(provider).resolve(["github_search"])
+        assert captured["timeout"] == 5.0 and captured["follow_redirects"] is True
 
 
 class TestSdkFallback:

--- a/packages/agent-runner/tests/test_mcp_tools.py
+++ b/packages/agent-runner/tests/test_mcp_tools.py
@@ -244,8 +244,8 @@ class TestSdkFallback:
     async def test_refusal_marks_endpoint_and_falls_back_to_sdk(self, provider, caplog):
         fallback = AsyncMock()
         with (
-            patch("agent.mcp_tools.fetch_catalogue_stateless", side_effect=StatelessListUnsupported("HTTP 400")),
-            patch("agent.mcp_tools.fetch_catalogue_mcp", fallback),
+            patch("agent_common.core.catalogue_ingest.fetch_catalogue_stateless", side_effect=StatelessListUnsupported("HTTP 400")),
+            patch("agent_common.core.catalogue_ingest.fetch_catalogue_mcp", fallback),
             patch("agent.mcp_tools.MultiServerMCPClient") as client_cls,
         ):
             from agent_common.core.tool_catalogue import build_server_catalogue, make_catalogue_tool
@@ -283,8 +283,8 @@ class TestSdkFallback:
             source="mcp",
         )
         with (
-            patch("agent.mcp_tools.fetch_catalogue_stateless", side_effect=StatelessListError("502")),
-            patch("agent.mcp_tools.fetch_catalogue_mcp", AsyncMock(return_value=cat)),
+            patch("agent_common.core.catalogue_ingest.fetch_catalogue_stateless", side_effect=StatelessListError("502")),
+            patch("agent_common.core.catalogue_ingest.fetch_catalogue_mcp", AsyncMock(return_value=cat)),
             patch("agent.mcp_tools.MultiServerMCPClient"),
         ):
             (tool,) = await _resolver(provider).resolve(["github_search"])
@@ -305,8 +305,8 @@ class TestSdkFallback:
             source="mcp",
         )
         with (
-            patch("agent.mcp_tools.fetch_catalogue_stateless", side_effect=AssertionError("must not be called")),
-            patch("agent.mcp_tools.fetch_catalogue_mcp", AsyncMock(return_value=cat)),
+            patch("agent_common.core.catalogue_ingest.fetch_catalogue_stateless", side_effect=AssertionError("must not be called")),
+            patch("agent_common.core.catalogue_ingest.fetch_catalogue_mcp", AsyncMock(return_value=cat)),
             patch("agent.mcp_tools.MultiServerMCPClient"),
         ):
             (tool,) = await _resolver(provider, stateless_list=False).resolve(["github_search"])

--- a/packages/agent-runner/tests/test_mcp_tools.py
+++ b/packages/agent-runner/tests/test_mcp_tools.py
@@ -1,0 +1,281 @@
+"""agent.mcp_tools — shared catalogue + call-time bearer tokens for scheduled runs.
+
+Mirrors ``agent-common/tests/test_dynamic_agent.py::
+test_with_a_token_provider_tools_are_token_free_and_mint_per_call`` for the runner.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from datetime import timedelta
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from agent_common.core.catalogue_ingest import StatelessListError, StatelessListUnsupported
+from agent_common.core.token_provider import UserTokenProvider
+from agent_common.core.tool_catalogue import LazyMcpTool, get_catalogue_store, reset_catalogue_store
+
+from agent.mcp_tools import McpToolResolver
+
+GATEWAY_URL = "https://gateway.example/mcp"
+CONSOLE_URL = "https://console.example/mcp"
+
+
+def _jwt(aud: str, ttl: float = 900) -> str:
+    def seg(o: dict[str, Any]) -> str:
+        return base64.urlsafe_b64encode(json.dumps(o).encode()).rstrip(b"=").decode()
+
+    return f"{seg({'alg': 'none'})}.{seg({'exp': time.time() + ttl, 'aud': aud})}.sig"
+
+
+def _tools_list_reply(names: list[str]) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "tools": [
+                {
+                    "name": n,
+                    "description": f"{n} does things",
+                    "inputSchema": {"type": "object", "properties": {"q": {"type": "string"}}},
+                }
+                for n in names
+            ]
+        },
+    }
+
+
+class Req(SimpleNamespace):
+    def override(self, **kw: Any) -> Req:
+        return Req(**{**self.__dict__, **kw})
+
+
+@pytest.fixture(autouse=True)
+def _fresh_store():
+    reset_catalogue_store()
+    yield
+    reset_catalogue_store()
+
+
+@pytest.fixture
+def exchanges() -> list[str]:
+    return []
+
+
+@pytest.fixture
+def provider(exchanges: list[str]) -> UserTokenProvider:
+    minted: dict[str, str] = {}
+
+    async def exchange(*, subject_token: str, target_client_id: str, requested_scopes: list[str]) -> str:
+        assert subject_token == "user-token"
+        exchanges.append(target_client_id)
+        return minted.setdefault(target_client_id, _jwt(target_client_id))
+
+    return UserTokenProvider("user-token", exchange)
+
+
+def _resolver(provider: UserTokenProvider, **kw: Any) -> McpToolResolver:
+    return McpToolResolver(
+        token_provider=provider,
+        gateway_url=GATEWAY_URL,
+        gateway_client_id="gatana",
+        console_mcp_url=CONSOLE_URL,
+        console_client_id="agent-console",
+        timeout=timedelta(seconds=5),
+        **kw,
+    )
+
+
+def _serve(catalogues: dict[str, list[str]], seen: list[httpx.Request]):
+    """An httpx transport answering stateless tools/list per URL with the given tool names."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        assert json.loads(request.content)["method"] == "tools/list"
+        return httpx.Response(200, json=_tools_list_reply(catalogues[str(request.url)]))
+
+    return httpx.MockTransport(handler)
+
+
+def _patch_http(transport: httpx.MockTransport):
+    real = httpx.AsyncClient
+    return patch("agent.mcp_tools.httpx.AsyncClient", lambda **kw: real(transport=transport, **kw))
+
+
+class TestStatelessListing:
+    @pytest.mark.asyncio
+    async def test_tools_are_token_free_lazy_and_mint_per_call(self, provider, exchanges):
+        """The listing carries the exchanged bearer; the tools it yields carry none and an
+        interceptor mints one per call (memoised until leeway, so one exchange per audience)."""
+        seen: list[httpx.Request] = []
+        transport = _serve({GATEWAY_URL: ["github_search", "jira_list"], CONSOLE_URL: ["console_create_skill"]}, seen)
+        with _patch_http(transport):
+            tools = {t.name: t for t in await _resolver(provider).resolve(["github_search", "console_create_skill"])}
+
+        assert set(tools) == {"github_search", "console_create_skill"}, "whitelist filtering kept"
+        assert exchanges == ["gatana", "agent-console"], "one exchange per audience, via the provider"
+        listed = {str(r.url): r.headers["Authorization"] for r in seen}
+        assert listed[GATEWAY_URL].startswith("Bearer ") and listed[CONSOLE_URL].startswith("Bearer ")
+
+        for tool in tools.values():
+            assert isinstance(tool, LazyMcpTool)
+            assert not tool.schema_decoded, "schemas decode lazily"
+            assert not (tool._connection.get("headers") or {}), "no Authorization header on the tool connection"
+            assert tool._interceptors and len(tool._interceptors) == 1
+
+        seen_headers: dict[str, str] = {}
+
+        async def handler(req: Req) -> str:
+            seen_headers.update(req.headers)
+            return "ok"
+
+        await tools["github_search"]._interceptors[0](Req(server_name="gateway", headers=None), handler)
+        assert seen_headers["Authorization"].startswith("Bearer ") and exchanges == ["gatana", "agent-console"], (
+            "memoised"
+        )
+        await tools["console_create_skill"]._interceptors[0](Req(server_name="console", headers={"X": "1"}), handler)
+        assert seen_headers["X"] == "1" and exchanges == ["gatana", "agent-console"]
+
+        assert get_catalogue_store().stateless_supported(GATEWAY_URL) is True
+        assert get_catalogue_store().stateless_supported(CONSOLE_URL) is True
+
+    @pytest.mark.asyncio
+    async def test_no_mcp_types_retained_after_discovery(self, provider):
+        transport = _serve({GATEWAY_URL: ["github_search"]}, [])
+        with _patch_http(transport):
+            (tool,) = await _resolver(provider).resolve(["github_search"])
+        import gc
+
+        import mcp.types
+
+        gc.collect()
+        assert not [o for o in gc.get_objects() if isinstance(o, mcp.types.Tool)]
+        assert tool.catalogue_entry.decode_schema()["properties"] == {"q": {"type": "string"}}
+
+    @pytest.mark.asyncio
+    async def test_leeway_above_token_lifetime_forces_one_exchange_per_call(self, provider, exchanges):
+        """The MCP_TOKEN_LEEWAY_SECONDS QA lever from #170: memoised tokens never count as fresh."""
+        provider._leeway = 100_000
+        with _patch_http(_serve({GATEWAY_URL: ["github_search"]}, [])):
+            (tool,) = await _resolver(provider).resolve(["github_search"])
+
+        async def handler(req: Req) -> str:
+            return "ok"
+
+        await tool._interceptors[0](Req(server_name="gateway", headers=None), handler)
+        await tool._interceptors[0](Req(server_name="gateway", headers=None), handler)
+        assert exchanges == ["gatana"] * 3, "listing + one exchange per call"
+
+    @pytest.mark.asyncio
+    async def test_only_needed_servers_are_listed(self, provider, exchanges):
+        seen: list[httpx.Request] = []
+        with _patch_http(_serve({GATEWAY_URL: ["github_search"]}, seen)):
+            resolver = _resolver(provider)
+            tools = await resolver.resolve(["github_search", "not_offered"])
+        assert [t.name for t in tools] == ["github_search"]
+        assert {str(r.url) for r in seen} == {GATEWAY_URL}, "console not touched"
+        assert exchanges == ["gatana"]
+        assert resolver.stats["unresolved"] == ["not_offered"]
+
+    @pytest.mark.asyncio
+    async def test_store_serves_names_without_any_listing(self, provider, exchanges):
+        seen: list[httpx.Request] = []
+        with _patch_http(_serve({GATEWAY_URL: ["github_search", "jira_list"]}, seen)):
+            await _resolver(provider).resolve(["github_search"])
+            assert len(seen) == 1
+            resolver = _resolver(provider)
+            (tool,) = await resolver.resolve(["jira_list"])
+        assert len(seen) == 1, "second run served from the process-wide store"
+        assert resolver.stats == {**resolver.stats, "from_store": 1, "listed": 0}
+        assert exchanges == ["gatana"], "no exchange needed when nothing is listed"
+        assert tool._interceptors and not (tool._connection.get("headers") or {})
+
+
+class TestSdkFallback:
+    @pytest.mark.asyncio
+    async def test_refusal_marks_endpoint_and_falls_back_to_sdk(self, provider, caplog):
+        fallback = AsyncMock()
+        with (
+            patch("agent.mcp_tools.fetch_catalogue_stateless", side_effect=StatelessListUnsupported("HTTP 400")),
+            patch("agent.mcp_tools.fetch_catalogue_mcp", fallback),
+            patch("agent.mcp_tools.MultiServerMCPClient") as client_cls,
+        ):
+            from agent_common.core.tool_catalogue import build_server_catalogue, make_catalogue_tool
+
+            fallback.return_value = build_server_catalogue(
+                "gateway",
+                [
+                    make_catalogue_tool(
+                        server_name="gateway", name="github_search", description="", input_schema={"type": "object"}
+                    )
+                ],
+                source="mcp",
+            )
+            resolver = _resolver(provider)
+            (tool,) = await resolver.resolve(["github_search"])
+            listing_connection = client_cls.call_args.args[0]["gateway"]
+
+        assert get_catalogue_store().stateless_supported(GATEWAY_URL) is False
+        assert "refuses stateless tools/list" in caplog.text
+        assert listing_connection["headers"]["Authorization"].startswith("Bearer "), "the SDK listing used the bearer"
+        assert not (tool._connection.get("headers") or {}), "the tool still has no credential"
+        assert resolver.stats["source"] == {"gateway": "mcp"}
+
+    @pytest.mark.asyncio
+    async def test_transient_error_falls_back_without_marking_endpoint(self, provider):
+        from agent_common.core.tool_catalogue import build_server_catalogue, make_catalogue_tool
+
+        cat = build_server_catalogue(
+            "gateway",
+            [
+                make_catalogue_tool(
+                    server_name="gateway", name="github_search", description="", input_schema={"type": "object"}
+                )
+            ],
+            source="mcp",
+        )
+        with (
+            patch("agent.mcp_tools.fetch_catalogue_stateless", side_effect=StatelessListError("502")),
+            patch("agent.mcp_tools.fetch_catalogue_mcp", AsyncMock(return_value=cat)),
+            patch("agent.mcp_tools.MultiServerMCPClient"),
+        ):
+            (tool,) = await _resolver(provider).resolve(["github_search"])
+        assert tool.name == "github_search"
+        assert get_catalogue_store().stateless_supported(GATEWAY_URL) is None
+
+    @pytest.mark.asyncio
+    async def test_stateless_disabled_goes_straight_to_sdk(self, provider):
+        from agent_common.core.tool_catalogue import build_server_catalogue, make_catalogue_tool
+
+        cat = build_server_catalogue(
+            "gateway",
+            [
+                make_catalogue_tool(
+                    server_name="gateway", name="github_search", description="", input_schema={"type": "object"}
+                )
+            ],
+            source="mcp",
+        )
+        with (
+            patch("agent.mcp_tools.fetch_catalogue_stateless", side_effect=AssertionError("must not be called")),
+            patch("agent.mcp_tools.fetch_catalogue_mcp", AsyncMock(return_value=cat)),
+            patch("agent.mcp_tools.MultiServerMCPClient"),
+        ):
+            (tool,) = await _resolver(provider, stateless_list=False).resolve(["github_search"])
+        assert tool.name == "github_search"
+
+
+class TestRunnerWiring:
+    def test_core_no_longer_lists_the_whole_gateway(self):
+        import inspect
+
+        import agent.core as core
+
+        src = inspect.getsource(core)
+        assert "MultiServerMCPClient" not in src and "get_tools()" not in src
+        assert "McpToolResolver(" in src and "UserTokenProvider(" in src

--- a/packages/agent-runner/tests/test_mcp_tools.py
+++ b/packages/agent-runner/tests/test_mcp_tools.py
@@ -57,13 +57,9 @@ class Req(SimpleNamespace):
 
 @pytest.fixture(autouse=True)
 def _fresh_store():
-    import agent.mcp_tools as m
-
     reset_catalogue_store()
-    m._LISTED_AT.clear()
     yield
     reset_catalogue_store()
-    m._LISTED_AT.clear()
 
 
 @pytest.fixture
@@ -187,29 +183,31 @@ class TestStatelessListing:
         assert resolver.stats["unresolved"] == ["not_offered"]
 
     @pytest.mark.asyncio
-    async def test_store_serves_names_without_any_listing(self, provider, exchanges):
+    async def test_every_run_lists_with_its_own_token_and_never_binds_another_users_view(self, provider):
+        """A Gatana profile can hide tools per user: a name another run's listing put in the
+        shared store must not be bound for a user whose own listing does not offer it."""
         seen: list[httpx.Request] = []
         with _patch_http(_serve({GATEWAY_URL: ["github_search", "jira_list"]}, seen)):
-            await _resolver(provider).resolve(["github_search"])
-            assert len(seen) == 1
-            resolver = _resolver(provider)
-            (tool,) = await resolver.resolve(["jira_list"])
-        assert len(seen) == 1, "second run served from the process-wide store"
-        assert resolver.stats == {**resolver.stats, "from_store": 1, "listed": 0}
-        assert exchanges == ["gatana"], (
-            "the exchange is memoised; still made up front so a bad user token fails the run"
-        )
-        assert tool._interceptors and not (tool._connection.get("headers") or {})
+            await _resolver(provider).resolve(["github_search", "jira_list"])
+        assert len(seen) == 1
+
+        async def exchange_b(**kw: Any) -> str:
+            return _jwt("gatana")
+
+        with _patch_http(_serve({GATEWAY_URL: ["github_search"]}, seen)):  # user B's view lacks jira_list
+            resolver = _resolver(UserTokenProvider("user-b-token", exchange_b))
+            tools = await resolver.resolve(["github_search", "jira_list"])
+        assert len(seen) == 2, "the second run listed again with its own token"
+        assert [t.name for t in tools] == ["github_search"]
+        assert resolver.stats["unresolved"] == ["jira_list"]
 
     @pytest.mark.asyncio
-    async def test_store_is_relisted_once_the_ttl_expired(self, provider):
-        seen: list[httpx.Request] = []
-        with _patch_http(_serve({GATEWAY_URL: ["github_search"]}, seen)):
-            await _resolver(provider).resolve(["github_search"])
-            resolver = _resolver(provider, catalogue_ttl_seconds=0)
-            (tool,) = await resolver.resolve(["github_search"])
-        assert len(seen) == 2 and resolver.stats["listed"] == 1
-        assert tool.name == "github_search"
+    async def test_identical_listings_share_one_interned_catalogue(self, provider):
+        with _patch_http(_serve({GATEWAY_URL: ["github_search"]}, [])):
+            (a,) = await _resolver(provider).resolve(["github_search"])
+            (b,) = await _resolver(provider).resolve(["github_search"])
+        assert a.catalogue_entry is b.catalogue_entry, "same bytes, interned once"
+        assert get_catalogue_store().interned("gateway") is not None
 
     @pytest.mark.asyncio
     async def test_scheduler_tools_are_console_tools(self, provider, exchanges):

--- a/packages/agent-runner/tests/test_mcp_tools.py
+++ b/packages/agent-runner/tests/test_mcp_tools.py
@@ -16,9 +16,14 @@ from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
-from agent_common.core.catalogue_ingest import StatelessListError, StatelessListUnsupported
+from agent_common.core.catalogue_ingest import (
+    StatelessListError,
+    StatelessListUnsupported,
+    reset_stateless_memo,
+    stateless_supported,
+)
 from agent_common.core.token_provider import UserTokenProvider
-from agent_common.core.tool_catalogue import LazyMcpTool, get_catalogue_store, reset_catalogue_store
+from agent_common.core.tool_catalogue import LazyMcpTool
 
 from agent.mcp_tools import McpToolResolver
 
@@ -56,10 +61,10 @@ class Req(SimpleNamespace):
 
 
 @pytest.fixture(autouse=True)
-def _fresh_store():
-    reset_catalogue_store()
+def _fresh_memo():
+    reset_stateless_memo()
     yield
-    reset_catalogue_store()
+    reset_stateless_memo()
 
 
 @pytest.fixture
@@ -141,8 +146,8 @@ class TestStatelessListing:
         await tools["console_create_skill"]._interceptors[0](Req(server_name="console", headers={"X": "1"}), handler)
         assert seen_headers["X"] == "1" and exchanges == ["gatana", "agent-console"]
 
-        assert get_catalogue_store().stateless_supported(GATEWAY_URL) is True
-        assert get_catalogue_store().stateless_supported(CONSOLE_URL) is True
+        assert stateless_supported(GATEWAY_URL) is True
+        assert stateless_supported(CONSOLE_URL) is True
 
     @pytest.mark.asyncio
     async def test_no_mcp_types_retained_after_discovery(self, provider):
@@ -184,8 +189,8 @@ class TestStatelessListing:
 
     @pytest.mark.asyncio
     async def test_every_run_lists_with_its_own_token_and_never_binds_another_users_view(self, provider):
-        """A Gatana profile can hide tools per user: a name another run's listing put in the
-        shared store must not be bound for a user whose own listing does not offer it."""
+        """A Gatana profile can hide tools per user: a name offered by another run's listing must
+        not be bound for a user whose own listing does not offer it."""
         seen: list[httpx.Request] = []
         with _patch_http(_serve({GATEWAY_URL: ["github_search", "jira_list"]}, seen)):
             await _resolver(provider).resolve(["github_search", "jira_list"])
@@ -202,14 +207,6 @@ class TestStatelessListing:
         assert resolver.stats["unresolved"] == ["jira_list"]
 
     @pytest.mark.asyncio
-    async def test_identical_listings_share_one_interned_catalogue(self, provider):
-        with _patch_http(_serve({GATEWAY_URL: ["github_search"]}, [])):
-            (a,) = await _resolver(provider).resolve(["github_search"])
-            (b,) = await _resolver(provider).resolve(["github_search"])
-        assert a.catalogue_entry is b.catalogue_entry, "same bytes, interned once"
-        assert get_catalogue_store().interned("gateway") is not None
-
-    @pytest.mark.asyncio
     async def test_scheduler_tools_are_console_tools(self, provider, exchanges):
         seen: list[httpx.Request] = []
         with _patch_http(_serve({CONSOLE_URL: ["scheduler_list_jobs"]}, seen)):
@@ -218,7 +215,7 @@ class TestStatelessListing:
         assert tool._connection["url"] == CONSOLE_URL
 
     @pytest.mark.asyncio
-    async def test_a_failing_exchange_fails_discovery_even_on_a_store_hit(self, provider):
+    async def test_a_failing_exchange_fails_discovery_even_after_an_earlier_listing(self, provider):
         with _patch_http(_serve({GATEWAY_URL: ["github_search"]}, [])):
             await _resolver(provider).resolve(["github_search"])
 
@@ -266,7 +263,7 @@ class TestSdkFallback:
             (tool,) = await resolver.resolve(["github_search"])
             listing_connection = client_cls.call_args.args[0]["gateway"]
 
-        assert get_catalogue_store().stateless_supported(GATEWAY_URL) is False
+        assert stateless_supported(GATEWAY_URL) is False
         assert "refuses stateless tools/list" in caplog.text
         assert listing_connection["headers"]["Authorization"].startswith("Bearer "), "the SDK listing used the bearer"
         assert not (tool._connection.get("headers") or {}), "the tool still has no credential"
@@ -292,7 +289,7 @@ class TestSdkFallback:
         ):
             (tool,) = await _resolver(provider).resolve(["github_search"])
         assert tool.name == "github_search"
-        assert get_catalogue_store().stateless_supported(GATEWAY_URL) is None
+        assert stateless_supported(GATEWAY_URL) is None
 
     @pytest.mark.asyncio
     async def test_stateless_disabled_goes_straight_to_sdk(self, provider):

--- a/packages/orchestrator-agent/app/core/discovery.py
+++ b/packages/orchestrator-agent/app/core/discovery.py
@@ -35,9 +35,11 @@ from agent_common.core.catalogue_ingest import (
     StatelessListUnsupported,
     fetch_catalogue_mcp,
     fetch_catalogue_stateless,
+    set_stateless_supported,
+    stateless_supported,
 )
 from agent_common.core.token_provider import UserTokenProvider, bearer_interceptor
-from agent_common.core.tool_catalogue import CatalogueStore, ServerCatalogue, build_lazy_tools, get_catalogue_store
+from agent_common.core.tool_catalogue import ServerCatalogue, build_lazy_tools
 
 logger = logging.getLogger(__name__)
 
@@ -228,11 +230,6 @@ class ToolDiscoveryService:
         self.config = config
         self.oauth2_client = oauth2_client
 
-    @property
-    def catalogue_store(self) -> CatalogueStore:
-        """Process-wide catalogue store (bytes shared across users; capability memo)."""
-        return get_catalogue_store()
-
     def _gateway_base_url(self) -> str:
         # Strip the trailing slash first: removesuffix("/mcp") is a no-op on ".../mcp/".
         return self.config.MCP_GATEWAY_URL.rstrip("/").removesuffix("/mcp")
@@ -313,27 +310,25 @@ class ToolDiscoveryService:
         connection), so the result is the same per-user listing; the stateless path just
         skips the SDK handshake and the pydantic parse. Whether an endpoint serves a
         stateless request is probed once per URL: a rejection marks it unsupported for the
-        process lifetime; any other failure falls back for this server only. Whatever the
-        path, the result is interned in the process-wide store so identical catalogues
-        share bytes across users.
+        process lifetime; any other failure falls back for this server only. The catalogue
+        is this user's view (the gateway lists per bearer, profiles filter per user) and is
+        owned by this user's discovery-cache entry — never shared with another user's.
         """
-        store = self.catalogue_store
         url = connection["url"]
-        if http_client is not None and self.config.MCP_CATALOGUE_STATELESS_LIST and store.stateless_supported(url) is not False:
+        if http_client is not None and self.config.MCP_CATALOGUE_STATELESS_LIST and stateless_supported(url) is not False:
             try:
                 catalogue = await fetch_catalogue_stateless(
                     http_client, url=url, headers=connection.get("headers"), server_slug=server_name
                 )
             except StatelessListUnsupported as e:
-                store.set_stateless_supported(url, False)
+                set_stateless_supported(url, False)
                 logger.warning(f"MCP endpoint refuses stateless tools/list — using SDK session for '{server_name}' ({e})")
             except StatelessListError as e:
                 logger.warning(f"Stateless tools/list failed for '{server_name}', falling back to SDK session: {e}")
             else:
-                store.set_stateless_supported(url, True)
-                return store.intern(catalogue)
-        catalogue = await fetch_catalogue_mcp(lambda: client.session(server_name), server_slug=server_name)
-        return store.intern(catalogue)
+                set_stateless_supported(url, True)
+                return catalogue
+        return await fetch_catalogue_mcp(lambda: client.session(server_name), server_slug=server_name)
 
     async def _get_catalogue_with_retry(
         self,

--- a/packages/orchestrator-agent/app/core/discovery.py
+++ b/packages/orchestrator-agent/app/core/discovery.py
@@ -29,15 +29,7 @@ from ringier_a2a_sdk.utils.mcp_errors import (
 from ringier_a2a_sdk.utils.mcp_progress import on_mcp_progress
 
 from ..models.config import AgentSettings
-from agent_common.core.catalogue_ingest import (
-    STATELESS_TIMEOUT_S,
-    StatelessListError,
-    StatelessListUnsupported,
-    fetch_catalogue_mcp,
-    fetch_catalogue_stateless,
-    set_stateless_supported,
-    stateless_supported,
-)
+from agent_common.core.catalogue_ingest import STATELESS_TIMEOUT_S, fetch_catalogue
 from agent_common.core.token_provider import UserTokenProvider, bearer_interceptor
 from agent_common.core.tool_catalogue import ServerCatalogue, build_lazy_tools
 
@@ -304,31 +296,20 @@ class ToolDiscoveryService:
         *,
         http_client: httpx.AsyncClient | None,
     ) -> ServerCatalogue:
-        """Fetch one server's catalogue: stateless ``tools/list`` POST → SDK session.
+        """Fetch one server's catalogue (``agent_common.core.catalogue_ingest.fetch_catalogue``).
 
-        Both paths hit the same MCP URL with the same bearer token (the server's
-        connection), so the result is the same per-user listing; the stateless path just
-        skips the SDK handshake and the pydantic parse. Whether an endpoint serves a
-        stateless request is probed once per URL: a rejection marks it unsupported for the
-        process lifetime; any other failure falls back for this server only. The catalogue
-        is this user's view (the gateway lists per bearer, profiles filter per user) and is
-        owned by this user's discovery-cache entry — never shared with another user's.
+        The catalogue is this user's view (the gateway lists per bearer, profiles filter per
+        user) and is owned by this user's discovery-cache entry — never shared with another
+        user's.
         """
-        url = connection["url"]
-        if http_client is not None and self.config.MCP_CATALOGUE_STATELESS_LIST and stateless_supported(url) is not False:
-            try:
-                catalogue = await fetch_catalogue_stateless(
-                    http_client, url=url, headers=connection.get("headers"), server_slug=server_name
-                )
-            except StatelessListUnsupported as e:
-                set_stateless_supported(url, False)
-                logger.warning(f"MCP endpoint refuses stateless tools/list — using SDK session for '{server_name}' ({e})")
-            except StatelessListError as e:
-                logger.warning(f"Stateless tools/list failed for '{server_name}', falling back to SDK session: {e}")
-            else:
-                set_stateless_supported(url, True)
-                return catalogue
-        return await fetch_catalogue_mcp(lambda: client.session(server_name), server_slug=server_name)
+        return await fetch_catalogue(
+            server_slug=server_name,
+            url=connection["url"],
+            headers=connection.get("headers"),
+            http_client=http_client,
+            session_factory=lambda: client.session(server_name),
+            stateless=self.config.MCP_CATALOGUE_STATELESS_LIST,
+        )
 
     async def _get_catalogue_with_retry(
         self,

--- a/packages/orchestrator-agent/tests/test_catalogue_discovery.py
+++ b/packages/orchestrator-agent/tests/test_catalogue_discovery.py
@@ -89,7 +89,7 @@ class TestDiscoveryIngestPaths:
     @pytest.mark.asyncio
     async def test_flag_off_uses_sdk_session_only(self):
         list_calls: list[str] = []
-        with patch("app.core.discovery.fetch_catalogue_stateless", new_callable=AsyncMock) as fast:
+        with patch("agent_common.core.catalogue_ingest.fetch_catalogue_stateless", new_callable=AsyncMock) as fast:
             tools = await _discover(_settings(stateless=False), _mcp_client(list_calls), [{"slug": "s1"}])
         fast.assert_not_awaited()
         assert list_calls == ["s1"]
@@ -100,7 +100,7 @@ class TestDiscoveryIngestPaths:
         """Same URL and token the SDK would use → same per-user listing, no handshake."""
         list_calls: list[str] = []
         with patch(
-            "app.core.discovery.fetch_catalogue_stateless", new_callable=AsyncMock, side_effect=lambda *a, **kw: _fast_catalogue(kw["server_slug"])
+            "agent_common.core.catalogue_ingest.fetch_catalogue_stateless", new_callable=AsyncMock, side_effect=lambda *a, **kw: _fast_catalogue(kw["server_slug"])
         ) as fast:
             tools = await _discover(_settings(stateless=True), _mcp_client(list_calls), [{"slug": "s1"}, {"slug": "s2"}])
         assert list_calls == [], "no SDK session on the fast path"
@@ -117,7 +117,7 @@ class TestDiscoveryIngestPaths:
         never shared between users' tools, even when the two views happen to be identical."""
         list_calls: list[str] = []
         with patch(
-            "app.core.discovery.fetch_catalogue_stateless", new_callable=AsyncMock, side_effect=lambda *a, **kw: _fast_catalogue(kw["server_slug"])
+            "agent_common.core.catalogue_ingest.fetch_catalogue_stateless", new_callable=AsyncMock, side_effect=lambda *a, **kw: _fast_catalogue(kw["server_slug"])
         ) as fast:
             a = await _discover(_settings(stateless=True), _mcp_client(list_calls), [{"slug": "s1"}])
             b = await _discover(_settings(stateless=True), _mcp_client(list_calls), [{"slug": "s1"}])
@@ -130,7 +130,7 @@ class TestDiscoveryIngestPaths:
     async def test_refusal_falls_back_and_is_remembered_per_url(self):
         list_calls: list[str] = []
         with patch(
-            "app.core.discovery.fetch_catalogue_stateless", new_callable=AsyncMock, side_effect=StatelessListUnsupported("400 no session")
+            "agent_common.core.catalogue_ingest.fetch_catalogue_stateless", new_callable=AsyncMock, side_effect=StatelessListUnsupported("400 no session")
         ) as fast:
             tools = await _discover(_settings(stateless=True), _mcp_client(list_calls), [{"slug": "s1"}])
             await _discover(_settings(stateless=True), _mcp_client(list_calls), [{"slug": "s1"}])
@@ -147,7 +147,7 @@ class TestDiscoveryIngestPaths:
                 raise StatelessListError("502")
             return _fast_catalogue(server_slug)
 
-        with patch("app.core.discovery.fetch_catalogue_stateless", side_effect=fast):
+        with patch("agent_common.core.catalogue_ingest.fetch_catalogue_stateless", side_effect=fast):
             tools = await _discover(_settings(stateless=True), _mcp_client(list_calls), [{"slug": "s1"}, {"slug": "s2"}])
         assert list_calls == ["s1"]
         assert sorted(t.name for t in tools) == ["fast_s2", "mcp_s1"]
@@ -161,7 +161,7 @@ class TestDiscoveryIngestPaths:
             seen["follow_redirects"] = client.follow_redirects
             return _fast_catalogue(server_slug)
 
-        with patch("app.core.discovery.fetch_catalogue_stateless", side_effect=fast):
+        with patch("agent_common.core.catalogue_ingest.fetch_catalogue_stateless", side_effect=fast):
             await _discover(_settings(stateless=True), _mcp_client([]), [{"slug": "s1"}])
         assert seen["follow_redirects"] is True
 
@@ -172,7 +172,7 @@ class TestDiscoveryIngestPaths:
         config.CONSOLE_BACKEND_URL = "https://console"
         config.CONSOLE_BACKEND_CLIENT_ID = "agent-console"
         with patch(
-            "app.core.discovery.fetch_catalogue_stateless", new_callable=AsyncMock, side_effect=lambda *a, **kw: _fast_catalogue(kw["server_slug"])
+            "agent_common.core.catalogue_ingest.fetch_catalogue_stateless", new_callable=AsyncMock, side_effect=lambda *a, **kw: _fast_catalogue(kw["server_slug"])
         ) as fast:
             tools = await _discover(config, _mcp_client(list_calls), [{"slug": "s1"}])
         assert sorted(c.kwargs["server_slug"] for c in fast.await_args_list) == ["console", "s1"]

--- a/packages/orchestrator-agent/tests/test_catalogue_discovery.py
+++ b/packages/orchestrator-agent/tests/test_catalogue_discovery.py
@@ -12,13 +12,13 @@ from mcp.types import ListToolsResult, Tool as MCPTool
 from agent_common.core.catalogue_ingest import (
     StatelessListError,
     StatelessListUnsupported,
+    reset_stateless_memo,
 )
 from app.core.discovery import ToolDiscoveryService
 from agent_common.core.tool_catalogue import (
     LazyMcpTool,
     build_server_catalogue,
     make_catalogue_tool,
-    reset_catalogue_store,
 )
 from app.models.config import AgentSettings
 
@@ -84,7 +84,7 @@ async def _discover(config: Mock, client: Mock, servers: list[dict]) -> list[Bas
 
 class TestDiscoveryIngestPaths:
     def setup_method(self):
-        reset_catalogue_store()
+        reset_stateless_memo()
 
     @pytest.mark.asyncio
     async def test_flag_off_uses_sdk_session_only(self):
@@ -112,7 +112,9 @@ class TestDiscoveryIngestPaths:
         assert all(isinstance(t, LazyMcpTool) and not t.schema_decoded for t in tools)
 
     @pytest.mark.asyncio
-    async def test_identical_catalogues_share_bytes_across_users(self):
+    async def test_each_user_owns_their_own_listing(self):
+        """A listing is a per-user view (profiles filter tools per user): fetched per user and
+        never shared between users' tools, even when the two views happen to be identical."""
         list_calls: list[str] = []
         with patch(
             "app.core.discovery.fetch_catalogue_stateless", new_callable=AsyncMock, side_effect=lambda *a, **kw: _fast_catalogue(kw["server_slug"])
@@ -120,7 +122,8 @@ class TestDiscoveryIngestPaths:
             a = await _discover(_settings(stateless=True), _mcp_client(list_calls), [{"slug": "s1"}])
             b = await _discover(_settings(stateless=True), _mcp_client(list_calls), [{"slug": "s1"}])
         assert fast.await_count == 2, "per-user listing: fetched for each user"
-        assert a[0].catalogue_entry is b[0].catalogue_entry, "…but identical bytes are interned once"
+        assert a[0].catalogue_entry is not b[0].catalogue_entry, "no process-wide catalogue registry"
+        assert a[0].catalogue_entry.schema_bytes == b[0].catalogue_entry.schema_bytes
         assert a[0] is not b[0], "per-user tool objects (they carry the user's connection)"
 
     @pytest.mark.asyncio

--- a/packages/orchestrator-agent/tests/test_discovery.py
+++ b/packages/orchestrator-agent/tests/test_discovery.py
@@ -11,7 +11,8 @@ from mcp.types import ListToolsResult, Tool as MCPTool
 import app.core.discovery as discovery_module
 from app.core.discovery import AgentDiscoveryService, ToolDiscoveryService
 from app.models.config import AgentSettings
-from agent_common.core.tool_catalogue import LazyMcpTool, reset_catalogue_store
+from agent_common.core.catalogue_ingest import reset_stateless_memo
+from agent_common.core.tool_catalogue import LazyMcpTool
 
 
 def _mcp_tool(name: str, description: str = "") -> MCPTool:
@@ -265,7 +266,7 @@ class TestToolDiscoveryService:
         oauth2_client.exchange_token = AsyncMock(return_value="mcp_token")
         service = ToolDiscoveryService(config, oauth2_client)
 
-        reset_catalogue_store()
+        reset_stateless_memo()
         tools = [_mcp_tool("allowed_tool", "This tool is allowed"), _mcp_tool("blocked_tool", "This tool is blocked")]
 
         with patch("app.core.discovery.MultiServerMCPClient") as mock_client:
@@ -332,7 +333,7 @@ class TestToolDiscoveryService:
             await asyncio.sleep(0)
             in_flight -= 1
 
-        reset_catalogue_store()
+        reset_stateless_memo()
         with patch("app.core.discovery.MultiServerMCPClient") as mock_client:
             mock_client.return_value = _mock_mcp_client(on_list=on_list)
             service.fetch_available_servers = AsyncMock(return_value=servers)


### PR DESCRIPTION
closes ringier-data/nannos#172

## What

`agent-runner` discovered MCP tools the pre-#170 way: two token exchanges baked into `StreamableHttpConnection.headers`, then `MultiServerMCPClient.get_tools()` over the **whole gateway** on every scheduled run. This gives a run the same shape as an orchestrator sub-agent, reusing what `agent-common` provides since #170:

- **Catalogue** — new `agent/mcp_tools.py::McpToolResolver`. Each server the whitelist needs is listed via `fetch_catalogue_stateless` (JSON-RPC `tools/list`, no handshake, no pydantic on the catalogue path) with `fetch_catalogue_mcp` as fallback. Endpoint refusal (400/404/405/406) is memoised per URL; a transient failure falls back for that listing only, and the fallback is logged. Every run lists with **its own token** — a Gatana profile can hide tools per user, so a listing is a per-user view and is never served to another run.
- **Tools** — every tool is a `LazyMcpTool`; schemas decode only for the tools the run binds/calls. No `mcp.types.Tool` survives discovery.
- **Credentials** — a per-run `UserTokenProvider` owns the user's token. Tool connections carry **no** `Authorization` header; `bearer_interceptor` mints one per call, re-exchanged within `MCP_TOKEN_LEEWAY_SECONDS` of `exp`, so an exchanged token expiring during a long run is re-minted instead of failing.
- The runner's whitelist filtering is unchanged (`console_*` → console MCP, everything else → gateway). Only servers the whitelist actually needs are listed/exchanged.

New env (all optional, documented in `.env.template`): `MCP_GATEWAY_CLIENT_ID` (default `gatana`), `MCP_CATALOGUE_STATELESS_LIST` (default `true`), `MCP_TOKEN_LEEWAY_SECONDS` (default 90 — set to `100000` for the one-exchange-per-call QA lever from #170).

Note on the issue text: the runner never had a `_validate_tool_schema` step of its own (that lives in `agent_common.agents.dynamic_agent`); `build_sub_agent_graph` is untouched, so the PTC `eval` self-correction still reaches the runner as before.

## Also in this PR: `CatalogueStore` removed (agent-common, orchestrator)

Reviewing the runner surfaced that `CatalogueStore` was unsound for the same reason: it kept **one catalogue per server** (whoever listed last) with no user dimension, and `dynamic_agent._resolve_catalogue_tools` resolved whitelisted names from it — so a sub-agent could be handed a tool its user's own listing does not offer. Its other job (sharing identical catalogues' bytes across users) is worth little now that the stateless path removed the parse amplification: ~200 KB of schema bytes per 500-tool view, held at most 60 s by the per-user discovery cache.

- `CatalogueStore` / `get_catalogue_store` / `reset_catalogue_store` deleted. The per-URL "serves stateless `tools/list`" memo — the only legitimately process-wide fact — moves to `catalogue_ingest` (`stateless_supported` / `set_stateless_supported` / `reset_stateless_memo`).
- `dynamic_agent`: `pre_resolved_tools` (the orchestrator's per-user discovery cache, which already carries the schemas) is the only source of names without a listing; anything else is listed on the sub-agent's own connection with the user's token — console names on `console`, gateway names on the gateway connection.
- Orchestrator `discovery._ingest_server` and the runner keep the catalogue they fetched instead of interning it.
- The "stateless `tools/list` → per-URL memo → SDK session" strategy both of them carried now lives once as `catalogue_ingest.fetch_catalogue()`; callers pass URL, bearer headers, httpx client and session factory and read `catalogue.source`.
- Tests flipped from "served from the store" to "listed per user" (agent-common 766 pass, orchestrator 684 pass).

## Before / after

Local fake FastMCP gateway (`stateless_http=True`, 500 tools with gateway-shaped schemas), whitelist of 5 tools, all imports hoisted out of the measured window, 3 runs each — loopback, so the network share of the SDK handshake and the 2 eager exchanges is understated:

| path | discovery | RSS after discovery | tracemalloc peak / retained | `mcp.types.Tool` alive after |
|---|---|---|---|---|
| **before** — `get_tools()` whole gateway | ~135 ms | +36 MB | 8.0 / 5.7 MB | **500** |
| **after** — stateless `tools/list` | **~100 ms** | **+8 MB** | 2.4 / 2.3 MB | 0 |
| after — SDK fallback path | ~175 ms | +39 MB | 8.1 / 5.1 MB | 0 |

Every run lists (per-user view); a name hidden from a user by their profile is never bound from another user's listing (`test_every_run_lists_with_its_own_token_and_never_binds_another_users_view`).

## Tests

`tests/test_mcp_tools.py` (12 new; 34 total pass, `ruff` clean, mypy error count 39 vs 41 on `main` — all pre-existing `import-untyped` for `agent_common`):
- runner mirror of `agent-common/tests/test_dynamic_agent.py::test_with_a_token_provider_tools_are_token_free_and_mint_per_call`: listing carries the bearer, tools carry none, one exchange per audience, interceptor memoised
- no `mcp.types.Tool` objects alive after discovery; schema decodes lazily on demand
- `MCP_TOKEN_LEEWAY_SECONDS` above token lifetime ⇒ one exchange per call
- only needed servers are listed; unresolved names are logged and skipped
- per-user views: a second user's run re-lists and does not get names their own listing lacks
- `scheduler_*` routed to the console MCP; a failing exchange fails discovery; listing honours `MCP_TIMEOUT_SECONDS`
- stateless refusal ⇒ endpoint memoised unsupported, SDK listing used the bearer, tool still token-free; transient error ⇒ fallback without memo; `MCP_CATALOGUE_STATELESS_LIST=false` ⇒ straight to SDK
- `agent.core` no longer references `MultiServerMCPClient`/`get_tools()`

Not run locally: a real run against the Gatana gateway (needs cluster credentials) — the stateless-vs-fallback decision against the real endpoint will show in the `Resolved N/M MCP tools … (gateway=stateless|mcp)` log line on first deploy.

## Checklist
- [x] I have performed a self-review of my code
- [x] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨 — no; defaults preserve behaviour, only the eager exchange goes away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




