### PR TITLE
fix(agent-common): sanitize tool names at ingest so PTC can see them

### DIFF
--- a/packages/agent-common/agent_common/core/tool_catalogue.py
+++ b/packages/agent-common/agent_common/core/tool_catalogue.py
@@ -24,6 +24,15 @@ another — so there is deliberately no process-wide catalogue registry: each us
 own their catalogue's bytes for as long as the per-user discovery cache holds them, and
 nothing may answer *which tools exist* except a listing made with that user's own token.
 
+Names have two spaces, and the split lives here. A tool is **exposed** under
+``sanitize_tool_name(wire_name)`` — the wire name with characters that PTC's
+``tools.<camelCase(name)>`` namespace cannot express folded away — and is **called** by
+its wire name (``CatalogueTool.call_name``). Ingest is the only place that sanitises a
+tool name, and the config boundary where a stored whitelist enters a process (orchestrator
+``registry``, agent-runner's job config) is the only place that sanitises a whitelist;
+everything in between — binding, PTC exposure, whitelist filtering, catalogue lookups —
+compares exposed names and nothing else.
+
 Dispatch delegates to ``langchain_mcp_adapters`` on first invocation: the one tool
 being called is rebuilt as an ``mcp.types.Tool`` (a single small pydantic object) and
 converted with ``convert_mcp_tool_to_langchain_tool`` so interceptors, progress
@@ -35,6 +44,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import re
 import time
 from collections.abc import Awaitable, Callable, Iterable, Mapping
 from dataclasses import dataclass, field
@@ -56,6 +66,36 @@ def canonical_bytes(value: Any) -> bytes:
     Canonical so identical schemas hash identically regardless of ingest source.
     """
     return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+# Characters a tool name may keep when it is exposed to an agent; everything else is
+# folded to "_" at ingest. A PTC agent reaches its tools as ``tools.<camelCase(name)>``
+# and ``langchain_quickjs`` SKIPS any tool whose camelCase name is not a valid JS
+# identifier — its only word separators are "-" and "_". The gateway serves dotted names
+# (``authrion-atp-v1_okrs.v1.search_okrs``), which camelCase to
+# ``authrionAtpV1Okrs.v1.searchOkrs``: not an identifier, so all 29 tools of that server
+# were in the catalogue yet invisible to the orchestrator and to every sub-agent, which
+# then reported them as non-existent (2026-08-28). Sanitising here — the one seam every
+# ingest path goes through — keeps the catalogue, the model-facing name and the PTC
+# namespace in agreement; the original name is kept as ``wire_name`` for dispatch.
+_UNSAFE_NAME_CHARS = re.compile(r"[^A-Za-z0-9_-]")
+
+
+def sanitize_tool_name(name: str) -> str:
+    """The name a tool is exposed under: its wire name with PTC-hostile characters folded to "_".
+
+    Idempotent, so a name that is already exposed-form passes through untouched — which is
+    what lets the config boundaries apply it to every stored whitelist blindly: a setting
+    saved before this existed still matches the tool it enabled.
+    """
+    safe = _UNSAFE_NAME_CHARS.sub("_", name)
+    # A JS identifier may not start with a digit, and a leading "-" survives camelCasing
+    # only when a lowercase letter follows. Neither occurs in a gateway name today.
+    if safe[:1].isdigit():
+        safe = f"_{safe}"
+    elif safe.startswith("-"):
+        safe = f"_{safe[1:]}"
+    return safe
 
 
 @dataclass(frozen=True, slots=True)
@@ -81,10 +121,19 @@ class CatalogueTool:
     output_schema_bytes: bytes | None = None
     annotations: dict[str, Any] | None = None
     meta: dict[str, Any] | None = None
+    # The upstream name, set only when it differs from the exposed one (see
+    # ``sanitize_tool_name``). Dispatch must use it: the server knows the tool by the name
+    # it listed, not by the name we show the model.
+    wire_name: str | None = None
 
     @property
     def name(self) -> str:
         return self.card.name
+
+    @property
+    def call_name(self) -> str:
+        """The name to call on the MCP server — the upstream one when it was sanitised."""
+        return self.wire_name or self.card.name
 
     def decode_schema(self) -> dict[str, Any]:
         schema = json.loads(self.schema_bytes)
@@ -137,8 +186,11 @@ def make_catalogue_tool(
     schema: Mapping[str, Any] = (
         input_schema if isinstance(input_schema, Mapping) else {"type": "object", "properties": {}}
     )
+    exposed_name = sanitize_tool_name(name)
+    if exposed_name != name:
+        logger.debug("Exposing MCP tool '%s' of '%s' as '%s'", name, server_name, exposed_name)
     card = ToolCard(
-        name=name,
+        name=exposed_name,
         description=description or "",
         param_names=_param_names(schema),
         server_name=server_name,
@@ -149,6 +201,7 @@ def make_catalogue_tool(
         output_schema_bytes=canonical_bytes(output_schema) if isinstance(output_schema, Mapping) else None,
         annotations=dict(annotations) if isinstance(annotations, Mapping) and annotations else None,
         meta=dict(meta) if isinstance(meta, Mapping) and meta else None,
+        wire_name=name if exposed_name != name else None,
     )
 
 
@@ -176,10 +229,15 @@ def build_server_catalogue(
     by_name: dict[str, CatalogueTool] = {}
     for tool in tools:
         if tool.name in by_name:
+            # Two upstream names can collide once sanitised ("a.b" and "a_b"): say which
+            # wire names were involved, or the drop looks like the server listing a tool
+            # twice.
             logger.warning(
-                "Duplicate tool name '%s' on server '%s' — keeping the first",
+                "Duplicate tool name '%s' on server '%s' — keeping the first (wire names: '%s', '%s')",
                 tool.name,
                 server_name,
+                by_name[tool.name].call_name,
+                tool.call_name,
             )
             continue
         by_name[tool.name] = tool
@@ -268,7 +326,8 @@ class LazyMcpTool(BaseTool):
             if not isinstance(input_schema, dict):  # pragma: no cover — always a dict for catalogue tools
                 input_schema = entry.decode_schema()
             mcp_tool = MCPTool(
-                name=entry.name,
+                # The server's own name for the tool; ``self.name`` may be the sanitised one.
+                name=entry.call_name,
                 description=entry.card.description or None,
                 inputSchema=input_schema,
                 annotations=entry.annotations,  # type: ignore[arg-type]

--- a/packages/agent-common/tests/test_tool_catalogue.py
+++ b/packages/agent-common/tests/test_tool_catalogue.py
@@ -26,6 +26,7 @@ from agent_common.core.tool_catalogue import (
     build_server_catalogue,
     compute_interface_hash,
     make_catalogue_tool,
+    sanitize_tool_name,
 )
 
 SCHEMA = {
@@ -87,6 +88,65 @@ class TestRepresentation:
         ]
         cat = build_server_catalogue("s", tools, source="stateless")
         assert cat.tools["dup"].card.description == "first"
+
+
+class TestNameSanitisation:
+    """A tool's exposed name must survive PTC's ``tools.<camelCase(name)>`` namespace."""
+
+    @pytest.mark.parametrize(
+        ("wire", "exposed"),
+        [
+            ("authrion-atp-v1_okrs.v1.search_okrs", "authrion-atp-v1_okrs_v1_search_okrs"),
+            ("plain_tool", "plain_tool"),
+            ("kebab-tool", "kebab-tool"),
+            ("has space", "has_space"),
+            ("2fa_check", "_2fa_check"),
+            ("-leading", "_leading"),
+        ],
+    )
+    def test_exposed_name_folds_ptc_hostile_characters(self, wire, exposed):
+        assert sanitize_tool_name(wire) == exposed
+        assert sanitize_tool_name(exposed) == exposed, "idempotent"
+
+    def test_sanitised_names_are_valid_js_identifiers_after_camel_casing(self):
+        from langchain_quickjs._prompt import is_valid_ptc_tool_name
+
+        for wire in ("authrion-atp-v1_okrs.v1.search_okrs", "a.b.c", "2fa_check", "-leading", "weird!name"):
+            assert is_valid_ptc_tool_name(sanitize_tool_name(wire)), wire
+
+    def test_catalogue_exposes_the_sanitised_name_and_keeps_the_wire_name(self):
+        cat = _catalogue("okrs.v1.search_okrs")
+        (entry,) = cat.tools.values()
+        assert entry.name == "okrs_v1_search_okrs"
+        assert entry.call_name == "okrs.v1.search_okrs"
+        assert "okrs_v1_search_okrs" in cat.tools
+
+    def test_unsanitised_name_keeps_no_wire_name(self):
+        (entry,) = _catalogue("plain").tools.values()
+        assert entry.wire_name is None and entry.call_name == "plain"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_calls_the_server_by_its_wire_name(self):
+        (tool,) = build_lazy_tools(_catalogue("okrs.v1.search_okrs"), connection={})
+        seen: dict = {}
+
+        async def fake_coroutine(runtime=None, **arguments):
+            return ("ok", None)
+
+        def fake_convert(session, mcp_tool, **kwargs):
+            seen["mcp_tool"] = mcp_tool
+            delegate = Mock()
+            delegate.coroutine = fake_coroutine
+            return delegate
+
+        with patch(
+            "langchain_mcp_adapters.tools.convert_mcp_tool_to_langchain_tool",
+            side_effect=fake_convert,
+        ):
+            await tool.ainvoke({"q": "hi"})
+
+        assert tool.name == "okrs_v1_search_okrs", "the model sees the sanitised name"
+        assert seen["mcp_tool"].name == "okrs.v1.search_okrs", "the server is called by its own name"
 
 
 class TestLazyMcpTool:

--- a/packages/agent-runner/agent/core.py
+++ b/packages/agent-runner/agent/core.py
@@ -50,6 +50,7 @@ from agent_common.core.model_factory import (
 )
 from agent_common.core.stream_watchdog import watch_stream_with_resume
 from agent_common.core.token_provider import DEFAULT_LEEWAY_S, UserTokenProvider
+from agent_common.core.tool_catalogue import sanitize_tool_name
 from google.protobuf.json_format import MessageToDict, ParseDict
 from google.protobuf.struct_pb2 import Struct
 from object_storage import get_object_storage_service
@@ -795,7 +796,11 @@ class AgentRunner(BaseAgent):
             "sub_agent_config_version_id": cfg_version.get("id"),
             "description": cfg_version.get("description", ""),
             "system_prompt": cfg_version.get("system_prompt", ""),
-            "mcp_tools": cfg_version.get("mcp_tools") or [],
+            # Sanitised here, the boundary where the job's whitelist enters the run: a
+            # stored name may be a tool's wire name, while the catalogue exposes it under
+            # its sanitised one (see ``sanitize_tool_name``). Everything downstream then
+            # compares exposed names only.
+            "mcp_tools": [sanitize_tool_name(n) for n in (cfg_version.get("mcp_tools") or [])],
             # Prefer effective_model: the backend (annotate_models) resolves a tier-bound config
             # (model is None, model_tier set) to its current alias here, so a tier-bound sub-agent
             # honors its tier instead of silently falling back to the standard default.

--- a/packages/agent-runner/tests/test_agent_runner_security.py
+++ b/packages/agent-runner/tests/test_agent_runner_security.py
@@ -25,6 +25,37 @@ def agent_runner():
         return runner
 
 
+class TestFetchSubAgentConfig:
+    """The job's stored tool whitelist enters the run here, in the catalogue's name space."""
+
+    @pytest.mark.asyncio
+    async def test_whitelist_is_sanitised_to_exposed_tool_names(self, agent_runner):
+        """A stored wire name (dots and all) arrives as the name the catalogue exposes it under."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "type": "automated",
+            "name": "okr-watch",
+            "config_version": {
+                "id": 7,
+                "system_prompt": "You read OKRs.",
+                "model": "claude-sonnet-4.6",
+                "mcp_tools": ["authrion-atp-v1_okrs.v1.search_okrs", "gcal_list_events"],
+            },
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            cfg = await agent_runner._fetch_sub_agent_config(7, "my-token")
+
+        assert cfg["mcp_tools"] == ["authrion-atp-v1_okrs_v1_search_okrs", "gcal_list_events"]
+
+
 class TestFetchUserIdFromBackend:
     """Security: user_id must come from verified backend response."""
 

--- a/packages/orchestrator-agent/app/core/registry.py
+++ b/packages/orchestrator-agent/app/core/registry.py
@@ -8,12 +8,22 @@ from typing import Any
 
 import httpx
 from agent_common.a2a.models import LocalFoundrySubAgentConfig, LocalLangGraphSubAgentConfig, LocalSubAgentConfig
+from agent_common.core.tool_catalogue import sanitize_tool_name
 from agent_common.models.base import ThinkingLevel
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from .prompt_placeholders import resolve_prompt_placeholders
 
 logger = logging.getLogger(__name__)
+
+# A stored whitelist names tools as console-backend's raw ``tools/list`` did, which may
+# differ from the name the catalogue exposes them under (see ``sanitize_tool_name``).
+# Normalising the two models that carry a whitelist into this process — user settings and
+# a sub-agent's config version — is what lets every consumer downstream (orchestrator
+# binding, PTC exposure, sub-agent discovery) compare exposed names and nothing else.
+# Assigning it in each model is what registers it: pydantic collects validators from the
+# class namespace, so the attribute is never read by name but must exist.
+_sanitize_whitelist = field_validator("mcp_tools")(lambda cls, v: [sanitize_tool_name(n) for n in v] if v else v)
 
 # System prompt addendum for playground mode
 PLAYGROUND_MODE_ADDENDUM = """
@@ -45,6 +55,8 @@ class UserSettings(BaseModel):
     thinking_level: ThinkingLevel | None = None
     tool_bypass_rules: dict[str, Any] = Field(default_factory=dict)
 
+    _sanitize_mcp_tools = _sanitize_whitelist
+
     class Config:
         json_encoders = {datetime: lambda v: v.isoformat()}
 
@@ -69,6 +81,8 @@ class SubAgentConfigVersion(BaseModel):
     system_prompt: str | None = None  # For local sub-agents: the system prompt
     agent_url: str | None = None  # For remote sub-agents: the URL of the agent
     mcp_tools: list[str] = []  # MCP tool names enabled for this version
+
+    _sanitize_mcp_tools = _sanitize_whitelist
 
     # Foundry agent configuration
     foundry_hostname: str | None = None

--- a/packages/orchestrator-agent/tests/test_registry.py
+++ b/packages/orchestrator-agent/tests/test_registry.py
@@ -183,6 +183,63 @@ class TestRegistryService:
             assert local_agent.model_name == "gpt-4o"
 
     @pytest.mark.asyncio
+    async def test_stored_whitelists_are_sanitised_to_exposed_tool_names(self, mock_registry_service):
+        """A whitelist naming a tool in its wire form arrives as the name the catalogue exposes.
+
+        The gateway lists dotted names; the catalogue exposes them with the dots folded
+        (see ``sanitize_tool_name``), so a setting saved from the console's raw listing
+        would otherwise match nothing at all.
+        """
+        mock_sub_agents_response = {
+            "items": [
+                {
+                    "id": 2,
+                    "name": "okr-analyst",
+                    "description": "Reads OKRs",
+                    "owner_user_id": "test-user",
+                    "type": "local",
+                    "current_version": 1,
+                    "default_version": 1,
+                    "config_version": {
+                        "id": 2,
+                        "sub_agent_id": 2,
+                        "version": 1,
+                        "description": "Reads OKRs",
+                        "model": "gpt-4o",
+                        "system_prompt": "You read OKRs.",
+                        "mcp_tools": ["authrion-atp-v1_okrs.v1.search_okrs", "gcal_list_events"],
+                        "status": "approved",
+                        "created_at": "2024-01-01T00:00:00",
+                    },
+                    "created_at": "2024-01-01T00:00:00",
+                    "updated_at": "2024-01-01T00:00:00",
+                }
+            ],
+            "total": 1,
+        }
+        mock_settings_response = {
+            "data": {
+                "user_id": "test-user-id",
+                "sub": "test-user-sub",
+                "language": "en",
+                "custom_prompt": None,
+                "timezone": "Europe/Zurich",
+                "mcp_tools": ["authrion-atp-v1_okrs.v1.search_okrs", "gcal_list_events"],
+                "created_at": "2026-01-01T00:00:00",
+                "updated_at": "2026-01-01T00:00:00",
+            }
+        }
+
+        with mock_registry_service(mock_sub_agents_response, mock_settings_response) as registry_service:
+            user = await registry_service.get_user(user_sub="test-user-sub", access_token="test-token")
+
+        assert user.tool_names == ["authrion-atp-v1_okrs_v1_search_okrs", "gcal_list_events"]
+        assert user.local_subagents[0].mcp_tools == [
+            "authrion-atp-v1_okrs_v1_search_okrs",
+            "gcal_list_events",
+        ]
+
+    @pytest.mark.asyncio
     async def test_local_agent_system_prompt_placeholders_resolved(self, mock_registry_service, monkeypatch):
         """A stored local-agent prompt has its {{CONSOLE_FRONTEND_URL}} placeholder resolved."""
         monkeypatch.setenv("CONSOLE_FRONTEND_URL", "https://console.example.com")


### PR DESCRIPTION
closes #

## What

Tools whose name contains a dot were in the catalogue but invisible to every agent.

A PTC agent reaches its tools as `tools.<camelCase(name)>`, and `langchain_quickjs` **skips** any tool whose camelCase name is not a valid JS identifier — its only word separators are `-` and `_`. The gateway serves dotted names, so `authrion-atp-v1_okrs.v1.search_okrs` camelCases to `authrionAtpV1Okrs.v1.searchOkrs`, which is not an identifier. From a real session's log:

```
GP agent: catalog mode with 552 tools (PTC=on)
Skipping PTC tool 'authrion-atp-v1_okrs.v1.search_okrs':
  'authrionAtpV1Okrs.v1.searchOkrs' is not a valid JS identifier
```

All 29 `okrs.v1.*` tools were dropped — from `tools.*`, and from `search`/`describe`, which filter on the same predicate. Asked for one, the orchestrator ran `Object.keys(tools)` and answered "not available in the current environment"; the general-purpose agent, holding all 552, reported that no OKR tool exists. `authrion-atp-v1` is the only server using dotted names today, so it was the only one affected.

## How

Names now have two spaces, and the split lives in `tool_catalogue`:

- **Exposed** — `sanitize_tool_name(wire_name)` folds anything outside `[A-Za-z0-9_-]` to `_`. Applied in `make_catalogue_tool`, the one seam every ingest path (stateless and SDK) goes through. This is the name the model, the whitelists, the PTC namespace and every listing see.
- **Wire** — kept as `CatalogueTool.wire_name`, used by `LazyMcpTool._get_delegate`, so the server is still called by the name it listed.

A stored whitelist still names tools as console-backend's raw `tools/list` did, so it is sanitized where it *enters a process*: pydantic validators on the two orchestrator models that carry one (`UserSettings`, `SubAgentConfigVersion`), and agent-runner's own job-config fetch — a separate service with its own ingress, so the orchestrator's validators are not in its path. Sanitizing is idempotent, so settings saved before this keep matching the tool they enabled. Everything in between — binding, PTC exposure, whitelist filtering, catalogue lookups — compares exposed names and nothing else. The rule is stated once in the `tool_catalogue` module docstring.

## Not in scope

- The Settings UI still displays wire names: console-backend serves its own raw listing, and its `watch_evaluator` calls tools by wire name, so sanitizing there needs the same split on that side. Sanitizing in console-backend would be the single hook that removes both agent-side hooks — worth doing if a third consumer appears.
- `discovery.discover_tools(white_list=...)` is untouched; its only production caller passes `None`.
- voice-agent lists and calls through its own MCP session, not the catalogue, so it stays consistently in wire space.

## Tests

- `agent-common` — new `TestNameSanitisation`: the fold and its idempotence; every sanitized name passes `langchain_quickjs`' own `is_valid_ptc_tool_name`; the catalogue keys on the exposed name; and dispatch calls `okrs.v1.search_okrs` while the model sees `okrs_v1_search_okrs`.
- `orchestrator-agent` — a registry test that a stored `authrion-atp-v1_okrs.v1.search_okrs` arrives sanitized in both `tool_names` and the sub-agent's `mcp_tools`. Verified it fails when either validator registration is removed.
- `agent-runner` — a `_fetch_sub_agent_config` test for the same, at its own boundary.

Full suites: agent-common 769 passed, orchestrator-agent 685 passed, agent-runner 35 passed. The 9 pre-existing `test_thinking_blocks_round_trip.py` failures also fail on clean `main`.

## Checklist
- [x] I have performed a self-review of my code
- [x] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨

Not breaking for a caller, but note the behaviour change: a dotted tool is now presented to models (and stored in new whitelists) under its sanitized name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
