### PR TITLE
feat: in-task auth on the Slack and Google Chat clients

### DIFF
--- a/packages/client-google-chat/src/handlers/buttonClickedHandler.ts
+++ b/packages/client-google-chat/src/handlers/buttonClickedHandler.ts
@@ -5,6 +5,7 @@ import { Logger } from '../utils/logger.js';
 import { handleIncomingMessage, NormalizedMessage } from './messageHandler.js';
 import { HandlerDependencies } from "./types.js";
 import { GoogleChatService } from '../services/googleChatService.js';
+import { AuthDecision, authResumeText, authorizationDataPart } from '../utils/inTaskAuth.js';
 
 export interface ButtonClickedPayload {
   cardId: string,
@@ -277,6 +278,54 @@ async function handleHitlFeedbackCardClick(payload: ButtonClickedPayload, deps: 
   await handleIncomingMessage(syntheticMessage, deps);
 }
 
+/**
+ * Handle the in-task authorization card (`urn:nannos:a2a:in-task-auth:1.0`).
+ *
+ * Both buttons answer the SAME parked interrupt, and both answer it explicitly:
+ * the decision rides a DataPart the orchestrator's middleware acts on directly —
+ * approved retries the blocked tool (so a credential that still is not there
+ * asks again, as a card), declined tells the agent to stop pushing the link.
+ * Agent-facing prose rides along for a server that never routed the DataPart.
+ *
+ * Nothing is lost by a misclick: the decision reached the agent, and asking
+ * again re-runs the tool and raises a fresh card.
+ */
+async function handleInTaskAuthCardClick(payload: ButtonClickedPayload, deps: HandlerDependencies) {
+  const logger = Logger.getLogger('handleInTaskAuthCardClick');
+
+  const params = payload.actionParameters as unknown as { taskId?: string; tool?: string; subject?: string };
+  const decision: AuthDecision = payload.action === 'approved' ? 'approved' : 'declined';
+  const subject = params.subject || params.tool;
+
+  logger.info(`In-task auth ${decision} for taskId=${params.taskId}${params.tool ? ` tool=${params.tool}` : ''}`);
+
+  await deps.chatService.updateMessage({
+    projectId: payload.projectId,
+    messageName: payload.messageId,
+    text:
+      decision === 'approved'
+        ? `✅ Authorized${subject ? ` — ${subject}` : ''}`
+        : `🚫 Authorization declined${subject ? ` — ${subject}` : ''}`,
+    cardsV2: [],
+  });
+
+  const syntheticMessage: NormalizedMessage = {
+    userId: payload.userId,
+    userEmail: payload.userEmail,
+    projectId: payload.projectId,
+    spaceId: payload.spaceId,
+    messageId: `synthetic-${randomUUID()}`,
+    threadId: payload.threadId,
+    // The text is what a server that never routed the DataPart reads; the
+    // DataPart is what the middleware acts on when it did.
+    rawText: authResumeText(decision, params.tool),
+    dataParts: [authorizationDataPart(decision)],
+    source: 'direct_message',
+  };
+
+  await handleIncomingMessage(syntheticMessage, deps);
+}
+
 export async function handleButtonClicked(
   payload: ButtonClickedPayload,
   deps: HandlerDependencies
@@ -312,6 +361,15 @@ export async function handleButtonClicked(
 
     case 'hitl_multi_card': {
       await handleHitlMultiCardClick(
+        payload,
+        deps,
+      );
+
+      break;
+    }
+
+    case 'in_task_auth_card': {
+      await handleInTaskAuthCardClick(
         payload,
         deps,
       );

--- a/packages/client-google-chat/src/handlers/messageHandler.ts
+++ b/packages/client-google-chat/src/handlers/messageHandler.ts
@@ -825,6 +825,17 @@ export async function handleIncomingMessage(msg: NormalizedMessage, deps: Handle
               statusEvent,
               config,
             );
+            if (authCardPosted) {
+              // Park the public spinner. Updating it in place is the ONLY thing
+              // that ever overwrites "🧠 Working…", and with the card carrying the
+              // prompt there is usually no final text to post — so without this
+              // the thread keeps a spinner that spins forever beside a card
+              // asking for a login. Written into the status line the block below
+              // already renders, rather than pushed here, or that same block
+              // would put the spinner straight back in this iteration.
+              statusMessage.thinking = '⏸️ Awaiting your authorization';
+              statusMessage.activity = '';
+            }
           }
 
           if (statusEvent.status.message?.extensions?.includes('urn:nannos:a2a:work-plan:1.0')) {

--- a/packages/client-google-chat/src/handlers/messageHandler.ts
+++ b/packages/client-google-chat/src/handlers/messageHandler.ts
@@ -17,6 +17,7 @@ import { HandlerDependencies } from './types.js';
 import { getSpinnerVerb } from '../utils/spinnerVerbs.js';
 import { FileStorageService } from '../services/fileStorageService.js';
 import { Config } from '../config/config.js';
+import { readAuthRequired } from '../utils/inTaskAuth.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -394,6 +395,65 @@ async function processMessageAttachments(
     return processedFiles;
 }
 
+/**
+ * The in-task authorization interrupt: A2A's own `auth-required` state, whose
+ * payload schema is the in-task-auth extension.
+ *
+ * The status TEXT is the MCP gateway addressing the AGENT ("You must tell the
+ * end-user to…") — the interrupt fires in middleware, before the model, so no
+ * LLM ever rewrites it. Google Chat used to post it verbatim. The card is our
+ * own copy instead, built from the DataPart when the producer sent one and from
+ * metadata or the prose's URL when it did not.
+ *
+ * Returns whether the card was posted — the caller then keeps that prose out of
+ * the finalized message.
+ */
+async function processAuthRequiredEvent(
+  logger: Logger,
+  chatService: GoogleChatService,
+  inFlightTaskStore: IInFlightTaskStore,
+  projectId: string,
+  spaceId: string,
+  threadId: string,
+  userId: string,
+  accumulatedTask: Task,
+  statusEvent: TaskStatusUpdateEvent,
+  config: Config,
+): Promise<boolean> {
+  const statusMeta = (statusEvent.metadata ?? statusEvent.status.message?.metadata) as
+    | Record<string, unknown>
+    | undefined;
+  const prompt = readAuthRequired(statusEvent.status.message?.parts, statusMeta);
+
+  logger.info(
+    { taskId: accumulatedTask.id, tool: prompt.tool, service: prompt.service, hasUrl: !!prompt.authUrl },
+    `Received in-task authorization interrupt`,
+  );
+
+  try {
+    const authCard = chatService.buildInTaskAuthCard(config, prompt, { taskId: accumulatedTask.id });
+
+    await chatService.sendPrivateCardMessage(
+      projectId,
+      spaceId,
+      userId,
+      [authCard],
+      threadId,
+    );
+
+    await inFlightTaskStore.touch(accumulatedTask.id).catch((err) => {
+      logger.error(err, `Failed to update in-flight task for auth interrupt: ${err}`);
+    });
+
+    return true;
+  } catch (cardErr) {
+    // Falling back to the wire text is worse copy than the card, but it is the
+    // only thing left that carries the URL — a silent turn would strand the user.
+    logger.error(cardErr, `Failed to post in-task authorization card, falling back to text: ${cardErr}`);
+    return false;
+  }
+}
+
 async function processHumanInTheLoopEvent(
   logger: Logger,
   chatService: GoogleChatService,
@@ -691,6 +751,10 @@ export async function handleIncomingMessage(msg: NormalizedMessage, deps: Handle
 
     let accumulatedTask: Task | null = null;
     let feedbackRequestData: { sub_agents?: string[] } | null = null;
+    // Set once the in-task authorization card is on screen: the `auth-required`
+    // status text is then the gateway's agent-facing prose, and finalizing must
+    // not post it beside the card that replaced it.
+    let authCardPosted = false;
     try {
       for await (const event of a2aClientService.sendMessageStream(a2aRequest, accessToken)) {
         logger.debug(`Stream event: ${_.get(event, 'kind')}`);
@@ -735,6 +799,21 @@ export async function handleIncomingMessage(msg: NormalizedMessage, deps: Handle
             statusEvent.status.message?.extensions?.includes('urn:nannos:a2a:human-in-the-loop:1.0')
           ) {
             await processHumanInTheLoopEvent(
+              logger,
+              chatService,
+              inFlightTaskStore,
+              projectId,
+              spaceId,
+              threadId,
+              userId,
+              accumulatedTask,
+              statusEvent,
+              config,
+            );
+          }
+
+          if (statusEvent.status.state === 'auth-required' && !authCardPosted) {
+            authCardPosted = await processAuthRequiredEvent(
               logger,
               chatService,
               inFlightTaskStore,
@@ -851,6 +930,7 @@ export async function handleIncomingMessage(msg: NormalizedMessage, deps: Handle
 
     const result = await handleTask({
       task: accumulatedTask,
+      suppressStatusText: authCardPosted,
       chatService,
       messageContext: {
         projectId,

--- a/packages/client-google-chat/src/services/a2aClientService.ts
+++ b/packages/client-google-chat/src/services/a2aClientService.ts
@@ -48,7 +48,11 @@ function createAuthenticatedFetch(accessToken: string): typeof fetch {
     headers.set('Authorization', `Bearer ${accessToken}`);
     headers.set(
       'X-A2A-Extensions',
-      'urn:nannos:a2a:activity-log:1.0, urn:nannos:a2a:work-plan:1.0, urn:nannos:a2a:feedback-request:1.0, urn:nannos:a2a:human-in-the-loop:1.0'
+      // in-task-auth is gated server-side on the client advertising it: without
+      // it an `auth-required` status is prose the gateway wrote for the agent;
+      // with it the facts arrive as a DataPart and the authorization card is
+      // built from them.
+      'urn:nannos:a2a:activity-log:1.0, urn:nannos:a2a:work-plan:1.0, urn:nannos:a2a:feedback-request:1.0, urn:nannos:a2a:human-in-the-loop:1.0, urn:nannos:a2a:in-task-auth:1.0'
     );
 
     return fetch(input, {

--- a/packages/client-google-chat/src/services/googleChatService.ts
+++ b/packages/client-google-chat/src/services/googleChatService.ts
@@ -657,6 +657,89 @@ export class GoogleChatService {
   }
 
   /**
+   * Build the in-task authorization card (`urn:nannos:a2a:in-task-auth:1.0`):
+   * a tool the agent wanted to use needs the END-USER's consent.
+   *
+   * The copy is OURS. What comes on the wire with an `auth-required` status is
+   * the MCP gateway addressing the AGENT ("You must tell the end-user to…"), so
+   * it is rendered only when the producer gave us no URL to link — better
+   * stranded text than no way forward.
+   *
+   * Unlike the panel this does NOT walk through stages (Authorize, then "Done,
+   * continue"): a Google Chat openLink button reports nothing back, so the way
+   * forward must not depend on a state change we would never see. All three
+   * buttons are live from the start.
+   */
+  buildInTaskAuthCard(
+    config: Config,
+    prompt: { authUrl?: string; tool?: string; service?: string; message?: string },
+    parameters: Record<string, unknown>,
+  ): chat_v1.Schema$CardWithId {
+    const buttonClickHandlerUrl = new URL(`/api/v1/chat/events`, config.baseUrl).toString();
+    const subject = prompt.service || prompt.tool || '';
+    const paramsJson = JSON.stringify({ ...parameters, ...(prompt.tool ? { tool: prompt.tool } : {}), subject });
+
+    const answerButton = (text: string, action: string) => ({
+      text,
+      onClick: {
+        action: {
+          function: buttonClickHandlerUrl,
+          parameters: [
+            { key: 'cardId', value: 'in_task_auth_card' },
+            { key: 'action', value: action },
+            { key: 'parameters', value: paramsJson },
+          ],
+        },
+      },
+    });
+
+    const buttons: any[] = [];
+    if (prompt.authUrl) {
+      buttons.push({
+        text: '🔓 Authorize',
+        onClick: { openLink: { url: prompt.authUrl } },
+        color: { red: 0.0, green: 0.54, blue: 0.86, alpha: 1 },
+      });
+    }
+    // Both answers resume the same parked interrupt. Declining has to reach the
+    // agent too — it is holding a blocked tool call and needs to stop pushing the
+    // link — so it stays offered even when there is no URL to open.
+    buttons.push(answerButton('✅ Done, continue', 'approved'));
+    buttons.push(answerButton("🚫 Don't allow", 'declined'));
+
+    const widgets: any[] = [
+      {
+        textParagraph: {
+          text: prompt.tool
+            ? `Nannos needs your permission to use <code>${prompt.tool}</code>.`
+            : 'Nannos needs your permission before it can continue.',
+        },
+      } as any,
+    ];
+    if (prompt.authUrl) {
+      widgets.push({
+        textParagraph: { text: 'Authorize in the browser, then come back and confirm here.' },
+      } as any);
+    } else if (prompt.message) {
+      widgets.push({ textParagraph: { text: prompt.message.substring(0, 3000) } } as any);
+    }
+    widgets.push({ divider: {} });
+    widgets.push({ buttonList: { buttons } } as any);
+
+    return {
+      cardId: 'in_task_auth_card',
+      card: {
+        header: {
+          title: '🔐 Authorization needed',
+          ...(subject ? { subtitle: subject } : {}),
+          imageType: 'CIRCLE',
+        },
+        sections: [{ widgets }],
+      },
+    };
+  }
+
+  /**
    * Build a multi-action HITL approval card for interrupts carrying more than one
    * action_request (e.g. parallel tool calls). Renders the detail of EVERY call (so
    * nothing is approved unseen) with a per-call Approve/Reject radio. "Submit

--- a/packages/client-google-chat/src/utils/inTaskAuth.ts
+++ b/packages/client-google-chat/src/utils/inTaskAuth.ts
@@ -1,0 +1,136 @@
+/**
+ * The `urn:nannos:a2a:in-task-auth:1.0` extension, Google Chat side.
+ *
+ * A tool the agent wanted to use needs the END-USER's consent (the MCP
+ * gateway's `need-credentials`, surfaced as A2A's own `auth-required` task
+ * state). The state is protocol; the schema of what it carries is ours, and
+ * this reads it — the same precedence the Embed SDK uses (payload → metadata →
+ * prose), so both clients name the same service and link the same URL.
+ *
+ * The status text is NOT end-user copy: it is the gateway addressing the AGENT
+ * ("You must tell the end-user to…"), and the auth interrupt fires in
+ * middleware, before the model, so no LLM ever rewrites it. Google Chat used to
+ * post it verbatim. The card (googleChatService.buildInTaskAuthCard) writes our
+ * own copy from what this reads instead, and the wire text survives only as the
+ * fallback for a producer that gave us no URL to link.
+ */
+import { Part } from '@a2a-js/sdk';
+
+export const IN_TASK_AUTH_EXTENSION = 'urn:nannos:a2a:in-task-auth:1.0';
+
+/** First http(s) URL in a text blob — the fallback when nothing structured came. */
+const URL_IN_TEXT = /https?:\/\/[^\s<>"')]+/;
+
+/**
+ * Tool names that mean nothing to an end-user: sandbox and orchestration
+ * plumbing. The gateway call that needs authorization often runs INSIDE one of
+ * these (a `need-credentials` from an MCP call made in the sandbox is reported
+ * against `eval`), so naming them misinforms rather than informs. Anything else
+ * is shown verbatim — a mangled tool name is worse than a plain one.
+ * Kept in step with the Embed SDK's own list (auth-required-card.tsx).
+ */
+const OPAQUE_TOOLS = new Set(['eval', 'task', 'client_action', 'python', 'bash', 'shell', 'call_tool']);
+
+export interface AuthPrompt {
+  /** Where the user completes the flow. Without it there is no card, only text. */
+  authUrl?: string;
+  /** The tool call that needed the credential, when it is fit to name. */
+  tool?: string;
+  /** Whose credential this is (e.g. "github"), when the producer named one. */
+  service?: string;
+  /** The gateway's own words — agent-facing; shown only when there is no URL. */
+  message?: string;
+}
+
+/**
+ * The in-task-auth DataPart (`AuthPayload.client_payload()`), when one came.
+ *
+ * Only the first method carrying a URL is used: the model allows several ("try
+ * in order"), but a card offers one way forward, and a method without a URL is
+ * nothing a Slack button can act on.
+ */
+function readAuthDataPart(parts: Part[] | undefined): AuthPrompt | null {
+  for (const part of parts ?? []) {
+    if (part.kind !== 'data') continue;
+    const data = (part as { kind: 'data'; data: Record<string, unknown> }).data;
+    const requirement = data?.auth_requirement;
+    if (typeof requirement !== 'object' || requirement === null) continue;
+    const req = requirement as { service?: unknown; resource?: unknown; auth_methods?: unknown };
+    const methods = Array.isArray(req.auth_methods) ? req.auth_methods : [];
+    const withUrl = methods.find(
+      (m) => typeof (m as { auth_url?: unknown })?.auth_url === 'string' && (m as { auth_url: string }).auth_url
+    ) as { auth_url?: string } | undefined;
+    return {
+      ...(withUrl?.auth_url && { authUrl: withUrl.auth_url }),
+      // `resource` is the specific thing that needed the credential (the tool
+      // call); `service` is who it belongs to. The card names them differently.
+      ...(typeof req.resource === 'string' && req.resource && { tool: req.resource }),
+      ...(typeof req.service === 'string' && req.service && { service: req.service }),
+    };
+  }
+  return null;
+}
+
+/**
+ * The authorize target for an `auth-required` status, in descending order of how
+ * much the producer told us: the structured DataPart of the in-task-auth
+ * extension, then the status metadata (`auth_url` + the `tool` that asked), then
+ * — last resort — the first URL in the message text.
+ *
+ * That last resort scrapes a sentence written for the agent, and it stays only
+ * because a stranded user is worse than an ugly parse: producers that negotiated
+ * the extension never reach it.
+ */
+export function readAuthRequired(parts: Part[] | undefined, metadata?: Record<string, unknown>): AuthPrompt {
+  const text = (parts ?? [])
+    .filter((p) => p.kind === 'text')
+    .map((p) => (p as { kind: 'text'; text: string }).text)
+    .join('\n')
+    .trim();
+  const structured = readAuthDataPart(parts);
+  const fromMeta = metadata?.auth_url ?? metadata?.authUrl ?? metadata?.authorizeUrl;
+  const authUrl =
+    structured?.authUrl ??
+    (typeof fromMeta === 'string' && fromMeta ? fromMeta : (text.match(URL_IN_TEXT)?.[0] ?? undefined));
+  const rawTool = structured?.tool ?? (typeof metadata?.tool === 'string' ? metadata.tool : undefined);
+  const tool = rawTool && !OPAQUE_TOOLS.has(rawTool) ? rawTool : undefined;
+  // The same filter applies to the service: a producer filling it in from the
+  // tool name would otherwise slip `eval` past the check that exists precisely
+  // to keep sandbox plumbing out of the user's face.
+  const service = structured?.service && !OPAQUE_TOOLS.has(structured.service) ? structured.service : undefined;
+  return {
+    ...(authUrl && { authUrl }),
+    ...(tool && { tool }),
+    ...(service && { service }),
+    ...(text && { message: text }),
+  };
+}
+
+/** What to call the thing being authorized — nothing, when neither is fit to show. */
+export function authSubject(prompt: AuthPrompt): string {
+  return prompt.service || prompt.tool || '';
+}
+
+/**
+ * What the buttons send as text. Agent-facing, so it is the same English the
+ * Embed SDK sends — the fallback for a server that never routed the DataPart,
+ * while the DataPart beside it is what the middleware acts on when it did.
+ */
+export function authResumeText(decision: 'approved' | 'declined', tool?: string): string {
+  if (decision === 'approved') {
+    return tool
+      ? `I have completed the authorization for ${tool}. Please retry what needed it and continue.`
+      : 'I have completed the authorization. Please retry what needed it and continue.';
+  }
+  return tool
+    ? `I am not going to authorize ${tool}. Do not ask again — tell me what you cannot do without it.`
+    : 'I am not going to authorize this. Do not ask again — tell me what you cannot do without it.';
+}
+
+/** The DataPart the executor routes straight to the parked auth interrupt. */
+export function authorizationDataPart(decision: 'approved' | 'declined'): Record<string, unknown> {
+  return { authorization: { decision } };
+}
+
+/** The decisions the card can answer a parked auth interrupt with. */
+export type AuthDecision = 'approved' | 'declined';

--- a/packages/client-google-chat/src/utils/inTaskAuth.ts
+++ b/packages/client-google-chat/src/utils/inTaskAuth.ts
@@ -16,8 +16,6 @@
  */
 import { Part } from '@a2a-js/sdk';
 
-export const IN_TASK_AUTH_EXTENSION = 'urn:nannos:a2a:in-task-auth:1.0';
-
 /** First http(s) URL in a text blob — the fallback when nothing structured came. */
 const URL_IN_TEXT = /https?:\/\/[^\s<>"')]+/;
 
@@ -115,6 +113,14 @@ export function authSubject(prompt: AuthPrompt): string {
  * What the buttons send as text. Agent-facing, so it is the same English the
  * Embed SDK sends — the fallback for a server that never routed the DataPart,
  * while the DataPart beside it is what the middleware acts on when it did.
+ *
+ * On that fallback path the words are READ, not just logged: a fast-LLM
+ * classifier grades them approve / reject / unclear before the agent ever sees
+ * them (orchestrator ``AuthErrorDetectionMiddleware._after_auth_interrupt`` ->
+ * ``classify_reply``), and an unclear verdict costs the user a whole extra
+ * round. So keep both sentences blunt and unambiguous about the DECISION —
+ * softening them ("maybe later", "I'll get to it") is what makes them
+ * unclassifiable.
  */
 export function authResumeText(decision: 'approved' | 'declined', tool?: string): string {
   if (decision === 'approved') {

--- a/packages/client-google-chat/src/utils/inTaskAuth.ts
+++ b/packages/client-google-chat/src/utils/inTaskAuth.ts
@@ -16,8 +16,11 @@
  */
 import { Part } from '@a2a-js/sdk';
 
-/** First http(s) URL in a text blob — the fallback when nothing structured came. */
-const URL_IN_TEXT = /https?:\/\/[^\s<>"')]+/;
+/** First http(s) URL in a text blob — the fallback when nothing structured came.
+ *  The trailing class drops sentence punctuation the URL cannot have ended on:
+ *  the prose this scrapes is a paragraph, so "…visit https://host/begin." would
+ *  otherwise yield a link with a full stop welded on and a button that 404s. */
+const URL_IN_TEXT = /https?:\/\/[^\s<>"')]*[^\s<>"').,;:!?\]}]/;
 
 /**
  * Tool names that mean nothing to an end-user: sandbox and orchestration

--- a/packages/client-google-chat/src/utils/taskResponseHandler.ts
+++ b/packages/client-google-chat/src/utils/taskResponseHandler.ts
@@ -38,6 +38,16 @@ export interface HandleTaskResponseParams {
   task: Task;
   chatService: GoogleChatService;
   messageContext: ChatMessageContext;
+  /**
+   * Drop `status.message` as a source of user-facing text.
+   *
+   * Set for an `auth-required` turn whose authorization card was already posted
+   * (messageHandler): that status text is the MCP gateway addressing the AGENT
+   * ("You must tell the end-user to…"), so posting it would repeat the prompt in
+   * machine-to-machine prose beside the card that replaced it. Whatever the turn
+   * streamed BEFORE the interrupt is still posted from the artifacts.
+   */
+  suppressStatusText?: boolean;
 }
 
 /**
@@ -121,7 +131,7 @@ export function processArtifacts(artifacts?: Artifact[]): {
  * Main entry point for handling any A2A response uniformly
  */
 export async function handleTask(params: HandleTaskResponseParams): Promise<{ messageId: string | undefined }> {
-  const { task, chatService, messageContext } = params;
+  const { task, chatService, messageContext, suppressStatusText } = params;
 
   const { projectId, spaceId, threadId, messageId, statusMessageId } = messageContext;
 
@@ -139,7 +149,7 @@ export async function handleTask(params: HandleTaskResponseParams): Promise<{ me
   // For interrupted states (input-required, auth-required), the authoritative
   // message is in status.message — artifacts are just intermediate streaming
   // tokens from BEFORE the interrupt fired, not the final response.
-  if (isInterruptedState(task.status.state) && task.status?.message?.parts) {
+  if (!suppressStatusText && isInterruptedState(task.status.state) && task.status?.message?.parts) {
     for (const part of task.status.message.parts) {
       if (part.kind === 'text') {
         message += (part as { kind: 'text'; text: string }).text;
@@ -153,7 +163,7 @@ export async function handleTask(params: HandleTaskResponseParams): Promise<{ me
   }
 
   // Final fallback: extract from status message (e.g. completed with no artifacts)
-  if (!message && task.status?.message?.parts) {
+  if (!message && !suppressStatusText && task.status?.message?.parts) {
     for (const part of task.status.message.parts) {
       if (part.kind === 'text') {
         message += (part as { kind: 'text'; text: string }).text;

--- a/packages/client-google-chat/src/utils/taskResponseHandler.ts
+++ b/packages/client-google-chat/src/utils/taskResponseHandler.ts
@@ -46,6 +46,10 @@ export interface HandleTaskResponseParams {
    * ("You must tell the end-user to…"), so posting it would repeat the prompt in
    * machine-to-machine prose beside the card that replaced it. Whatever the turn
    * streamed BEFORE the interrupt is still posted from the artifacts.
+   *
+   * It gates BOTH readers of `status.message` below — the interrupted-state
+   * branch and the generic final fallback — on purpose: they draw from the same
+   * text, so gating only the first would just let the second post it again.
    */
   suppressStatusText?: boolean;
 }

--- a/packages/client-google-chat/test/utils/inTaskAuth.test.ts
+++ b/packages/client-google-chat/test/utils/inTaskAuth.test.ts
@@ -59,6 +59,13 @@ describe('readAuthRequired', () => {
     expect(scraped.tool).toBeUndefined();
   });
 
+  test('the scrape stops before sentence punctuation', () => {
+    // The prose is a paragraph, so the URL is routinely followed by a full stop
+    // or a comma — welding one onto the link gives the button a 404.
+    expect(readAuthRequired([textPart(`Please go to ${AUTH_URL}. Then retry.`)], undefined).authUrl).toBe(AUTH_URL);
+    expect(readAuthRequired([textPart(`see ${AUTH_URL}, then come back`)], undefined).authUrl).toBe(AUTH_URL);
+  });
+
   test('sandbox plumbing is never named as the thing being authorized', () => {
     const prompt = readAuthRequired([textPart(GATEWAY_TEXT)], { auth_url: AUTH_URL, tool: 'eval' });
     expect(prompt.tool).toBeUndefined();

--- a/packages/client-google-chat/test/utils/inTaskAuth.test.ts
+++ b/packages/client-google-chat/test/utils/inTaskAuth.test.ts
@@ -1,0 +1,122 @@
+/**
+ * The `in-task-auth` extension on Google Chat: A2A's `auth-required` state
+ * carries the facts as data, and the card is built from them instead of from a
+ * sentence the MCP gateway wrote for the agent. The properties worth pinning are
+ * the reading PRECEDENCE (payload → metadata → prose, so a producer that never
+ * negotiated the URN still works), that plumbing tool names never reach the
+ * user, and that both answers leave with a decision the executor can route.
+ */
+import { describe, test, expect } from '@jest/globals';
+import { Part } from '@a2a-js/sdk';
+import {
+  authResumeText,
+  authorizationDataPart,
+  authSubject,
+  readAuthRequired,
+} from '../../src/utils/inTaskAuth.js';
+import { GoogleChatService } from '../../src/services/googleChatService.js';
+import { Config } from '../../src/config/config.js';
+
+const AUTH_URL = 'https://gatana.nannos.ringier.ch/api/v1/mcp-servers/oauth/gt_7MOP0ckoiO/begin';
+const GATEWAY_TEXT =
+  'This tool requires secondary authorization. You must tell the end-user to please go to the authorizeUrl.\n\n' +
+  `Please visit the following URL to complete authentication:\n${AUTH_URL}\n\n` +
+  'After completing authentication, you can retry your request.';
+
+const textPart = (text: string): Part => ({ kind: 'text', text }) as Part;
+const dataPart = (data: Record<string, unknown>): Part => ({ kind: 'data', data }) as Part;
+
+const payloadPart = (overrides: Record<string, unknown> = {}) =>
+  dataPart({
+    requires_auth: true,
+    auth_requirement: {
+      service: 'github',
+      resource: 'github_get_me',
+      auth_methods: [{ method: 'oauth2', description: 'GitHub OAuth', auth_url: AUTH_URL }],
+      ...overrides,
+    },
+  });
+
+describe('readAuthRequired', () => {
+  test('the DataPart wins: service and the tool that asked arrive separately', () => {
+    const prompt = readAuthRequired([textPart(GATEWAY_TEXT), payloadPart()], {
+      auth_url: 'https://wrong.example/other',
+      tool: 'eval',
+    });
+    expect(prompt.authUrl).toBe(AUTH_URL);
+    expect(prompt.service).toBe('github');
+    expect(prompt.tool).toBe('github_get_me');
+    expect(prompt.message).toContain('secondary authorization');
+  });
+
+  test('falls back to status metadata, then to scraping the prose', () => {
+    const fromMeta = readAuthRequired([textPart(GATEWAY_TEXT)], { auth_url: AUTH_URL, tool: 'github_get_me' });
+    expect(fromMeta.authUrl).toBe(AUTH_URL);
+    expect(fromMeta.tool).toBe('github_get_me');
+
+    const scraped = readAuthRequired([textPart(GATEWAY_TEXT)], undefined);
+    expect(scraped.authUrl).toBe(AUTH_URL);
+    expect(scraped.tool).toBeUndefined();
+  });
+
+  test('sandbox plumbing is never named as the thing being authorized', () => {
+    const prompt = readAuthRequired([textPart(GATEWAY_TEXT)], { auth_url: AUTH_URL, tool: 'eval' });
+    expect(prompt.tool).toBeUndefined();
+    expect(authSubject(prompt)).toBe('');
+  });
+});
+
+describe('buildInTaskAuthCard', () => {
+  const config = { baseUrl: 'https://chat.nannos.example' } as Config;
+  const service = Object.create(GoogleChatService.prototype) as GoogleChatService;
+
+  function buttons(card: any): any[] {
+    const widgets = card.card.sections[0].widgets;
+    return widgets.find((w: any) => w.buttonList)?.buttonList.buttons ?? [];
+  }
+  function answerParams(card: any, action: string): any {
+    const btn = buttons(card).find(
+      (b: any) => b.onClick?.action?.parameters?.some((p: any) => p.key === 'action' && p.value === action)
+    );
+    const raw = btn.onClick.action.parameters.find((p: any) => p.key === 'parameters').value;
+    return JSON.parse(raw);
+  }
+
+  test('links the provider and offers both answers', () => {
+    const prompt = readAuthRequired([textPart(GATEWAY_TEXT), payloadPart()], {});
+    const card = service.buildInTaskAuthCard(config, prompt, { taskId: 't1' });
+
+    expect(buttons(card).find((b: any) => b.onClick?.openLink)?.onClick.openLink.url).toBe(AUTH_URL);
+    expect(answerParams(card, 'approved')).toMatchObject({ taskId: 't1', tool: 'github_get_me', subject: 'github' });
+    expect(answerParams(card, 'declined')).toMatchObject({ taskId: 't1' });
+
+    // Our own copy names the service and the tool; the gateway's agent-facing
+    // prose is not rendered when there is a URL to link.
+    const rendered = JSON.stringify(card);
+    expect(rendered).toContain('github');
+    expect(rendered).toContain('github_get_me');
+    expect(rendered).not.toContain('You must tell the end-user');
+  });
+
+  test('with no URL anywhere, the wire text is shown and the answers stay', () => {
+    const prompt = readAuthRequired([textPart('Authorization is required to continue.')], undefined);
+    const card = service.buildInTaskAuthCard(config, prompt, { taskId: 't1' });
+
+    expect(buttons(card).find((b: any) => b.onClick?.openLink)).toBeUndefined();
+    expect(JSON.stringify(card)).toContain('Authorization is required to continue.');
+    expect(answerParams(card, 'approved')).toBeDefined();
+    expect(answerParams(card, 'declined')).toBeDefined();
+  });
+});
+
+describe('the answer sent back', () => {
+  test('the DataPart is what the executor routes to the parked interrupt', () => {
+    expect(authorizationDataPart('approved')).toEqual({ authorization: { decision: 'approved' } });
+    expect(authorizationDataPart('declined')).toEqual({ authorization: { decision: 'declined' } });
+  });
+
+  test('the prose beside it names the tool and tells the agent what to do', () => {
+    expect(authResumeText('approved', 'github_get_me')).toContain('github_get_me');
+    expect(authResumeText('declined')).toContain('Do not ask again');
+  });
+});

--- a/packages/client-slack/src/listeners/actions/inTaskAuthButton.ts
+++ b/packages/client-slack/src/listeners/actions/inTaskAuthButton.ts
@@ -1,0 +1,101 @@
+import { App } from '@slack/bolt';
+import { Logger } from '../../utils/logger.js';
+import { handleIncomingMessage, HandlerDependencies, NormalizedMessage } from '../events/messageHandler.js';
+import { recordDecision } from '../../utils/taskResponseHandler.js';
+import {
+  AUTH_ACTION_DECLINE,
+  AUTH_ACTION_DONE,
+  AUTH_ACTION_OPEN,
+  authResumeText,
+  authorizationDataPart,
+} from '../../utils/inTaskAuth.js';
+
+/**
+ * Register handlers for the in-task authorization card
+ * (`urn:nannos:a2a:in-task-auth:1.0`).
+ *
+ * Both answering buttons resume the SAME parked interrupt, and both answer it
+ * explicitly: the decision rides a DataPart the orchestrator's middleware acts
+ * on directly — approved retries the blocked tool (so a credential that still
+ * is not there asks again, as a card), declined tells the agent to stop pushing
+ * the link. Agent-facing prose rides along for a server that never routed the
+ * DataPart.
+ *
+ * Nothing is lost by a misclick: the decision reached the agent, and asking
+ * again re-runs the tool and raises a fresh card.
+ */
+export function registerInTaskAuthActions(app: App, makeDeps: () => HandlerDependencies): void {
+  const logger = Logger.getLogger('inTaskAuthButton');
+
+  // The "Authorize" button is a URL button — Slack still delivers the click, and
+  // it needs an ack within 3 seconds or the user sees "operation timeout". The
+  // card is deliberately left in place: the user has to come back and confirm.
+  app.action(AUTH_ACTION_OPEN, async ({ ack }) => {
+    await ack();
+    logger.debug('Acknowledged in-task authorize link click');
+  });
+
+  const answer = (actionId: string, decision: 'approved' | 'declined') => {
+    app.action(actionId, async ({ ack, body, client }) => {
+      await ack();
+
+      const userId = body.user?.id;
+      const action = (body as any).actions?.[0];
+      const actionValue = action?.value || '';
+      const channelId = (body as any).channel?.id;
+      const messageTs = (body as any).message?.ts;
+      const threadTs = (body as any).message?.thread_ts || messageTs;
+
+      if (!actionValue || !userId || !channelId || !messageTs) {
+        logger.warn(`Missing required values in ${actionId} action`);
+        return;
+      }
+
+      try {
+        const decoded = JSON.parse(Buffer.from(actionValue, 'base64').toString());
+        const { taskId, tool, subject } = decoded;
+
+        logger.info(`In-task auth ${decision} by user ${userId} for task ${taskId}${tool ? ` tool ${tool}` : ''}`);
+
+        // Strip the buttons from the card (keep the trace); the resume posts the
+        // outcome.
+        await recordDecision(
+          client,
+          channelId,
+          messageTs,
+          decoded.streamMessageTs,
+          decision === 'approved' ? 'Authorized' : 'Authorization declined',
+          subject || tool || undefined,
+          decision === 'approved'
+        );
+
+        const syntheticMessage: NormalizedMessage = {
+          userId,
+          teamId: (body as any).team?.id || '',
+          channelId,
+          messageTs: messageTs || Date.now().toString(),
+          threadTs,
+          // The text is what a server that never routed the DataPart reads; the
+          // DataPart is what the middleware acts on when it did.
+          rawText: authResumeText(decision, tool),
+          dataParts: [authorizationDataPart(decision)],
+          source: 'direct_message',
+          client,
+          planMessageTs: decoded.planMessageTs,
+          resumeStreamTs: decoded.streamMessageTs,
+        };
+
+        handleIncomingMessage(syntheticMessage, makeDeps()).catch((err) => {
+          logger.error(err, `Failed to send in-task auth ${decision} to orchestrator: ${err}`);
+        });
+      } catch (error) {
+        logger.error(error, `Failed to process ${actionId}: ${error}`);
+      }
+    });
+  };
+
+  answer(AUTH_ACTION_DONE, 'approved');
+  answer(AUTH_ACTION_DECLINE, 'declined');
+
+  logger.info('Registered in-task authorization action handlers');
+}

--- a/packages/client-slack/src/listeners/events/messageHandler.ts
+++ b/packages/client-slack/src/listeners/events/messageHandler.ts
@@ -965,35 +965,48 @@ export async function handleIncomingMessage(msg: NormalizedMessage, deps: Handle
               `Received in-task authorization interrupt`
             );
 
-            interruptWidgetPosted = true;
+            // Both flags are set only AFTER the card is on screen. Setting them
+            // first (and letting a throw escape) is how the user ends up on a
+            // paused timeline with no card and no link: the flags make the code
+            // below skip finalize, so the status text — ugly, but the only other
+            // carrier of the URL — never posts either, and the kept in-flight
+            // record has the recovery loop deliver that same prose minutes later.
+            // A failed post therefore falls through to finalize deliberately.
+            try {
+              const authWidget = buildAuthRequiredWidget({
+                ...prompt,
+                taskId: accumulatedTask.id,
+                contextId: accumulatedTask.contextId || '',
+                channelId,
+                threadTs,
+                planMessageTs: streamer.planTs,
+                streamMessageTs: streamer.ts,
+              });
 
-            // PAUSE the streamed timeline (don't stop it): the turn resumes on the
-            // user's answer and continues the SAME widget. The auth-required task
-            // state keeps the finally cleanup from discarding it.
-            await streamer.pause('Awaiting your authorization');
+              // PAUSE the streamed timeline (don't stop it): the turn resumes on
+              // the user's answer and continues the SAME widget. The auth-required
+              // task state keeps the finally cleanup from discarding it.
+              await streamer.pause('Awaiting your authorization');
 
-            const authWidget = buildAuthRequiredWidget({
-              ...prompt,
-              taskId: accumulatedTask.id,
-              contextId: accumulatedTask.contextId || '',
-              channelId,
-              threadTs,
-              planMessageTs: streamer.planTs,
-              streamMessageTs: streamer.ts,
-            });
+              await client.chat.postMessage({
+                channel: channelId,
+                thread_ts: threadTs,
+                text: 'Authorization needed',
+                blocks: authWidget,
+              });
 
-            await client.chat.postMessage({
-              channel: channelId,
-              thread_ts: threadTs,
-              text: 'Authorization needed',
-              blocks: authWidget,
-            });
-
-            // The prompt has been delivered, so the in-flight record's job is done
-            // (the resume re-enters via the IDs in the card's button payload — see
-            // inTaskAuthButton.ts). Leaving it would only let the recovery loop
-            // re-post the prompt minutes later.
-            responsePosted = true;
+              interruptWidgetPosted = true;
+              // The prompt has been delivered, so the in-flight record's job is
+              // done (the resume re-enters via the IDs in the card's button
+              // payload — see inTaskAuthButton.ts). Leaving it would only let the
+              // recovery loop re-post the prompt minutes later.
+              responsePosted = true;
+            } catch (authErr) {
+              logger.error(
+                authErr,
+                `Failed to post the authorization card; falling through to the status text so the URL still reaches the user: ${authErr}`
+              );
+            }
           }
 
           // Sub-agent that produced this update (used to attribute thinking/activity cards)

--- a/packages/client-slack/src/listeners/events/messageHandler.ts
+++ b/packages/client-slack/src/listeners/events/messageHandler.ts
@@ -19,6 +19,7 @@ import type {
   ContextRecord,
 } from '../../storage/types.js';
 import { handleError, postMessage, finalizeStreamedTask, isInterruptedOrTerminated, isTerminatedState, isTurnDelivered } from '../../utils/taskResponseHandler.js';
+import { buildAuthRequiredWidget, readAuthRequired } from '../../utils/inTaskAuth.js';
 import { ThinkingStepsStreamer, type WorkPlanTodo } from '../../utils/thinkingStepsStreamer.js';
 import { FeedbackService } from '../../services/feedbackService.js';
 import _ from 'lodash';
@@ -944,6 +945,55 @@ export async function handleIncomingMessage(msg: NormalizedMessage, deps: Handle
                 responsePosted = true;
               }
             }
+          }
+
+          // Handle the in-task authorization interrupt: A2A's own `auth-required`
+          // state, whose payload schema is the in-task-auth extension. The status
+          // TEXT is the MCP gateway addressing the AGENT ("You must tell the
+          // end-user to…") — the interrupt fires in middleware, before the model,
+          // so no LLM ever rewrites it. Posting it verbatim (what happened before)
+          // handed the user machine-to-machine prose. The card below is our own
+          // copy, built from the DataPart when the producer sent one and from
+          // metadata or the prose's URL when it did not.
+          if (statusEvent.status.state === 'auth-required' && !interruptWidgetPosted) {
+            const statusMeta = (statusEvent.metadata ?? statusEvent.status.message?.metadata) as
+              | Record<string, unknown>
+              | undefined;
+            const prompt = readAuthRequired(statusEvent.status.message?.parts, statusMeta);
+            logger.info(
+              { taskId: accumulatedTask.id, tool: prompt.tool, service: prompt.service, hasUrl: !!prompt.authUrl },
+              `Received in-task authorization interrupt`
+            );
+
+            interruptWidgetPosted = true;
+
+            // PAUSE the streamed timeline (don't stop it): the turn resumes on the
+            // user's answer and continues the SAME widget. The auth-required task
+            // state keeps the finally cleanup from discarding it.
+            await streamer.pause('Awaiting your authorization');
+
+            const authWidget = buildAuthRequiredWidget({
+              ...prompt,
+              taskId: accumulatedTask.id,
+              contextId: accumulatedTask.contextId || '',
+              channelId,
+              threadTs,
+              planMessageTs: streamer.planTs,
+              streamMessageTs: streamer.ts,
+            });
+
+            await client.chat.postMessage({
+              channel: channelId,
+              thread_ts: threadTs,
+              text: 'Authorization needed',
+              blocks: authWidget,
+            });
+
+            // The prompt has been delivered, so the in-flight record's job is done
+            // (the resume re-enters via the IDs in the card's button payload — see
+            // inTaskAuthButton.ts). Leaving it would only let the recovery loop
+            // re-post the prompt minutes later.
+            responsePosted = true;
           }
 
           // Sub-agent that produced this update (used to attribute thinking/activity cards)

--- a/packages/client-slack/src/listeners/index.ts
+++ b/packages/client-slack/src/listeners/index.ts
@@ -17,6 +17,7 @@ import { registerNannosCommand } from './commands/nannos.js';
 import { registerAuthorizeButtonAction } from './actions/authorizeButton.js';
 import { registerFeedbackButtonActions } from './actions/feedbackButton.js';
 import { registerHitlActions } from './actions/hitlButton.js';
+import { registerInTaskAuthActions } from './actions/inTaskAuthButton.js';
 import { registerHitlModalHandler } from './views/hitlModal.js';
 import { registerReactionListeners } from './events/reactionHandler.js';
 import { Logger } from '../utils/logger.js';
@@ -121,6 +122,9 @@ export async function registerListeners(
   });
   registerHitlActions(app, makeHitlDeps);
   registerHitlModalHandler(app, makeHitlDeps);
+  // The in-task authorization card resumes the same way a HITL decision does,
+  // so it re-enters through the same per-event dependency factory.
+  registerInTaskAuthActions(app, makeHitlDeps);
 
   // Register reaction listeners for message feedback (requires console-backend)
   if (feedbackService) {

--- a/packages/client-slack/src/services/a2aClientService.ts
+++ b/packages/client-slack/src/services/a2aClientService.ts
@@ -60,8 +60,11 @@ function createAuthenticatedFetch(accessToken: string): typeof fetch {
       'X-A2A-Extensions',
       // intermediate-output is gated server-side on the client advertising it
       // (the orchestrator suppresses sub-agent reasoning otherwise) — advertise
-      // it so the "reasoning" thinking cards are populated.
-      'urn:nannos:a2a:activity-log:1.0, urn:nannos:a2a:work-plan:1.0, urn:nannos:a2a:intermediate-output:1.0, urn:nannos:a2a:feedback-request:1.0, urn:nannos:a2a:human-in-the-loop:1.0'
+      // it so the "reasoning" thinking cards are populated. in-task-auth is
+      // gated the same way: without it an `auth-required` status is prose the
+      // gateway wrote for the agent; with it the facts arrive as a DataPart and
+      // the authorization card is built from them.
+      'urn:nannos:a2a:activity-log:1.0, urn:nannos:a2a:work-plan:1.0, urn:nannos:a2a:intermediate-output:1.0, urn:nannos:a2a:feedback-request:1.0, urn:nannos:a2a:human-in-the-loop:1.0, urn:nannos:a2a:in-task-auth:1.0'
     );
     return fetch(input, {
       ...init,

--- a/packages/client-slack/src/utils/inTaskAuth.ts
+++ b/packages/client-slack/src/utils/inTaskAuth.ts
@@ -15,8 +15,6 @@
  */
 import { Part } from '@a2a-js/sdk';
 
-export const IN_TASK_AUTH_EXTENSION = 'urn:nannos:a2a:in-task-auth:1.0';
-
 /** First http(s) URL in a text blob — the fallback when nothing structured came. */
 const URL_IN_TEXT = /https?:\/\/[^\s<>"')]+/;
 
@@ -114,6 +112,14 @@ export function authSubject(prompt: AuthPrompt): string {
  * What the buttons send as text. Agent-facing, so it is the same English the
  * Embed SDK sends — the fallback for a server that never routed the DataPart,
  * while the DataPart beside it is what the middleware acts on when it did.
+ *
+ * On that fallback path the words are READ, not just logged: a fast-LLM
+ * classifier grades them approve / reject / unclear before the agent ever sees
+ * them (orchestrator ``AuthErrorDetectionMiddleware._after_auth_interrupt`` ->
+ * ``classify_reply``), and an unclear verdict costs the user a whole extra
+ * round. So keep both sentences blunt and unambiguous about the DECISION —
+ * softening them ("maybe later", "I'll get to it") is what makes them
+ * unclassifiable.
  */
 export function authResumeText(decision: 'approved' | 'declined', tool?: string): string {
   if (decision === 'approved') {

--- a/packages/client-slack/src/utils/inTaskAuth.ts
+++ b/packages/client-slack/src/utils/inTaskAuth.ts
@@ -15,8 +15,11 @@
  */
 import { Part } from '@a2a-js/sdk';
 
-/** First http(s) URL in a text blob — the fallback when nothing structured came. */
-const URL_IN_TEXT = /https?:\/\/[^\s<>"')]+/;
+/** First http(s) URL in a text blob — the fallback when nothing structured came.
+ *  The trailing class drops sentence punctuation the URL cannot have ended on:
+ *  the prose this scrapes is a paragraph, so "…visit https://host/begin." would
+ *  otherwise yield a link with a full stop welded on and a button that 404s. */
+const URL_IN_TEXT = /https?:\/\/[^\s<>"')]*[^\s<>"').,;:!?\]}]/;
 
 /**
  * Tool names that mean nothing to an end-user: sandbox and orchestration

--- a/packages/client-slack/src/utils/inTaskAuth.ts
+++ b/packages/client-slack/src/utils/inTaskAuth.ts
@@ -1,0 +1,234 @@
+/**
+ * The `urn:nannos:a2a:in-task-auth:1.0` extension, Slack side.
+ *
+ * A tool the agent wanted to use needs the END-USER's consent (the MCP
+ * gateway's `need-credentials`, surfaced as A2A's own `auth-required` task
+ * state). The state is protocol; the schema of what it carries is ours, and
+ * this reads it — the same precedence the Embed SDK uses (payload → metadata →
+ * prose), so both clients name the same service and link the same URL.
+ *
+ * The status text is NOT end-user copy: it is the gateway addressing the AGENT
+ * ("You must tell the end-user to…"), and the auth interrupt fires in
+ * middleware, before the model, so no LLM ever rewrites it. Slack used to post
+ * it verbatim. The card below is our own copy instead, and the wire text
+ * survives only as the fallback for a producer that gave us no URL to link.
+ */
+import { Part } from '@a2a-js/sdk';
+
+export const IN_TASK_AUTH_EXTENSION = 'urn:nannos:a2a:in-task-auth:1.0';
+
+/** First http(s) URL in a text blob — the fallback when nothing structured came. */
+const URL_IN_TEXT = /https?:\/\/[^\s<>"')]+/;
+
+/**
+ * Tool names that mean nothing to an end-user: sandbox and orchestration
+ * plumbing. The gateway call that needs authorization often runs INSIDE one of
+ * these (a `need-credentials` from an MCP call made in the sandbox is reported
+ * against `eval`), so naming them misinforms rather than informs. Anything else
+ * is shown verbatim — a mangled tool name is worse than a plain one.
+ * Kept in step with the Embed SDK's own list (auth-required-card.tsx).
+ */
+const OPAQUE_TOOLS = new Set(['eval', 'task', 'client_action', 'python', 'bash', 'shell', 'call_tool']);
+
+export interface AuthPrompt {
+  /** Where the user completes the flow. Without it there is no card, only text. */
+  authUrl?: string;
+  /** The tool call that needed the credential, when it is fit to name. */
+  tool?: string;
+  /** Whose credential this is (e.g. "github"), when the producer named one. */
+  service?: string;
+  /** The gateway's own words — agent-facing; shown only when there is no URL. */
+  message?: string;
+}
+
+/**
+ * The in-task-auth DataPart (`AuthPayload.client_payload()`), when one came.
+ *
+ * Only the first method carrying a URL is used: the model allows several ("try
+ * in order"), but a card offers one way forward, and a method without a URL is
+ * nothing a Slack button can act on.
+ */
+function readAuthDataPart(parts: Part[] | undefined): AuthPrompt | null {
+  for (const part of parts ?? []) {
+    if (part.kind !== 'data') continue;
+    const data = (part as { kind: 'data'; data: Record<string, unknown> }).data;
+    const requirement = data?.auth_requirement;
+    if (typeof requirement !== 'object' || requirement === null) continue;
+    const req = requirement as { service?: unknown; resource?: unknown; auth_methods?: unknown };
+    const methods = Array.isArray(req.auth_methods) ? req.auth_methods : [];
+    const withUrl = methods.find(
+      (m) => typeof (m as { auth_url?: unknown })?.auth_url === 'string' && (m as { auth_url: string }).auth_url
+    ) as { auth_url?: string } | undefined;
+    return {
+      ...(withUrl?.auth_url && { authUrl: withUrl.auth_url }),
+      // `resource` is the specific thing that needed the credential (the tool
+      // call); `service` is who it belongs to. The card names them differently.
+      ...(typeof req.resource === 'string' && req.resource && { tool: req.resource }),
+      ...(typeof req.service === 'string' && req.service && { service: req.service }),
+    };
+  }
+  return null;
+}
+
+/**
+ * The authorize target for an `auth-required` status, in descending order of how
+ * much the producer told us: the structured DataPart of the in-task-auth
+ * extension, then the status metadata (`auth_url` + the `tool` that asked), then
+ * — last resort — the first URL in the message text.
+ *
+ * That last resort scrapes a sentence written for the agent, and it stays only
+ * because a stranded user is worse than an ugly parse: producers that negotiated
+ * the extension never reach it.
+ */
+export function readAuthRequired(parts: Part[] | undefined, metadata?: Record<string, unknown>): AuthPrompt {
+  const text = (parts ?? [])
+    .filter((p) => p.kind === 'text')
+    .map((p) => (p as { kind: 'text'; text: string }).text)
+    .join('\n')
+    .trim();
+  const structured = readAuthDataPart(parts);
+  const fromMeta = metadata?.auth_url ?? metadata?.authUrl ?? metadata?.authorizeUrl;
+  const authUrl =
+    structured?.authUrl ??
+    (typeof fromMeta === 'string' && fromMeta ? fromMeta : (text.match(URL_IN_TEXT)?.[0] ?? undefined));
+  const rawTool = structured?.tool ?? (typeof metadata?.tool === 'string' ? metadata.tool : undefined);
+  const tool = rawTool && !OPAQUE_TOOLS.has(rawTool) ? rawTool : undefined;
+  // The same filter applies to the service: a producer filling it in from the
+  // tool name would otherwise slip `eval` past the check that exists precisely
+  // to keep sandbox plumbing out of the user's face.
+  const service = structured?.service && !OPAQUE_TOOLS.has(structured.service) ? structured.service : undefined;
+  return {
+    ...(authUrl && { authUrl }),
+    ...(tool && { tool }),
+    ...(service && { service }),
+    ...(text && { message: text }),
+  };
+}
+
+/** What to call the thing being authorized — nothing, when neither is fit to show. */
+export function authSubject(prompt: AuthPrompt): string {
+  return prompt.service || prompt.tool || '';
+}
+
+/**
+ * What the buttons send as text. Agent-facing, so it is the same English the
+ * Embed SDK sends — the fallback for a server that never routed the DataPart,
+ * while the DataPart beside it is what the middleware acts on when it did.
+ */
+export function authResumeText(decision: 'approved' | 'declined', tool?: string): string {
+  if (decision === 'approved') {
+    return tool
+      ? `I have completed the authorization for ${tool}. Please retry what needed it and continue.`
+      : 'I have completed the authorization. Please retry what needed it and continue.';
+  }
+  return tool
+    ? `I am not going to authorize ${tool}. Do not ask again — tell me what you cannot do without it.`
+    : 'I am not going to authorize this. Do not ask again — tell me what you cannot do without it.';
+}
+
+/** The DataPart the executor routes straight to the parked auth interrupt. */
+export function authorizationDataPart(decision: 'approved' | 'declined'): Record<string, unknown> {
+  return { authorization: { decision } };
+}
+
+export const AUTH_ACTION_OPEN = 'nannos_auth_open';
+export const AUTH_ACTION_DONE = 'nannos_auth_done';
+export const AUTH_ACTION_DECLINE = 'nannos_auth_decline';
+
+export interface AuthWidgetData extends AuthPrompt {
+  taskId: string;
+  contextId: string;
+  channelId: string;
+  threadTs: string;
+  /** Existing plan-widget ts, carried through the resume. */
+  planMessageTs?: string;
+  /** Open thinking-steps stream ts, so the resume continues the same widget. */
+  streamMessageTs?: string;
+}
+
+/**
+ * The authorization card: our copy, one link out and one answer back.
+ *
+ * Unlike the panel this does NOT walk through stages (Authorize, then "Done,
+ * continue"). Slack could — a link button fires an action too — but that makes
+ * the way forward depend on a `chat.update` succeeding, and a failed update
+ * would leave the user looking at a card with no way to confirm. All three
+ * buttons are therefore live from the start; on a chat surface a stable card
+ * reads better than a reactive one anyway.
+ */
+export function buildAuthRequiredWidget(data: AuthWidgetData): any[] {
+  const subject = authSubject(data);
+  const payload = {
+    taskId: data.taskId,
+    contextId: data.contextId,
+    channelId: data.channelId,
+    threadTs: data.threadTs,
+    subject,
+    ...(data.tool ? { tool: data.tool } : {}),
+    ...(data.planMessageTs ? { planMessageTs: data.planMessageTs } : {}),
+    ...(data.streamMessageTs ? { streamMessageTs: data.streamMessageTs } : {}),
+  };
+  const encodedData = Buffer.from(JSON.stringify(payload)).toString('base64');
+
+  const blocks: any[] = [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: [
+          `*🔐 ${subject ? `Authorization needed for ${subject}` : 'Authorization needed'}*`,
+          data.tool
+            ? `Nannos needs your permission to use \`${data.tool}\`.`
+            : 'Nannos needs your permission before it can continue.',
+        ].join('\n'),
+      },
+    },
+  ];
+
+  if (!data.authUrl) {
+    // No URL anywhere: the gateway's own text is all the user has to go on, so
+    // show it rather than an empty card. Answering is still offered — the user
+    // may be able to authorize by another route, and declining still needs to
+    // reach the agent.
+    if (data.message) {
+      blocks.push({ type: 'section', text: { type: 'mrkdwn', text: data.message.substring(0, 2900) } });
+    }
+  } else {
+    blocks.push({
+      type: 'context',
+      elements: [
+        { type: 'mrkdwn', text: 'Authorize in the browser, then come back and confirm here.' },
+      ],
+    });
+  }
+
+  const elements: any[] = [];
+  if (data.authUrl) {
+    elements.push({
+      type: 'button',
+      text: { type: 'plain_text', text: 'Authorize' },
+      // A URL button opens the browser; the action_id exists so Slack gets its
+      // ack (without one it warns "operation timeout" after 3s).
+      url: data.authUrl,
+      action_id: AUTH_ACTION_OPEN,
+      value: encodedData,
+      style: 'primary',
+    });
+  }
+  elements.push({
+    type: 'button',
+    text: { type: 'plain_text', text: 'Done, continue' },
+    action_id: AUTH_ACTION_DONE,
+    value: encodedData,
+  });
+  elements.push({
+    type: 'button',
+    text: { type: 'plain_text', text: "Don't allow" },
+    action_id: AUTH_ACTION_DECLINE,
+    value: encodedData,
+    style: 'danger',
+  });
+  blocks.push({ type: 'actions', elements });
+
+  return blocks;
+}

--- a/packages/client-slack/test/utils/inTaskAuth.test.ts
+++ b/packages/client-slack/test/utils/inTaskAuth.test.ts
@@ -75,6 +75,16 @@ describe('readAuthRequired', () => {
     expect(prompt.tool).toBeUndefined();
   });
 
+  test('the scrape stops before sentence punctuation', () => {
+    // The prose is a paragraph, so the URL is routinely followed by a full stop
+    // or a comma — welding one onto the link gives the button a 404.
+    const prompt = readAuthRequired([textPart(`Please go to ${AUTH_URL}. Then retry.`)], undefined);
+    expect(prompt.authUrl).toBe(AUTH_URL);
+    expect(
+      readAuthRequired([textPart(`see ${AUTH_URL}, then come back`)], undefined).authUrl
+    ).toBe(AUTH_URL);
+  });
+
   test('sandbox plumbing is never named as the thing being authorized', () => {
     // A `need-credentials` raised inside the sandbox is reported against `eval`;
     // "Authorization needed for eval" is worse than naming nothing at all.

--- a/packages/client-slack/test/utils/inTaskAuth.test.ts
+++ b/packages/client-slack/test/utils/inTaskAuth.test.ts
@@ -1,0 +1,160 @@
+/**
+ * The `in-task-auth` extension on Slack: A2A's `auth-required` state carries the
+ * facts as data, and the card is built from them instead of from a sentence the
+ * MCP gateway wrote for the agent. The properties worth pinning are the reading
+ * PRECEDENCE (payload → metadata → prose, so a producer that never negotiated
+ * the URN still works), that plumbing tool names never reach the user, and that
+ * both answers leave with a decision the executor can route.
+ */
+import { describe, test, expect } from '@jest/globals';
+import { Part } from '@a2a-js/sdk';
+import {
+  AUTH_ACTION_DECLINE,
+  AUTH_ACTION_DONE,
+  AUTH_ACTION_OPEN,
+  authResumeText,
+  authorizationDataPart,
+  authSubject,
+  buildAuthRequiredWidget,
+  readAuthRequired,
+} from '../../src/utils/inTaskAuth.js';
+
+const AUTH_URL = 'https://gatana.nannos.ringier.ch/api/v1/mcp-servers/oauth/gt_7MOP0ckoiO/begin';
+const GATEWAY_TEXT =
+  'This tool requires secondary authorization. You must tell the end-user to please go to the authorizeUrl.\n\n' +
+  `Please visit the following URL to complete authentication:\n${AUTH_URL}\n\n` +
+  'After completing authentication, you can retry your request.';
+
+const textPart = (text: string): Part => ({ kind: 'text', text }) as Part;
+const dataPart = (data: Record<string, unknown>): Part => ({ kind: 'data', data }) as Part;
+
+const payloadPart = (overrides: Record<string, unknown> = {}) =>
+  dataPart({
+    requires_auth: true,
+    auth_requirement: {
+      service: 'github',
+      resource: 'github_get_me',
+      auth_methods: [{ method: 'oauth2', description: 'GitHub OAuth', auth_url: AUTH_URL }],
+      ...overrides,
+    },
+  });
+
+function actionElements(blocks: any[]): any[] {
+  return blocks.find((b) => b.type === 'actions')?.elements ?? [];
+}
+function byAction(blocks: any[], actionId: string): any {
+  return actionElements(blocks).find((e) => e.action_id === actionId);
+}
+function decodedValue(blocks: any[], actionId: string): any {
+  return JSON.parse(Buffer.from(byAction(blocks, actionId).value, 'base64').toString());
+}
+
+describe('readAuthRequired', () => {
+  test('the DataPart wins: service and the tool that asked arrive separately', () => {
+    const prompt = readAuthRequired([textPart(GATEWAY_TEXT), payloadPart()], {
+      auth_url: 'https://wrong.example/other',
+      tool: 'eval',
+    });
+    expect(prompt.authUrl).toBe(AUTH_URL);
+    expect(prompt.service).toBe('github');
+    expect(prompt.tool).toBe('github_get_me');
+    // The gateway's own words ride along for the no-URL fallback only.
+    expect(prompt.message).toContain('secondary authorization');
+  });
+
+  test('falls back to status metadata when no payload came', () => {
+    const prompt = readAuthRequired([textPart(GATEWAY_TEXT)], { auth_url: AUTH_URL, tool: 'github_get_me' });
+    expect(prompt.authUrl).toBe(AUTH_URL);
+    expect(prompt.tool).toBe('github_get_me');
+    expect(prompt.service).toBeUndefined();
+  });
+
+  test('last resort: scrapes the URL out of the prose', () => {
+    const prompt = readAuthRequired([textPart(GATEWAY_TEXT)], undefined);
+    expect(prompt.authUrl).toBe(AUTH_URL);
+    expect(prompt.tool).toBeUndefined();
+  });
+
+  test('sandbox plumbing is never named as the thing being authorized', () => {
+    // A `need-credentials` raised inside the sandbox is reported against `eval`;
+    // "Authorization needed for eval" is worse than naming nothing at all.
+    const fromMeta = readAuthRequired([textPart(GATEWAY_TEXT)], { auth_url: AUTH_URL, tool: 'eval' });
+    expect(fromMeta.tool).toBeUndefined();
+    expect(authSubject(fromMeta)).toBe('');
+
+    const fromPayload = readAuthRequired([payloadPart({ service: 'eval', resource: 'eval' })], undefined);
+    expect(fromPayload.service).toBeUndefined();
+    expect(fromPayload.tool).toBeUndefined();
+  });
+
+  test('a method without a URL is nothing a button can act on', () => {
+    const prompt = readAuthRequired(
+      [textPart('no link here'), payloadPart({ auth_methods: [{ method: 'ciba', description: 'push' }] })],
+      undefined
+    );
+    expect(prompt.authUrl).toBeUndefined();
+    expect(prompt.service).toBe('github');
+  });
+});
+
+describe('buildAuthRequiredWidget', () => {
+  const base = { taskId: 't1', contextId: 'ctx', channelId: 'C1', threadTs: '100.0' };
+
+  test('links the provider and offers both answers', () => {
+    const blocks = buildAuthRequiredWidget({ ...base, ...readAuthRequired([textPart(GATEWAY_TEXT), payloadPart()], {}) });
+
+    expect(byAction(blocks, AUTH_ACTION_OPEN).url).toBe(AUTH_URL);
+    expect(byAction(blocks, AUTH_ACTION_DONE)).toBeDefined();
+    expect(byAction(blocks, AUTH_ACTION_DECLINE).style).toBe('danger');
+
+    // Our own copy names the service in the head and the tool in the body — the
+    // gateway's agent-facing prose is not rendered when there is a URL to link.
+    const rendered = JSON.stringify(blocks);
+    expect(rendered).toContain('Authorization needed for github');
+    expect(rendered).toContain('github_get_me');
+    expect(rendered).not.toContain('You must tell the end-user');
+  });
+
+  test('carries the routing ids the resume re-enters with', () => {
+    const blocks = buildAuthRequiredWidget({
+      ...base,
+      ...readAuthRequired([payloadPart()], {}),
+      planMessageTs: '99.1',
+      streamMessageTs: '99.2',
+    });
+    expect(decodedValue(blocks, AUTH_ACTION_DONE)).toMatchObject({
+      taskId: 't1',
+      contextId: 'ctx',
+      channelId: 'C1',
+      threadTs: '100.0',
+      tool: 'github_get_me',
+      subject: 'github',
+      planMessageTs: '99.1',
+      streamMessageTs: '99.2',
+    });
+  });
+
+  test('with no URL anywhere, the wire text is shown rather than an empty card', () => {
+    const prompt = readAuthRequired([textPart('Authorization is required to continue.')], undefined);
+    const blocks = buildAuthRequiredWidget({ ...base, ...prompt });
+
+    expect(byAction(blocks, AUTH_ACTION_OPEN)).toBeUndefined();
+    expect(JSON.stringify(blocks)).toContain('Authorization is required to continue.');
+    // Declining still has to reach the agent, so the answers stay.
+    expect(byAction(blocks, AUTH_ACTION_DONE)).toBeDefined();
+    expect(byAction(blocks, AUTH_ACTION_DECLINE)).toBeDefined();
+  });
+});
+
+describe('the answer sent back', () => {
+  test('the DataPart is what the executor routes to the parked interrupt', () => {
+    expect(authorizationDataPart('approved')).toEqual({ authorization: { decision: 'approved' } });
+    expect(authorizationDataPart('declined')).toEqual({ authorization: { decision: 'declined' } });
+  });
+
+  test('the prose beside it names the tool and tells the agent what to do', () => {
+    expect(authResumeText('approved', 'github_get_me')).toContain('github_get_me');
+    expect(authResumeText('approved', 'github_get_me')).toContain('retry');
+    expect(authResumeText('declined')).toContain('Do not ask again');
+  });
+});

--- a/packages/orchestrator-agent/app/core/a2a_extensions.py
+++ b/packages/orchestrator-agent/app/core/a2a_extensions.py
@@ -181,10 +181,19 @@ carrying::
 
 ``approved`` retries the blocked tool (a credential that still is not there
 raises the prompt again); ``declined`` tells the agent to stop pushing the URL.
-Sending no DataPart is NOT a rejection: the user's own words are handed to the
-model node instead, which reads them (see AuthErrorDetectionMiddleware). Clients
-send agent-facing prose alongside the DataPart so a server that never routed it
-still behaves sanely.
+
+Sending no DataPart is NOT a rejection, and it is not left to a keyword match
+either. A reply in words goes through AuthErrorDetectionMiddleware's ladder: a
+small fast-LLM classifier reads it against the question that was actually asked
+("ok, done" -> approved, "no, those scopes are too wide" -> declined), and only a
+clear verdict is acted on; anything it cannot read — including a failed
+classification, which never counts as consent — hands the user's words plus both
+options to the model node, which runs next anyway. A genuine "done" therefore
+still ends in a retry, one round later than a click would have.
+
+That ladder is why clients send agent-facing prose alongside the DataPart: it is
+what a server that never routed the DataPart falls back to, and it is written to
+be classifiable rather than merely polite.
 
 Consumers: the Embed SDK / web client (auth-required-card.tsx), the Slack client
 (utils/inTaskAuth.ts) and the Google Chat client (utils/inTaskAuth.ts).

--- a/packages/orchestrator-agent/app/core/a2a_extensions.py
+++ b/packages/orchestrator-agent/app/core/a2a_extensions.py
@@ -172,8 +172,22 @@ Only the requirement half ever crosses the wire: ``AuthPayload.client_payload()`
 cannot emit ``oauth2_client_config``, which carries a client secret.
 
 Unlike the human-in-the-loop extension this carries no ``review_configs``:
-nothing is being proposed, so there is no decision for the gateway to receive.
-The client resumes the task with a message once the user has authenticated.
+nothing is being PROPOSED, so there is nothing for the gateway to refuse. The
+answer is still a decision, though — it is addressed to the AGENT, which is
+holding a blocked tool call. A client resumes the parked task with a message
+carrying::
+
+  {"authorization": {"decision": "approved"|"declined"}}
+
+``approved`` retries the blocked tool (a credential that still is not there
+raises the prompt again); ``declined`` tells the agent to stop pushing the URL.
+Sending no DataPart is NOT a rejection: the user's own words are handed to the
+model node instead, which reads them (see AuthErrorDetectionMiddleware). Clients
+send agent-facing prose alongside the DataPart so a server that never routed it
+still behaves sanely.
+
+Consumers: the Embed SDK / web client (auth-required-card.tsx), the Slack client
+(utils/inTaskAuth.ts) and the Google Chat client (utils/inTaskAuth.ts).
 """
 
 # Keep in sync with the repo-root a2a-extensions.json registry (pinned by


### PR DESCRIPTION
closes ringier-data/nannos#178

Building on #177: the Slack and Google Chat clients now register for `urn:nannos:a2a:in-task-auth:1.0` and handle the in-task auth interrupt the way the web client does.

Before this, neither client advertised the URN, so an `auth-required` status arrived as prose the MCP gateway wrote **for the agent** ("You must tell the end-user to…") — and both clients posted it verbatim. The user read machine-to-machine instructions with the authorize URL buried inside, and had no way to *answer* the parked interrupt: typing a sentence left the model to guess whether it meant "done" or "no".

## What each client gained

1. **Negotiation** — `in-task-auth` added to `X-A2A-Extensions`. Emission is gated server-side on it, so without it the status stays prose.
2. **Reading the payload** — a new `src/utils/inTaskAuth.ts` per client, with the same precedence as the SDK's `readAuthRequired`: DataPart → status metadata → last-resort URL scrape out of the prose. A producer that never negotiated the URN therefore keeps working unchanged. It also carries over the SDK's `OPAQUE_TOOLS` filter, so a `need-credentials` reported against `eval` never becomes "Authorization needed for eval".
3. **Our own card** instead of the gateway's prose:
   - Slack: `buildAuthRequiredWidget` posted as its own message, with the timeline paused (`streamer.pause('Awaiting your authorization')`) and the in-flight record released the way a HITL pause does. The card's message becomes the decision receipt on resume.
   - Google Chat: `googleChatService.buildInTaskAuthCard`, posted privately; finalizing gained `suppressStatusText` so the prose is not posted beside the card that replaced it — anything streamed *before* the interrupt is still delivered from the artifacts.
   - The wire text survives only as the fallback when no URL was found anywhere.
4. **Answering the interrupt** — both buttons resume with `{"authorization": {"decision": "approved"|"declined"}}` plus the same English agent-facing prose the panel sends (the fallback for a server that never routed the DataPart). Slack: a new `listeners/actions/inTaskAuthButton.ts`, including an ack-only handler on the URL button so Slack does not warn "operation timeout". Google Chat: a new `in_task_auth_card` case in `buttonClickedHandler`.

One deliberate divergence from the panel: neither card walks through stages (Authorize → then "Done, continue"). A Google Chat `openLink` reports nothing back, and on Slack it would make the way forward depend on a `chat.update` succeeding — so all buttons are live from the start.

The orchestrator change is documentation only: the extension's contract still claimed there was no decision for a client to send, which #177 had already made untrue.

## Verification

- `npx tsc --noEmit` clean in both clients.
- `client-slack`: 77/77 jest tests pass (10 new); `client-google-chat`: 29/29 (7 new). The new tests pin the reading precedence (payload / metadata / prose), the plumbing-name filter, card contents and routing ids, and the answer shapes.
- `npx eslint .` cannot run in either client in this environment — the private `@alloy-ch/eslint-config-alloy` is not installed. Pre-existing, unrelated to this change.

## Checklist
- [x] I have performed a self-review of my code
- [x] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨 — no: the extension is additive and negotiated, and a producer that never sends the DataPart is handled by the metadata/prose fallbacks.