### PR TITLE
fix(agent-common): don't orphan a tool result when force-stopping a loop

### DIFF
--- a/packages/agent-common/agent_common/middleware/loop_detection_middleware.py
+++ b/packages/agent-common/agent_common/middleware/loop_detection_middleware.py
@@ -36,13 +36,23 @@ import json
 import logging
 from typing import Annotated, Any
 
-from langchain.agents.middleware.types import AgentMiddleware, AgentState, PrivateStateAttr
+from langchain.agents.middleware.types import AgentMiddleware, AgentState, PrivateStateAttr, hook_config
 from langchain_core.messages import AIMessage, ToolCall, ToolMessage
 from langgraph.runtime import Runtime
 from langgraph.typing import ContextT
 from typing_extensions import NotRequired
 
 logger = logging.getLogger(__name__)
+
+#: Terminal response tools. These are how a turn *delivers its answer*, not tools the
+#: model chooses between — every turn ends in exactly one of them, and the sub-agent
+#: pass-through variant carries byte-identical arguments every time
+#: (``{"task_state": "completed", "message": "", "include_subagent_output": true}``).
+#: ``tool_call_history`` is cumulative for the whole thread, so tracking them makes a
+#: block inevitable on any sufficiently long conversation: ~6 pass-through turns trip
+#: ``max_repeats``, ~11 turns trip ``max_tool_repeats``. Blocking the response tool is
+#: never right — there is no loop to break, only an answer to deliver.
+RESPONSE_TOOLS: frozenset[str] = frozenset({"FinalResponseSchema", "SubAgentResponseSchema"})
 
 
 class LoopDetectionState(AgentState):
@@ -84,6 +94,8 @@ class RepeatedToolCallMiddleware(AgentMiddleware[LoopDetectionState, ContextT]):
     - dispatch_tools: Tools exempt from max_tool_repeats (e.g. dispatch/meta-tools
       like 'task' that delegate to sub-agents). These are still subject to
       max_repeats (same args) detection.
+    - response_tools: Terminal response tools, exempt from detection altogether
+      (see ``RESPONSE_TOOLS``).
     """
 
     state_schema = LoopDetectionState  # type: ignore[assignment]
@@ -97,6 +109,7 @@ class RepeatedToolCallMiddleware(AgentMiddleware[LoopDetectionState, ContextT]):
         window_size: int = 10,
         force_stop_after: int = 3,
         dispatch_tools: set[str] | None = {"task"},
+        response_tools: frozenset[str] | set[str] | None = None,
     ):
         """Initialize loop detection middleware.
 
@@ -106,13 +119,15 @@ class RepeatedToolCallMiddleware(AgentMiddleware[LoopDetectionState, ContextT]):
             max_tool_repeats: Same tool threshold (default: 5)
             window_size: Sliding window size (default: 10)
             force_stop_after: After blocking a tool this many consecutive times,
-                strip tool_calls from the AIMessage to force the graph to END.
+                end the run (jump to END) instead of letting the model retry.
                 This prevents infinite block-retry loops when the model ignores
                 error messages. (default: 3)
             dispatch_tools: Set of tool names exempt from max_tool_repeats.
                 Dispatch/meta-tools (e.g. 'task') delegate to sub-agents and are
                 expected to be called many times with different arguments. They are
                 still subject to max_repeats (same args) detection.
+            response_tools: Terminal response tools, excluded from tracking entirely
+                (see ``RESPONSE_TOOLS``). Pass an empty set to disable the exemption.
         """
         super().__init__()
         self.tool_name = tool_name
@@ -121,11 +136,12 @@ class RepeatedToolCallMiddleware(AgentMiddleware[LoopDetectionState, ContextT]):
         self.window_size = window_size
         self.force_stop_after = force_stop_after
         self.dispatch_tools = dispatch_tools or set()
+        self.response_tools = frozenset(RESPONSE_TOOLS if response_tools is None else response_tools)
         logger.info(
             f"RepeatedToolCallMiddleware initialized: tool_name={tool_name}, "
             f"max_repeats={max_repeats}, max_tool_repeats={max_tool_repeats}, "
             f"window_size={window_size}, force_stop_after={force_stop_after}, "
-            f"dispatch_tools={self.dispatch_tools}"
+            f"dispatch_tools={self.dispatch_tools}, response_tools={sorted(self.response_tools)}"
         )
 
     @property
@@ -161,6 +177,9 @@ class RepeatedToolCallMiddleware(AgentMiddleware[LoopDetectionState, ContextT]):
         Returns:
             True if this middleware should track this tool call.
         """
+        # Terminal response tools are never loop candidates — see ``RESPONSE_TOOLS``.
+        if tool_call["name"] in self.response_tools:
+            return False
         return self.tool_name is None or tool_call["name"] == self.tool_name
 
     def _build_error_message(self, info: dict[str, Any]) -> str:
@@ -226,6 +245,7 @@ class RepeatedToolCallMiddleware(AgentMiddleware[LoopDetectionState, ContextT]):
 
         return False, 0, ""
 
+    @hook_config(can_jump_to=["end"])
     async def aafter_model(
         self,
         state: LoopDetectionState,
@@ -237,6 +257,8 @@ class RepeatedToolCallMiddleware(AgentMiddleware[LoopDetectionState, ContextT]):
         - Only blocks looping tool calls with error ToolMessages
         - Lets non-looping calls execute normally
         - Updates history state for tracking
+        - Never rewrites an existing message: a tool call that already has a result is
+          left alone, so a stop can never orphan a tool result
 
         Args:
             state: Current agent state
@@ -251,13 +273,26 @@ class RepeatedToolCallMiddleware(AgentMiddleware[LoopDetectionState, ContextT]):
             return None
 
         last_ai_message = None
-        for message in reversed(messages):
-            if isinstance(message, AIMessage):
-                last_ai_message = message
+        last_ai_index = -1
+        for index in range(len(messages) - 1, -1, -1):
+            if isinstance(messages[index], AIMessage):
+                last_ai_message = messages[index]
+                last_ai_index = index
                 break
 
         if not last_ai_message or not last_ai_message.tool_calls:
             return None
+
+        # Tool calls that already have a result at this point. ``after_model`` hooks run
+        # innermost-first, so a result can already exist before this one runs — the HITL
+        # middleware answers a rejected call while keeping the call itself, and the model
+        # node emits an AIMessage together with its ToolMessage for structured-output
+        # responses. Answering such a call a second time would leave the turn with two
+        # toolResult blocks for one toolUse, which Anthropic models reject with a hard
+        # 400 on *every* subsequent turn (the conversation is bricked, not just the turn).
+        already_answered = {
+            message.tool_call_id for message in messages[last_ai_index + 1 :] if isinstance(message, ToolMessage)
+        }
 
         # Get current history (per-tool tracking).
         # Deep-copy: shallow .copy() shares inner lists, and .append() below
@@ -330,9 +365,9 @@ class RepeatedToolCallMiddleware(AgentMiddleware[LoopDetectionState, ContextT]):
             logger.debug(f"[LOOP DETECTION] Tracked {len(last_ai_message.tool_calls)} tool call(s)")
             return {"tool_call_history": history}
 
-        # Check if we should force-stop by stripping tool_calls from the AIMessage.
-        # This prevents the infinite block-retry loop where the model ignores error
-        # messages and keeps retrying the same tool call.
+        # Check if we should force-stop and end the run. This prevents the infinite
+        # block-retry loop where the model ignores error messages and keeps retrying
+        # the same tool call.
         should_force_stop = any(
             info["repeat_count"] - self.max_repeats >= self.force_stop_after
             if info["loop_type"] == "same_args"
@@ -345,28 +380,31 @@ class RepeatedToolCallMiddleware(AgentMiddleware[LoopDetectionState, ContextT]):
         all_tracked_blocked = len(blocked_calls) == len(tracked_calls)
 
         if should_force_stop and all_tracked_blocked:
-            # Strip tool_calls from AIMessage by returning a modified copy with same ID.
-            # LangGraph's message reducer upserts by ID, so this replaces the original.
-            # With no tool_calls, the graph routes to END instead of tools node.
+            # End the run by jumping to END, leaving the message history untouched.
+            #
+            # This used to rebuild the AIMessage without its tool_calls (same id, upserted
+            # by the message reducer) so that routing would fall through to END. That
+            # rewrite is what orphans a tool result: any result already emitted for those
+            # calls — by the HITL middleware, or by the model node's own structured-output
+            # branch, which returns the AIMessage and its ToolMessage in one update — is
+            # left answering a tool call that no longer exists. The gateway then rejects
+            # the whole conversation on every later turn. Stopping a tool must never
+            # orphan its output, so express the stop as what it actually is (end the run)
+            # instead of as message surgery.
             blocked_names = [info["tool_name"] for info in blocked_calls]
             logger.warning(
                 f"[LOOP DETECTION] Force-stopping: {blocked_names} blocked "
-                f"{self.force_stop_after}+ consecutive times. Stripping tool_calls to end loop."
-            )
-
-            # Preserve any text content the model generated alongside the tool calls
-            modified_ai = AIMessage(
-                content=last_ai_message.content or "",
-                id=last_ai_message.id,
-                response_metadata=last_ai_message.response_metadata,
+                f"{self.force_stop_after}+ consecutive times. Ending the run."
             )
             return {
                 "tool_call_history": history,
-                "messages": [modified_ai],
+                "jump_to": "end",
             }
 
         # Build error ToolMessages for blocked calls (only blocked ones!)
-        # Frame as permanent failure (not rate-limiting) so models don't stubbornly retry
+        # Frame as permanent failure (not rate-limiting) so models don't stubbornly retry.
+        # Calls that already carry a result are skipped: a second result for the same
+        # ``tool_call_id`` is one toolResult block too many for the preceding turn.
         error_messages = [
             ToolMessage(
                 content=self._build_error_message(info),
@@ -375,7 +413,15 @@ class RepeatedToolCallMiddleware(AgentMiddleware[LoopDetectionState, ContextT]):
                 status="error",
             )
             for info in blocked_calls
+            if info["tool_call"]["id"] not in already_answered
         ]
+
+        if not error_messages:
+            logger.info(
+                "[LOOP DETECTION] All blocked call(s) already have results; "
+                "recording history only to avoid duplicate tool results"
+            )
+            return {"tool_call_history": history}
 
         logger.info(
             f"[LOOP DETECTION] Blocked {len(blocked_calls)} looping tool call(s): "

--- a/packages/agent-common/agent_common/middleware/loop_detection_middleware.py
+++ b/packages/agent-common/agent_common/middleware/loop_detection_middleware.py
@@ -54,6 +54,12 @@ logger = logging.getLogger(__name__)
 #: never right — there is no loop to break, only an answer to deliver.
 RESPONSE_TOOLS: frozenset[str] = frozenset({"FinalResponseSchema", "SubAgentResponseSchema"})
 
+#: Result given to a call that never ran because the run was force-stopped over a
+#: *different* looping call on the same turn.
+_STOPPED_BEFORE_EXECUTION = (
+    "BLOCKED: the run was stopped because another tool call on this turn was looping. This call was not executed."
+)
+
 
 class LoopDetectionState(AgentState):
     """Extended agent state with tool call tracking for loop detection.
@@ -396,10 +402,32 @@ class RepeatedToolCallMiddleware(AgentMiddleware[LoopDetectionState, ContextT]):
                 f"[LOOP DETECTION] Force-stopping: {blocked_names} blocked "
                 f"{self.force_stop_after}+ consecutive times. Ending the run."
             )
-            return {
-                "tool_call_history": history,
-                "jump_to": "end",
-            }
+
+            # Answer every call that has no result yet before ending. A tool call left
+            # unanswered in the checkpoint is the mirror image of the orphaned result —
+            # the next turn sends a tool_use with no tool_result, which providers reject
+            # just as hard (cf. ``_seal_dangling_tool_calls`` on the adoption path).
+            # Appending results can never remove a call, so this direction is always safe.
+            blocked_by_id = {info["tool_call"]["id"]: info for info in blocked_calls}
+            stop_messages = [
+                ToolMessage(
+                    content=(
+                        self._build_error_message(blocked_by_id[tool_call["id"]])
+                        if tool_call["id"] in blocked_by_id
+                        else _STOPPED_BEFORE_EXECUTION
+                    ),
+                    tool_call_id=tool_call["id"],
+                    name=tool_call["name"],
+                    status="error",
+                )
+                for tool_call in last_ai_message.tool_calls
+                if tool_call.get("id") and tool_call["id"] not in already_answered
+            ]
+
+            update: dict[str, Any] = {"tool_call_history": history, "jump_to": "end"}
+            if stop_messages:
+                update["messages"] = stop_messages
+            return update
 
         # Build error ToolMessages for blocked calls (only blocked ones!)
         # Frame as permanent failure (not rate-limiting) so models don't stubbornly retry.

--- a/packages/agent-common/tests/test_loop_detection_graph_e2e.py
+++ b/packages/agent-common/tests/test_loop_detection_graph_e2e.py
@@ -1,0 +1,329 @@
+"""Graph-level tests for loop force-stop (issue #182).
+
+The unit tests call ``aafter_model`` directly and take on faith that the state update it
+returns does the right thing once LangGraph applies it. These run a *real* agent graph with
+a real checkpointer instead, because the bug that bricked conversations was never visible
+in a single hook call: it was written into the checkpoint, and only the *next* turn died.
+
+So the assertions here are about what ends up persisted, and about what the model is handed
+when the conversation is resumed — which is exactly what the provider validates:
+
+* every ``ToolMessage`` answers a ``tool_call`` on the immediately preceding ``AIMessage``
+  (no orphaned result → ``toolResult blocks … exceeds … toolUse blocks``), and
+* every ``tool_call`` has exactly one result (no dangling call → ``tool_use`` with no
+  ``tool_result``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import pytest
+from langchain.agents.factory import create_agent
+from langchain.agents.structured_output import ToolStrategy
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.tools import StructuredTool
+from langgraph.checkpoint.memory import InMemorySaver
+from pydantic import BaseModel, Field
+
+from agent_common.middleware.loop_detection_middleware import RepeatedToolCallMiddleware
+
+
+def assert_tool_pairing_valid(messages: list[BaseMessage]) -> None:
+    """Assert the message list satisfies the provider's tool-call/result contract.
+
+    This is the offline proxy for what Bedrock enforces; a list that fails here is one the
+    gateway rejects with a hard 400, permanently, because it lives in the checkpoint.
+    """
+    answered: dict[str, int] = {}
+    open_calls: dict[str, str] = {}
+
+    for position, message in enumerate(messages):
+        if isinstance(message, ToolMessage):
+            assert message.tool_call_id in open_calls, (
+                f"orphaned tool result at index {position}: tool_call_id "
+                f"{message.tool_call_id!r} matches no tool call on the preceding AIMessage"
+            )
+            answered[message.tool_call_id] = answered.get(message.tool_call_id, 0) + 1
+            assert answered[message.tool_call_id] == 1, (
+                f"duplicate tool result at index {position} for {message.tool_call_id!r}"
+            )
+        elif isinstance(message, AIMessage):
+            unanswered = [cid for cid in open_calls if cid not in answered]
+            assert not unanswered, (
+                f"dangling tool call(s) {unanswered} left unanswered before the AIMessage at index {position}"
+            )
+            open_calls = {tc["id"]: tc["name"] for tc in message.tool_calls if tc.get("id")}
+
+    unanswered = [cid for cid in open_calls if cid not in answered]
+    assert not unanswered, f"dangling tool call(s) {unanswered} at the end of the conversation"
+
+
+class _SearchArgs(BaseModel):
+    q: str = Field(description="query")
+
+
+def _make_search_tool() -> StructuredTool:
+    def _search(q: str) -> str:
+        return "no results"
+
+    return StructuredTool.from_function(func=_search, name="search", description="search", args_schema=_SearchArgs)
+
+
+class _LoopingModel(BaseChatModel):
+    """A model that keeps making the same tool call until told to stop.
+
+    Records every message list it is handed, so a test can assert on what would actually
+    have gone to the provider rather than only on what was persisted.
+    """
+
+    calls: int = 0
+    stop_looping: bool = False
+    seen_requests: list = []
+
+    @property
+    def _llm_type(self) -> str:
+        return "looping"
+
+    def bind_tools(self, tools: list, **kwargs: Any) -> "_LoopingModel":
+        return self
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: Optional[list[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        self.seen_requests.append(list(messages))
+        self.calls += 1
+        # A runaway loop would hang the suite; fail loudly instead.
+        assert self.calls < 25, "force-stop never ended the run"
+
+        if self.stop_looping:
+            message: BaseMessage = AIMessage(content="Here is the answer.")
+        else:
+            message = AIMessage(
+                content="",
+                tool_calls=[{"name": "search", "args": {"q": "always the same"}, "id": f"call-{self.calls}"}],
+            )
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+
+def _build_agent(model: _LoopingModel):
+    return create_agent(
+        model=model,
+        tools=[_make_search_tool()],
+        middleware=[
+            RepeatedToolCallMiddleware(
+                max_repeats=1,
+                window_size=10,
+                # Block on the 2nd identical call, force-stop on the 3rd.
+                force_stop_after=2,
+            )
+        ],
+        checkpointer=InMemorySaver(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_force_stop_ends_the_run_and_leaves_a_valid_checkpoint():
+    model = _LoopingModel(seen_requests=[])
+    agent = _build_agent(model)
+    config = {"configurable": {"thread_id": "loop-1"}}
+
+    result = await agent.ainvoke({"messages": [HumanMessage(content="search for it")]}, config)
+
+    # The run terminated on its own — jump_to: "end" really does end the assembled graph,
+    # not just return a state update the unit tests can inspect.
+    assert model.calls < 25
+
+    messages = result["messages"]
+    assert_tool_pairing_valid(messages)
+
+    # The looping call was stopped, and stopping it did not leave it unanswered.
+    last_ai = next(m for m in reversed(messages) if isinstance(m, AIMessage))
+    assert last_ai.tool_calls, "the AIMessage must keep its tool calls — rewriting it is what orphans results"
+    blocked = [m for m in messages if isinstance(m, ToolMessage) and m.status == "error"]
+    assert blocked, "the blocked call must be answered, not left dangling"
+    assert blocked[-1].tool_call_id == last_ai.tool_calls[0]["id"]
+
+
+@pytest.mark.asyncio
+async def test_conversation_resumes_cleanly_after_a_force_stop():
+    """The regression that bricked threads: the turn *after* the stop.
+
+    A force-stopped turn is only harmless if the next turn can still be sent.
+
+    Note this covers resume for a *plain* tool loop, where the stopped call never produced
+    a result — that shape survives the old stripping behaviour too, so this test alone does
+    not discriminate between old and new. ``test_structured_output_turns_never_corrupt_the_checkpoint``
+    is the discriminating one: there the result exists before the stop.
+    """
+    model = _LoopingModel(seen_requests=[])
+    agent = _build_agent(model)
+    config = {"configurable": {"thread_id": "loop-2"}}
+
+    await agent.ainvoke({"messages": [HumanMessage(content="search for it")]}, config)
+    calls_after_first_turn = model.calls
+
+    # Same thread: the force-stopped history is replayed from the checkpoint.
+    model.stop_looping = True
+    result = await agent.ainvoke({"messages": [HumanMessage(content="never mind, just answer")]}, config)
+
+    assert model.calls > calls_after_first_turn, "the resumed turn never reached the model"
+
+    # What the model was handed on the resumed turn is what the provider would have seen.
+    assert_tool_pairing_valid(model.seen_requests[-1])
+    assert_tool_pairing_valid(result["messages"])
+
+    # And the turn produced a normal answer rather than dying on the replayed history.
+    assert result["messages"][-1].content == "Here is the answer."
+
+
+@pytest.mark.asyncio
+async def test_pairing_helper_catches_both_failure_shapes():
+    """Guard the guard: the invariant must actually reject the two bad shapes."""
+    orphan = [
+        AIMessage(content="", id="ai", tool_calls=[]),
+        ToolMessage(content="result", tool_call_id="gone", name="search"),
+    ]
+    with pytest.raises(AssertionError, match="orphaned tool result"):
+        assert_tool_pairing_valid(orphan)
+
+    dangling = [
+        AIMessage(content="", id="ai", tool_calls=[{"name": "search", "args": {}, "id": "unanswered"}]),
+    ]
+    with pytest.raises(AssertionError, match="dangling tool call"):
+        assert_tool_pairing_valid(dangling)
+
+
+class AnswerSchema(BaseModel):
+    """Terminal response schema, under a name the exemption does not cover.
+
+    Deliberately not called ``FinalResponseSchema``: this exercises the force-stop path
+    itself, independently of which tool names happen to be exempt from loop detection.
+    """
+
+    task_state: str = Field(description="state")
+    message: str = Field(description="answer")
+
+
+class _StructuredOutputModel(BaseChatModel):
+    """Always answers by calling the response schema with identical arguments.
+
+    This is the production shape. With a ``ToolStrategy`` response format the model node
+    returns ``{"messages": [AIMessage, ToolMessage]}`` — the call *and* its result in one
+    state update — so by the time ``after_model`` runs, the result already exists. That is
+    what made stripping ``tool_calls`` corrupt the checkpoint.
+    """
+
+    calls: int = 0
+    seen_requests: list = []
+    schema_name: str = "AnswerSchema"
+
+    @property
+    def _llm_type(self) -> str:
+        return "structured"
+
+    def bind_tools(self, tools: list, **kwargs: Any) -> "_StructuredOutputModel":
+        return self
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: Optional[list[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        self.seen_requests.append(list(messages))
+        self.calls += 1
+        assert self.calls < 25, "the run never terminated"
+        return ChatResult(
+            generations=[
+                ChatGeneration(
+                    message=AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": self.schema_name,
+                                # Byte-identical every turn, exactly like the sub-agent
+                                # pass-through variant in production.
+                                "args": {"task_state": "completed", "message": ""},
+                                "id": f"answer-{self.calls}",
+                            }
+                        ],
+                    )
+                )
+            ]
+        )
+
+
+class FinalResponseSchema(BaseModel):
+    """The real terminal response schema name, which ``RESPONSE_TOOLS`` exempts."""
+
+    task_state: str = Field(description="state")
+    message: str = Field(description="answer")
+
+
+def _build_structured_agent(model: _StructuredOutputModel, *, schema: type[BaseModel] = AnswerSchema):
+    return create_agent(
+        model=model,
+        tools=[],
+        response_format=ToolStrategy(schema),
+        middleware=[
+            RepeatedToolCallMiddleware(
+                max_repeats=1,
+                window_size=10,
+                force_stop_after=2,
+            )
+        ],
+        checkpointer=InMemorySaver(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_structured_output_turns_never_corrupt_the_checkpoint():
+    """The production path, reproduced: repeated turns that each end in the response tool.
+
+    ``tool_call_history`` is cumulative across turns, so turn 2 is blocked and turn 3
+    force-stops — the same ladder the failing thread walked, in three turns instead of
+    thirteen. Before the fix, turn 2 appended a second result for a call that already had
+    one, and turn 3 stripped the call its result belonged to; from then on every turn
+    replayed an illegal history.
+    """
+    model = _StructuredOutputModel(seen_requests=[])
+    agent = _build_structured_agent(model)
+    config = {"configurable": {"thread_id": "structured-1"}}
+
+    for turn in range(4):
+        result = await agent.ainvoke({"messages": [HumanMessage(content=f"question {turn}")]}, config)
+        # What the model was handed is what the provider would have received.
+        assert_tool_pairing_valid(model.seen_requests[-1])
+        assert_tool_pairing_valid(result["messages"])
+
+    # Four turns actually happened — the conversation never got stuck or bricked.
+    assert model.calls >= 4
+
+
+@pytest.mark.asyncio
+async def test_response_tool_is_never_force_stopped():
+    """The exemption, end to end: the terminal response tool is not a loop candidate."""
+    model = _StructuredOutputModel(seen_requests=[], schema_name="FinalResponseSchema")
+    agent = _build_structured_agent(model, schema=FinalResponseSchema)
+    config = {"configurable": {"thread_id": "structured-2"}}
+
+    for turn in range(6):
+        result = await agent.ainvoke({"messages": [HumanMessage(content=f"question {turn}")]}, config)
+        assert_tool_pairing_valid(result["messages"])
+
+    # No BLOCKED result was ever produced for the response tool.
+    blocked = [
+        m
+        for m in result["messages"]
+        if isinstance(m, ToolMessage) and isinstance(m.content, str) and m.content.startswith("BLOCKED:")
+    ]
+    assert not blocked, "the terminal response tool must never be blocked as a loop"

--- a/packages/agent-common/tests/test_loop_detection_graph_e2e.py
+++ b/packages/agent-common/tests/test_loop_detection_graph_e2e.py
@@ -36,10 +36,21 @@ def assert_tool_pairing_valid(messages: list[BaseMessage]) -> None:
     """Assert the message list satisfies the provider's tool-call/result contract.
 
     This is the offline proxy for what Bedrock enforces; a list that fails here is one the
-    gateway rejects with a hard 400, permanently, because it lives in the checkpoint.
+    gateway rejects with a hard 400, permanently, because it lives in the checkpoint. The
+    rule is per *turn*, not global: results must follow their ``AIMessage`` immediately, so
+    anything else appearing in between (a ``HumanMessage``, say) closes the group — a
+    result arriving after that answers nothing, and a call left open is dangling.
     """
-    answered: dict[str, int] = {}
-    open_calls: dict[str, str] = {}
+    open_calls: set[str] = set()
+    answered: set[str] = set()
+    opened_at = 0
+
+    def _close(position: int) -> None:
+        unanswered = sorted(open_calls - answered)
+        assert not unanswered, (
+            f"dangling tool call(s) {unanswered} from the AIMessage at index {opened_at}: "
+            f"no result before index {position}"
+        )
 
     for position, message in enumerate(messages):
         if isinstance(message, ToolMessage):
@@ -47,19 +58,22 @@ def assert_tool_pairing_valid(messages: list[BaseMessage]) -> None:
                 f"orphaned tool result at index {position}: tool_call_id "
                 f"{message.tool_call_id!r} matches no tool call on the preceding AIMessage"
             )
-            answered[message.tool_call_id] = answered.get(message.tool_call_id, 0) + 1
-            assert answered[message.tool_call_id] == 1, (
+            assert message.tool_call_id not in answered, (
                 f"duplicate tool result at index {position} for {message.tool_call_id!r}"
             )
-        elif isinstance(message, AIMessage):
-            unanswered = [cid for cid in open_calls if cid not in answered]
-            assert not unanswered, (
-                f"dangling tool call(s) {unanswered} left unanswered before the AIMessage at index {position}"
-            )
-            open_calls = {tc["id"]: tc["name"] for tc in message.tool_calls if tc.get("id")}
+            answered.add(message.tool_call_id)
+            continue
 
-    unanswered = [cid for cid in open_calls if cid not in answered]
-    assert not unanswered, f"dangling tool call(s) {unanswered} at the end of the conversation"
+        _close(position)
+        # Any non-result message ends the group; only an AIMessage opens a new one. Ids are
+        # tracked per group rather than globally, so the check does not rely on tool_call_id
+        # being unique across the whole conversation.
+        open_calls, answered = set(), set()
+        if isinstance(message, AIMessage) and message.tool_calls:
+            open_calls = {tc["id"] for tc in message.tool_calls if tc.get("id")}
+            opened_at = position
+
+    _close(len(messages))
 
 
 class _SearchArgs(BaseModel):
@@ -201,6 +215,25 @@ async def test_pairing_helper_catches_both_failure_shapes():
     ]
     with pytest.raises(AssertionError, match="dangling tool call"):
         assert_tool_pairing_valid(dangling)
+
+    # The provider's rule is per turn: the result must directly follow its call.
+    separated = [
+        AIMessage(content="", id="ai", tool_calls=[{"name": "search", "args": {}, "id": "late"}]),
+        HumanMessage(content="actually, never mind"),
+        ToolMessage(content="result", tool_call_id="late", name="search"),
+    ]
+    with pytest.raises(AssertionError, match="dangling tool call"):
+        assert_tool_pairing_valid(separated)
+
+    # Ids are scoped per turn, so reuse across turns is not a duplicate.
+    reused = [
+        AIMessage(content="", id="ai1", tool_calls=[{"name": "search", "args": {}, "id": "same"}]),
+        ToolMessage(content="result", tool_call_id="same", name="search"),
+        HumanMessage(content="again"),
+        AIMessage(content="", id="ai2", tool_calls=[{"name": "search", "args": {}, "id": "same"}]),
+        ToolMessage(content="result", tool_call_id="same", name="search"),
+    ]
+    assert_tool_pairing_valid(reused)
 
 
 class AnswerSchema(BaseModel):

--- a/packages/agent-common/tests/test_loop_detection_graph_e2e.py
+++ b/packages/agent-common/tests/test_loop_detection_graph_e2e.py
@@ -66,8 +66,10 @@ class _SearchArgs(BaseModel):
     q: str = Field(description="query")
 
 
-def _make_search_tool() -> StructuredTool:
+def _make_search_tool(executions: list | None = None) -> StructuredTool:
     def _search(q: str) -> str:
+        if executions is not None:
+            executions.append(q)
         return "no results"
 
     return StructuredTool.from_function(func=_search, name="search", description="search", args_schema=_SearchArgs)
@@ -113,10 +115,10 @@ class _LoopingModel(BaseChatModel):
         return ChatResult(generations=[ChatGeneration(message=message)])
 
 
-def _build_agent(model: _LoopingModel):
+def _build_agent(model: _LoopingModel, executions: list | None = None):
     return create_agent(
         model=model,
-        tools=[_make_search_tool()],
+        tools=[_make_search_tool(executions)],
         middleware=[
             RepeatedToolCallMiddleware(
                 max_repeats=1,
@@ -327,3 +329,74 @@ async def test_response_tool_is_never_force_stopped():
         if isinstance(m, ToolMessage) and isinstance(m.content, str) and m.content.startswith("BLOCKED:")
     ]
     assert not blocked, "the terminal response tool must never be blocked as a loop"
+
+
+@pytest.mark.asyncio
+async def test_blocking_still_fires_on_the_turn_after_a_force_stop():
+    """The counter must survive the stop — otherwise the next turn runs the loop again.
+
+    ``tool_call_history`` is private state carried in the checkpoint. If a force-stop lost
+    it (or reset it), the very next turn would start from zero: the looping call would be
+    executed again and the user would be back where they started, one turn later. So the
+    check is behavioural — on the turn after a stop, the same call must be refused
+    *without* the tool running.
+    """
+    executions: list = []
+    model = _LoopingModel(seen_requests=[])
+    agent = _build_agent(model, executions)
+    config = {"configurable": {"thread_id": "loop-3"}}
+
+    await agent.ainvoke({"messages": [HumanMessage(content="search for it")]}, config)
+    executions_after_first_turn = len(executions)
+    assert executions_after_first_turn, "the tool should have run before the loop was detected"
+
+    # Same thread, same looping model: the model asks for the identical call again.
+    result = await agent.ainvoke({"messages": [HumanMessage(content="try again")]}, config)
+
+    # Refused on the strength of history carried over from the previous turn — the gate
+    # still holds, and the tool did not execute a single further time.
+    assert len(executions) == executions_after_first_turn, (
+        "the looping tool ran again after the force-stop — the repeat counter was lost"
+    )
+
+    last_ai = next(m for m in reversed(result["messages"]) if isinstance(m, AIMessage))
+    refusal = next(m for m in reversed(result["messages"]) if isinstance(m, ToolMessage))
+    assert refusal.tool_call_id == last_ai.tool_calls[0]["id"]
+    assert refusal.status == "error"
+    assert_tool_pairing_valid(result["messages"])
+
+
+@pytest.mark.asyncio
+async def test_do_not_retry_guidance_reaches_the_model_on_the_next_turn():
+    """The refusal is only useful if the model can still read it when it next runs.
+
+    The BLOCKED result is what tells the model to stop retrying and answer with what it
+    has. It is written into the checkpoint on the stopped turn, so the turn after must
+    replay it verbatim — if it were dropped or rewritten, the model would be refused with
+    no idea why, and would simply try again.
+    """
+    model = _LoopingModel(seen_requests=[])
+    agent = _build_agent(model)
+    config = {"configurable": {"thread_id": "loop-4"}}
+
+    await agent.ainvoke({"messages": [HumanMessage(content="search for it")]}, config)
+
+    model.stop_looping = True
+    await agent.ainvoke({"messages": [HumanMessage(content="never mind")]}, config)
+
+    replayed = model.seen_requests[-1]
+    guidance = [
+        m.content
+        for m in replayed
+        if isinstance(m, ToolMessage) and isinstance(m.content, str) and m.content.startswith("BLOCKED:")
+    ]
+    assert guidance, "the model was refused on the previous turn but sees no explanation now"
+    assert any("Do NOT retry with the same arguments" in text for text in guidance)
+    assert any("respond to the user with what you have so far" in text for text in guidance)
+
+    # Specifically the *force-stopped* call must carry it. The stopped call used to get no
+    # result at all, so the model was left with a bare unanswered call and no reason.
+    stopped_call = next(m.tool_calls[0]["id"] for m in reversed(replayed) if isinstance(m, AIMessage) and m.tool_calls)
+    stopped_result = next(m for m in replayed if isinstance(m, ToolMessage) and m.tool_call_id == stopped_call)
+    assert stopped_result.content.startswith("BLOCKED:")
+    assert "Do NOT retry with the same arguments" in stopped_result.content

--- a/packages/agent-common/tests/test_loop_detection_middleware.py
+++ b/packages/agent-common/tests/test_loop_detection_middleware.py
@@ -314,8 +314,10 @@ class TestForceStop:
         assert result is not None
         # Ends the run outright. Crucially it does NOT rewrite the AIMessage: doing so
         # orphans any tool result already emitted for the stripped call (issue #182).
+        # The unanswered call is sealed with a result so it is not left dangling.
         assert result["jump_to"] == "end"
-        assert "messages" not in result
+        assert [m.tool_call_id for m in result["messages"]] == ["tc-1"]
+        assert result["messages"][0].status == "error"
 
     @pytest.mark.asyncio
     async def test_no_force_stop_below_threshold(self):
@@ -392,9 +394,11 @@ class TestForceStop:
                 assert len(result["messages"]) == 1
                 assert isinstance(result["messages"][0], ToolMessage)
             else:
-                # 3rd block: force-stop — end the run, message history untouched
+                # 3rd block: force-stop — end the run; the blocked call is answered
+                # (never left dangling) and no existing message is rewritten.
                 assert result["jump_to"] == "end"
-                assert "messages" not in result
+                assert len(result["messages"]) == 1
+                assert result["messages"][0].tool_call_id == f"tc-fs-{block_round}"
 
     """Test dispatch_tools parameter for exempting dispatcher tools from max_tool_repeats."""
 
@@ -574,7 +578,7 @@ class TestAlreadyAnsweredToolCalls:
 
         assert result is not None
         # The run still stops — but by jumping to END, not by stripping the tool call
-        # that ``rejection`` answers.
+        # that ``rejection`` answers, and without answering it a second time.
         assert result["jump_to"] == "end"
         assert "messages" not in result
 
@@ -728,3 +732,39 @@ class TestResponseToolsExempt:
         assert middleware._matches_tool_filter({"name": "search", "args": {}, "id": "x"}) is True
         for name in RESPONSE_TOOLS:
             assert middleware._matches_tool_filter({"name": name, "args": {}, "id": "x"}) is False
+
+    @pytest.mark.asyncio
+    async def test_force_stop_seals_every_unanswered_call_on_the_turn(self):
+        """No tool call may survive a force-stop unanswered — including untracked ones.
+
+        ``all_tracked_blocked`` ignores calls this middleware doesn't track (an exempt
+        response tool, or one filtered out by ``tool_name``), so force-stop can fire on a
+        turn that also carries such a call. Leaving it unanswered puts a ``tool_use`` with
+        no ``tool_result`` in the checkpoint — the mirror image of the orphaned result,
+        and rejected just as hard on the next turn.
+        """
+        from langchain_core.messages import AIMessage, ToolMessage
+
+        middleware = RepeatedToolCallMiddleware(tool_name="search", max_repeats=3, force_stop_after=2, window_size=20)
+
+        args_hash = middleware._hash_args({"q": "x"})
+        ai_message = AIMessage(
+            content="",
+            id="msg-mixed",
+            tool_calls=[
+                {"name": "search", "args": {"q": "x"}, "id": "tc-looping"},
+                {"name": "read_file", "args": {"path": "/a"}, "id": "tc-untracked"},
+            ],
+        )
+
+        state = {"messages": [ai_message], "tool_call_history": {"search": [args_hash] * 5}}
+
+        result = await middleware.aafter_model(state, MagicMock())
+
+        assert result is not None
+        assert result["jump_to"] == "end"
+        answered = {m.tool_call_id for m in result["messages"] if isinstance(m, ToolMessage)}
+        assert answered == {"tc-looping", "tc-untracked"}
+        # The untracked call did not loop — it simply never ran.
+        untracked = next(m for m in result["messages"] if m.tool_call_id == "tc-untracked")
+        assert "not executed" in untracked.content

--- a/packages/agent-common/tests/test_loop_detection_middleware.py
+++ b/packages/agent-common/tests/test_loop_detection_middleware.py
@@ -284,11 +284,11 @@ class TestEdgeCases:
 
 
 class TestForceStop:
-    """Test force-stop behavior that strips tool_calls from AIMessage."""
+    """Test force-stop behavior that ends the run once a tool keeps looping."""
 
     @pytest.mark.asyncio
     async def test_force_stop_strips_tool_calls_after_threshold(self):
-        """After force_stop_after consecutive blocks, tool_calls are stripped from AIMessage."""
+        """After force_stop_after consecutive blocks, the run ends (no message rewrite)."""
         from langchain_core.messages import AIMessage
 
         middleware = RepeatedToolCallMiddleware(max_repeats=3, force_stop_after=2, window_size=20)
@@ -312,12 +312,10 @@ class TestForceStop:
         result = await middleware.aafter_model(state, MagicMock())
 
         assert result is not None
-        # Should return a modified AIMessage (same ID, no tool_calls)
-        assert "messages" in result
-        modified_msg = result["messages"][0]
-        assert isinstance(modified_msg, AIMessage)
-        assert modified_msg.id == "msg-123"
-        assert modified_msg.tool_calls == []
+        # Ends the run outright. Crucially it does NOT rewrite the AIMessage: doing so
+        # orphans any tool result already emitted for the stripped call (issue #182).
+        assert result["jump_to"] == "end"
+        assert "messages" not in result
 
     @pytest.mark.asyncio
     async def test_no_force_stop_below_threshold(self):
@@ -394,10 +392,9 @@ class TestForceStop:
                 assert len(result["messages"]) == 1
                 assert isinstance(result["messages"][0], ToolMessage)
             else:
-                # 3rd block: force-stop — AIMessage with stripped tool_calls
-                assert len(result["messages"]) == 1
-                assert isinstance(result["messages"][0], AIMessage)
-                assert result["messages"][0].tool_calls == []
+                # 3rd block: force-stop — end the run, message history untouched
+                assert result["jump_to"] == "end"
+                assert "messages" not in result
 
     """Test dispatch_tools parameter for exempting dispatcher tools from max_tool_repeats."""
 
@@ -536,3 +533,198 @@ class TestErrorMessages:
         assert "many times" in msg.lower()
         assert "BLOCKED" in msg
         assert "respond to the user" in msg
+
+
+class TestAlreadyAnsweredToolCalls:
+    """Regression tests for issue #182 — stopping a tool must not orphan its output.
+
+    ``after_model`` hooks run innermost-first, so a tool call can already have a result
+    by the time this hook runs: the HITL middleware answers a rejected call while
+    keeping the call, and the model node emits an AIMessage together with its
+    ToolMessage for structured-output responses. Answering such a call again, or
+    removing the call the result belongs to, leaves the conversation with a tool result
+    that matches no tool call — a hard 400 on every later turn.
+    """
+
+    @pytest.mark.asyncio
+    async def test_force_stop_never_rewrites_messages(self):
+        from langchain_core.messages import AIMessage, ToolMessage
+
+        middleware = RepeatedToolCallMiddleware(max_repeats=3, force_stop_after=2, window_size=20)
+
+        args_hash = middleware._hash_args({"path": "/file.txt"})
+        ai_message = AIMessage(
+            content="",
+            id="msg-789",
+            tool_calls=[{"name": "read_personal_file", "args": {"path": "/file.txt"}, "id": "tc-9"}],
+        )
+        rejection = ToolMessage(
+            content="User rejected the tool call.",
+            tool_call_id="tc-9",
+            name="read_personal_file",
+            status="error",
+        )
+
+        state = {
+            "messages": [ai_message, rejection],
+            "tool_call_history": {"read_personal_file": [args_hash] * 5},
+        }
+
+        result = await middleware.aafter_model(state, MagicMock())
+
+        assert result is not None
+        # The run still stops — but by jumping to END, not by stripping the tool call
+        # that ``rejection`` answers.
+        assert result["jump_to"] == "end"
+        assert "messages" not in result
+
+    @pytest.mark.asyncio
+    async def test_no_duplicate_blocked_result_for_answered_call(self):
+        from langchain_core.messages import AIMessage, ToolMessage
+
+        middleware = RepeatedToolCallMiddleware(max_repeats=3, force_stop_after=99, window_size=20)
+
+        args_hash = middleware._hash_args({"path": "/file.txt"})
+        ai_message = AIMessage(
+            content="",
+            id="msg-790",
+            tool_calls=[{"name": "read_personal_file", "args": {"path": "/file.txt"}, "id": "tc-10"}],
+        )
+        tool_message = ToolMessage(content="file contents", tool_call_id="tc-10", name="read_personal_file")
+
+        state = {
+            "messages": [ai_message, tool_message],
+            "tool_call_history": {"read_personal_file": [args_hash] * 3},
+        }
+
+        result = await middleware.aafter_model(state, MagicMock())
+
+        assert result is not None
+        assert "messages" not in result
+
+    @pytest.mark.asyncio
+    async def test_blocked_result_still_emitted_for_unanswered_call(self):
+        """The fix must not disarm blocking for calls that have not run yet."""
+        from langchain_core.messages import AIMessage, ToolMessage
+
+        middleware = RepeatedToolCallMiddleware(max_repeats=3, force_stop_after=99, window_size=20)
+
+        args_hash = middleware._hash_args({"path": "/file.txt"})
+        ai_message = AIMessage(
+            content="",
+            id="msg-791",
+            tool_calls=[{"name": "read_personal_file", "args": {"path": "/file.txt"}, "id": "tc-11"}],
+        )
+
+        state = {
+            "messages": [ai_message],
+            "tool_call_history": {"read_personal_file": [args_hash] * 3},
+        }
+
+        result = await middleware.aafter_model(state, MagicMock())
+
+        assert result is not None
+        assert len(result["messages"]) == 1
+        assert isinstance(result["messages"][0], ToolMessage)
+        assert result["messages"][0].tool_call_id == "tc-11"
+        assert result["messages"][0].status == "error"
+
+    @pytest.mark.asyncio
+    async def test_hook_can_jump_to_end(self):
+        """The graph only honours ``jump_to`` when the hook declares it."""
+        from langchain.agents.factory import _get_can_jump_to
+
+        assert "end" in _get_can_jump_to(RepeatedToolCallMiddleware(), "after_model")
+
+
+class TestResponseToolsExempt:
+    """The terminal response tools are never loop candidates (issue #182).
+
+    ``FinalResponseSchema`` is how a turn delivers its answer — once per turn, and with
+    byte-identical arguments whenever a sub-agent's output is passed through. Since
+    ``tool_call_history`` is cumulative for the whole thread, tracking it makes a block
+    inevitable on any long conversation.
+    """
+
+    @pytest.mark.asyncio
+    async def test_final_response_schema_never_blocked(self):
+        from langchain_core.messages import AIMessage
+
+        middleware = RepeatedToolCallMiddleware(max_repeats=5, max_tool_repeats=10, window_size=10)
+
+        args = {"task_state": "completed", "message": "", "include_subagent_output": True}
+        args_hash = middleware._hash_args(args)
+        ai_message = AIMessage(
+            content="",
+            id="msg-resp",
+            tool_calls=[{"name": "FinalResponseSchema", "args": args, "id": "tc-resp"}],
+        )
+
+        # Far past both thresholds on the identical-args *and* per-tool counts.
+        state = {
+            "messages": [ai_message],
+            "tool_call_history": {"FinalResponseSchema": [args_hash] * 40},
+        }
+
+        result = await middleware.aafter_model(state, MagicMock())
+
+        # Not tracked at all: no block, no force-stop, no history growth for it.
+        assert result is not None
+        assert "messages" not in result
+        assert "jump_to" not in result
+        assert len(result["tool_call_history"]["FinalResponseSchema"]) == 40
+
+    @pytest.mark.asyncio
+    async def test_sub_agent_response_schema_also_exempt(self):
+        from langchain_core.messages import AIMessage
+
+        middleware = RepeatedToolCallMiddleware(max_repeats=1, window_size=10)
+
+        args = {"task_state": "completed"}
+        ai_message = AIMessage(
+            content="",
+            id="msg-resp2",
+            tool_calls=[{"name": "SubAgentResponseSchema", "args": args, "id": "tc-resp2"}],
+        )
+        state = {
+            "messages": [ai_message],
+            "tool_call_history": {"SubAgentResponseSchema": [middleware._hash_args(args)] * 10},
+        }
+
+        result = await middleware.aafter_model(state, MagicMock())
+
+        assert result is not None
+        assert "messages" not in result
+        assert "jump_to" not in result
+
+    @pytest.mark.asyncio
+    async def test_exemption_can_be_disabled(self):
+        """Opt-out keeps the old behaviour for callers that want it."""
+        from langchain_core.messages import AIMessage, ToolMessage
+
+        middleware = RepeatedToolCallMiddleware(max_repeats=3, force_stop_after=99, response_tools=set())
+
+        args = {"task_state": "completed"}
+        ai_message = AIMessage(
+            content="",
+            id="msg-resp3",
+            tool_calls=[{"name": "FinalResponseSchema", "args": args, "id": "tc-resp3"}],
+        )
+        state = {
+            "messages": [ai_message],
+            "tool_call_history": {"FinalResponseSchema": [middleware._hash_args(args)] * 5},
+        }
+
+        result = await middleware.aafter_model(state, MagicMock())
+
+        assert result is not None
+        assert isinstance(result["messages"][0], ToolMessage)
+
+    def test_ordinary_tool_still_tracked(self):
+        from agent_common.middleware.loop_detection_middleware import RESPONSE_TOOLS
+
+        middleware = RepeatedToolCallMiddleware(max_repeats=3)
+
+        assert middleware._matches_tool_filter({"name": "search", "args": {}, "id": "x"}) is True
+        for name in RESPONSE_TOOLS:
+            assert middleware._matches_tool_filter({"name": name, "args": {}, "id": "x"}) is False


### PR DESCRIPTION
closes #182

## What was actually wrong

A conversation died with a hard 400 from Bedrock — `The number of toolResult blocks at
messages.N.content exceeds the number of toolUse blocks of previous turn` — and stayed
dead: the illegal messages sit in the persisted checkpoint, so every later turn replays
them and fails identically.

Reconstructing the failing thread's message list refutes the issue's summarization
hypothesis: that thread had never been summarized (full unsummarized history, below the
trigger, no summary message, no summarization event). The corruption is written by
`RepeatedToolCallMiddleware`, via two independent defects.

### 1. The response tool was treated as a loop candidate

`FinalResponseSchema` is how a turn *delivers its answer* — once per turn — and the
sub-agent pass-through variant carries byte-identical arguments every time:

```json
{"include_subagent_output": true, "message": "", "task_state": "completed"}
```

`tool_call_history` is cumulative for the whole thread, never reset at a turn boundary, so
with `max_repeats=5` / `max_tool_repeats=10` / `force_stop_after=3` a block is arithmetic,
not bad luck. The failing thread walked exactly that ladder:

| call | verdict |
|---|---|
| 6th identical-args | `same_args` block — *"called 5 times with identical arguments"* |
| 7th identical | block — *"called 6 times"* |
| 12th call to the tool | `same_tool` block — *"called 12 times (with 5 different argument sets)"* |
| 13th call | 13−10 = 3 ≥ `force_stop_after` → **force-stop** |

`dispatch_tools` already exempts `task`/`eval` from `max_tool_repeats`, but nothing
exempted the terminal response tools from anything. They are now excluded from detection
altogether (`RESPONSE_TOOLS`, opt-out via `response_tools=set()`): there is no loop to
break there, only an answer to deliver.

### 2. Force-stop orphaned the tool result

Force-stop rebuilt the `AIMessage` without its `tool_calls` (same `id`, upserted by the
message reducer) so routing would fall through to `END`. But the model node's
structured-output branch returns `{"messages": [output, ToolMessage(...)]}` — the
`AIMessage` **and** its result in one update — so the result is always already there. The
rebuilt message removed the call it answered, leaving:

| # | type | `tool_calls` | `tool_call_id` |
|---|------|--------------|----------------|
| n | `ai` | `[]` (`finish_reason == "tool_calls"`) | — |
| n+1 | `tool` | — | `tooluse_…` (matches nothing) |

Force-stop now ends the run by jumping to `END` instead of rewriting the `AIMessage`, so
stopping a tool cannot orphan its output. This also covers the HITL path, which answers a
rejected call while deliberately keeping the call on the `AIMessage`.

Ending the run is not enough on its own, though: a call left unanswered in the checkpoint
is the mirror image of the orphan — the next turn sends a `tool_use` with no `tool_result`,
which providers reject just as hard (the repo already treats that shape as invalid, see
`_seal_dangling_tool_calls`, which only ever runs on the adoption path). So force-stop
first *seals* every call on the turn that has no result yet — blocked ones with their
`BLOCKED` message, any other unanswered call (an exempt response tool, or one outside a
`tool_name`-filtered instance, neither of which counts toward `all_tracked_blocked`) with a
"not executed" result — and then jumps to `END`. Only ever appending results means no
existing message is rewritten, so neither failure shape can be reintroduced.

Additionally: a blocked call that already has a result no longer receives a second,
`BLOCKED` result — two `toolResult` blocks for one `toolUse` is the same illegal shape.

## Scope

Deliberately write-side only. An earlier revision of this PR also added a
request-boundary middleware that repaired already-corrupted message lists; it was dropped
as not worth the complexity. **Consequence: threads already carrying an orphan in their
checkpoint stay broken** and need to be started fresh — this PR stops new ones being
created.

## Verification

- `agent-common` 961, `orchestrator-agent` 769, `agent-runner` 35, `ringier-a2a-sdk` 390 — all passing
- New regression tests: the exemption (both response tools, plus the opt-out), force-stop
  against an already-answered call, sealing of every unanswered call on a mixed
  tracked/untracked turn, no duplicate `BLOCKED` result, and a check that the hook actually
  declares `can_jump_to=["end"]` (the graph ignores `jump_to` otherwise).

### Graph-level tests

`tests/test_loop_detection_graph_e2e.py` runs a real agent graph with a real checkpointer
and asserts the provider's own contract against both the persisted history and the message
list handed to the model on the *resumed* turn — the turn that actually died in production.

`assert_tool_pairing_valid` is the offline proxy for that contract, enforced per turn as the
provider does: every result answers a call on the immediately preceding `AIMessage`, every
call has exactly one result, any other message closes the group, and ids are scoped per turn
rather than globally.

Seven tests:

- a plain tool loop force-stops, ends the run, and leaves a valid checkpoint;
- the conversation resumes cleanly afterwards;
- the production shape — repeated `ToolStrategy` turns (where the model node emits the
  `AIMessage` and its result in one update) walking the same block-then-force-stop ladder as
  the failing thread, in three turns instead of thirteen;
- the terminal response tool is never blocked or force-stopped;
- **the repeat counter survives the stop** — asserted behaviourally: on the turn after a
  stop the identical call is refused and the tool does not execute again, so a lost
  `tool_call_history` (which would silently re-run the loop one turn later) fails the test;
- **the "do NOT retry" guidance is replayed to the model** on the next turn, attached to the
  refused call — it previously got no result at all;
- the invariant helper itself rejects an orphan, a dangling call, and a result separated
  from its call.

**Verified non-vacuous against every revision this PR passed through**, by swapping in the
older middleware and re-running: 4 of 7 fail against pre-fix (`abd4b7bc`), and 4 of 7
against the intermediate `jump_to: "end"`-without-sealing revision (`bb63fcb6`). The two
sets differ, so the suite pins both failure directions — the orphaned result and the
dangling call — not just the original bug.

## Checklist
- [x] I have performed a self-review of my code
- [x] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨
