### PR TITLE
Score tool risk through tool calling, not strict json_schema

### DIFF
--- a/packages/agent-common/agent_common/core/tool_risk_scorer.py
+++ b/packages/agent-common/agent_common/core/tool_risk_scorer.py
@@ -267,7 +267,20 @@ async def _score_tool_via_llm(
     from agent_common.core.model_factory import create_model, get_default_fast_model, require_default_model
 
     model = create_model(get_default_fast_model() or require_default_model(), streaming=False)
-    structured_model = model.with_structured_output(ToolRiskOutput)
+    # method="function_calling", not the langchain-openai>=0.3 default of "json_schema".
+    # OpenAI's strict structured-output validator requires every object to declare
+    # additionalProperties: false and to list every property in `required`, but
+    # ToolRiskOutput is built on open maps (risk_factors, risky_values) whose keys are
+    # the tool's own parameter names, unknowable ahead of the call. Under the default
+    # every scoring request came back 400 ("'additionalProperties' is required to be
+    # supplied and to be false"), so each tool silently fell through to the
+    # deterministic fallback after paying a full round trip.
+    #
+    # Tool calling accepts the same schema and is what the rest of this stack already
+    # speaks: the gateway normalizes every provider (Bedrock included) into
+    # OpenAI-shape tool_calls (see a2a.structured_response.select_response_format,
+    # which picks ToolStrategy for the same reason).
+    structured_model = model.with_structured_output(ToolRiskOutput, method="function_calling")
 
     # Build user prompt with tool details
     schema_str = json.dumps(input_schema, indent=2) if input_schema else "No schema available"


### PR DESCRIPTION
langchain-openai>=0.3 defaults with_structured_output to method "json_schema", which OpenAI validates strictly: every object must declare additionalProperties: false and list all properties in `required`. ToolRiskOutput is built on open maps (risk_factors, risky_values) keyed by the scored tool's own parameter names, so it can never satisfy that.

Every scoring call therefore came back 400 and fell through to the deterministic fallback, but only after a full round trip, and a failed call is never cached, so the same tools were rescored on every message. Measured on the deployed stack: four tools per turn, ~1.6s each.

"function_calling" accepts the same schema, and it is what the rest of the stack already speaks: tools go out via convert_to_openai_tool and the gateway normalizes every provider (Bedrock included) into OpenAI-shape tool_calls, the same reasoning behind ToolStrategy in a2a.structured_response.select_response_format. Verified against the live gateway: the default 400s, function_calling returns 0.05 for get_current_time.

closes #

## Checklist
- [x] I have performed a self-review of my code
- [x] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨
