### PR TITLE
fix(a2a): don't drop a stringified sub_agent_id on dispatch

### DIFF
--- a/packages/agent-runner/agent/core.py
+++ b/packages/agent-runner/agent/core.py
@@ -638,10 +638,21 @@ class AgentRunner(BaseAgent):
         message_meta = _extract_message_metadata(task)
 
         # Struct numbers arrive as floats (protobuf doubles); coerce the ids back
-        # to int — e.g. the sub-agent config URL path rejects "42.0".
+        # to int — e.g. the sub-agent config URL path rejects "42.0". Numeric strings are
+        # accepted too: a caller that stringifies the id must not silently turn into a
+        # no-op run (the sub-agent branch below is skipped when this returns None).
         def _meta_int(key: str) -> int | None:
             value = message_meta.get(key)
-            return int(value) if isinstance(value, int | float) else None
+            if isinstance(value, bool):
+                return None
+            if isinstance(value, int | float):
+                return int(value)
+            if isinstance(value, str):
+                try:
+                    return int(float(value))
+                except ValueError:
+                    logger.warning("Ignoring non-numeric %s in message metadata: %r", key, value)
+            return None
 
         sub_agent_id: int | None = _meta_int("sub_agent_id")
         scheduled_job_id: int | None = _meta_int("scheduled_job_id")

--- a/packages/agent-runner/tests/test_agent_runner_security.py
+++ b/packages/agent-runner/tests/test_agent_runner_security.py
@@ -267,6 +267,25 @@ class TestDispatchShapes:
         assert next(i for i in items if i.get("scheduler_status") == "success")["agent_message"] == ("Handled it.")
 
     @pytest.mark.asyncio
+    async def test_a_stringified_sub_agent_id_still_runs_the_sub_agent(self, agent_runner):
+        """A caller that stringifies the id must not silently produce a no-op success."""
+        agent_runner._fetch_sub_agent_config = AsyncMock(
+            return_value={"type": "automated", "name": "debug", "sub_agent_id": 5}
+        )
+        agent_runner._execute_sub_agent = AsyncMock(return_value=("Investigated.", "completed"))
+        items = await self._run(agent_runner, self._task("5"), "Investigate bug report abc.")
+
+        agent_runner._fetch_sub_agent_config.assert_awaited_once()
+        assert agent_runner._fetch_sub_agent_config.await_args[0][0] == 5
+        assert next(i for i in items if i.get("scheduler_status") == "success")["agent_message"] == "Investigated."
+
+    @pytest.mark.asyncio
+    async def test_a_non_numeric_sub_agent_id_is_ignored(self, agent_runner):
+        agent_runner._execute_sub_agent = AsyncMock()
+        await self._run(agent_runner, self._task("not-an-id"), "text")
+        agent_runner._execute_sub_agent.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_an_empty_dispatch_falls_back_to_the_default_instruction(self, agent_runner):
         agent_runner._fetch_sub_agent_config = AsyncMock(
             return_value={"type": "automated", "name": "triage", "sub_agent_id": 5}

--- a/packages/console-backend/console_backend/services/debug_agent_service.py
+++ b/packages/console-backend/console_backend/services/debug_agent_service.py
@@ -40,8 +40,13 @@ class DebugAgentService:
         self._agent_runner_url = agent_runner_url.rstrip("/")
         self._oauth_service = oauth_service
 
-    async def get_debug_agent_id(self, db: AsyncSession) -> str | None:
-        """Find the active debug agent (system_role='debug', approved with default_version)."""
+    async def get_debug_agent_id(self, db: AsyncSession) -> int | None:
+        """Find the active debug agent (system_role='debug', approved with default_version).
+
+        Returned as int: agent-runner reads sub_agent_id off the A2A message metadata
+        through a numeric coercion, so a stringified id is silently dropped and the run
+        completes without ever executing the sub-agent.
+        """
         result = await db.execute(
             text(
                 "SELECT id FROM sub_agents "
@@ -50,7 +55,7 @@ class DebugAgentService:
             )
         )
         row = result.scalar_one_or_none()
-        return str(row) if row is not None else None
+        return int(row) if row is not None else None
 
     async def trigger_debug(
         self,
@@ -102,7 +107,7 @@ class DebugAgentService:
     async def _run_debug(
         self,
         report_id: str,
-        sub_agent_id: str,
+        sub_agent_id: int,
         bug_report: BugReportResponse,
         user_access_token: str,
         context_id: str,
@@ -116,7 +121,7 @@ class DebugAgentService:
             )
             # Dispatch to agent-runner via the native a2a-sdk v1.1.0 streaming client and drive
             # the stream to completion (the debug agent updates the bug report via MCP tools).
-            await dispatch_streaming(
+            result_data = await dispatch_streaming(
                 agent_url=self._agent_runner_url,
                 access_token=access_token,
                 parts=self._build_message_parts(report_id, bug_report),
@@ -124,7 +129,13 @@ class DebugAgentService:
                 context_id=context_id,
                 timeout_read=float(DEBUG_AGENT_TIMEOUT_SECONDS),
             )
-            logger.info(f"Debug agent completed for bug report {report_id}")
+            # agent-runner reports a non-completed terminal state in-band, so an unchecked
+            # await here would log "completed" for a run that never executed.
+            state = result_data["result"].get("status", {}).get("state")
+            if state == "completed":
+                logger.info(f"Debug agent completed for bug report {report_id}")
+            else:
+                logger.error(f"Debug agent finished in state {state!r} for bug report {report_id}")
         except Exception:
             logger.exception(f"Debug agent failed for bug report {report_id}")
         finally:

--- a/packages/console-backend/console_backend/services/skill_security_service.py
+++ b/packages/console-backend/console_backend/services/skill_security_service.py
@@ -78,8 +78,12 @@ class SkillSecurityService:
         self._agent_runner_url = agent_runner_url.rstrip("/")
         self._oauth_service = oauth_service
 
-    async def get_assessor_agent_id(self, db: AsyncSession) -> str | None:
-        """Find the active assessor system agent."""
+    async def get_assessor_agent_id(self, db: AsyncSession) -> int | None:
+        """Find the active assessor system agent.
+
+        Returned as int — see DebugAgentService.get_debug_agent_id: agent-runner drops a
+        stringified sub_agent_id and the assessor never runs.
+        """
         result = await db.execute(
             text(
                 "SELECT id FROM sub_agents "
@@ -88,7 +92,7 @@ class SkillSecurityService:
             )
         )
         row = result.scalar_one_or_none()
-        return str(row) if row is not None else None
+        return int(row) if row is not None else None
 
     async def assess_skill(
         self,


### PR DESCRIPTION
## Problem

Triggering the debug agent on a bug report appears to succeed instantly and does nothing. The service logs `Debug agent completed` a few hundred milliseconds after dispatch, with no work in between, and the report reverts out of `investigating`.

The agent was never started.

## Cause

`sub_agents.id` is a `SERIAL`, but `DebugAgentService.get_debug_agent_id` and `SkillSecurityService.get_assessor_agent_id` both returned it as `str(row)` and passed that in the A2A message metadata. agent-runner reads the id back through `_meta_int`, which coerced only `int | float` and returned `None` for a string. With `sub_agent_id = None` the sub-agent branch of `_stream_impl` is skipped entirely and the run yields `TASK_STATE_COMPLETED` right away, echoing the instruction text back as the result.

The scheduler passes `job.sub_agent_id` as an int and was unaffected — which is why only these two callers broke. The skill assessor degraded quietly to `verdict="caution"` (its assessor-unavailable fallback) rather than failing outright, so it looked plausible.

Regressed in 3a0bcf8b, which replaced a plain `message_meta.get("sub_agent_id")` — truthy for `"12"` — with the numeric-only `_meta_int` guard.

## Changes

- Both lookups return the id as `int`, typed `int | None`.
- `_meta_int` also accepts numeric strings and warns on a genuinely non-numeric value, so a stringifying caller cannot silently become a no-op again. Booleans stay rejected.
- `DebugAgentService` inspects the dispatch's terminal state rather than logging `completed` for whatever task came back — the unchecked `await` is what made the no-op look like a success.

## Tests

Two regression tests on the dispatch shapes: a stringified id runs the sub-agent with the coerced int, a non-numeric one is still ignored. agent-runner suite (37) and the console-backend debug/skill/scheduler selection (238) pass.

## Note

Not addressed here: `_run_debug`'s `finally` block reverts `investigating` → `acknowledged` on any outcome, so a genuinely failed run is indistinguishable from one the agent chose not to act on. Worth a distinct state, but out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)