### PR TITLE
fix(scheduler): format scheduled notifications for the delivering channel

### DIFF
--- a/packages/agent-common/agent_common/a2a/base.py
+++ b/packages/agent-common/agent_common/a2a/base.py
@@ -45,6 +45,15 @@ class SubAgentInput(BaseModel):
         default=None,
         description="Scheduled job ID to propagate to remote agents for cost attribution.",
     )
+    message_formatting: Optional[str] = Field(
+        default=None,
+        description=(
+            "How the channel that delivers the answer renders text ('slack', 'google-chat', "
+            "'plain', 'markdown'). Rides the outgoing A2A message metadata as "
+            "`messageFormatting`, which is the same key an interactive client sends, so a "
+            "remote agent applies its own formatting rules without this side touching its prompt."
+        ),
+    )
 
 
 class BaseA2ARunnable(ABC):

--- a/packages/agent-common/agent_common/a2a/base.py
+++ b/packages/agent-common/agent_common/a2a/base.py
@@ -51,7 +51,13 @@ class SubAgentInput(BaseModel):
             "How the channel that delivers the answer renders text ('slack', 'google-chat', "
             "'plain', 'markdown'). Rides the outgoing A2A message metadata as "
             "`messageFormatting`, which is the same key an interactive client sends, so a "
-            "remote agent applies its own formatting rules without this side touching its prompt."
+            "remote agent applies its own formatting rules without this side touching its prompt. "
+            "SET IT ONLY when the invoked agent's own text is what reaches the user — a "
+            "scheduled job dispatched by agent-runner, where the answer goes straight to a "
+            "delivery channel. Leave it None whenever an orchestrator is routing: the "
+            "orchestrator composes the delivered message and applies the channel's rules to "
+            "it, so the sub-agent writes raw material for that and rules about a medium it "
+            "never writes to would only spend its prompt."
         ),
     )
 

--- a/packages/agent-common/agent_common/a2a/client_runnable.py
+++ b/packages/agent-common/agent_common/a2a/client_runnable.py
@@ -452,6 +452,7 @@ class A2AClientRunnable(BaseA2ARunnable):
         context_id: Optional[str],
         task_id: Optional[str],
         scheduled_job_id: Optional[int] = None,
+        message_formatting: Optional[str] = None,
     ) -> Message:
         """Transform a list of LangChain HumanMessages to a single A2A Message.
 
@@ -464,6 +465,9 @@ class A2AClientRunnable(BaseA2ARunnable):
             context_id: Optional context ID for multi-turn conversations
             task_id: Optional task ID for continuing existing tasks
             scheduled_job_id: Optional scheduled job ID for cost attribution
+            message_formatting: Optional rendering rules of the delivering channel, sent
+                as `messageFormatting` — the key an interactive client uses — so the remote
+                agent applies them through its own request-metadata path
 
         Returns:
             Constructed A2A Message aggregating parts from all HumanMessages
@@ -474,6 +478,8 @@ class A2AClientRunnable(BaseA2ARunnable):
         }
         if scheduled_job_id is not None:
             message_metadata["scheduled_job_id"] = scheduled_job_id
+        if message_formatting:
+            message_metadata["messageFormatting"] = message_formatting
 
         all_parts: list[A2APart] = []
 
@@ -629,6 +635,7 @@ class A2AClientRunnable(BaseA2ARunnable):
                 context_id,
                 task_id,
                 scheduled_job_id=input_data_validated.scheduled_job_id,
+                message_formatting=input_data_validated.message_formatting,
             )
 
             logger.info(f"Streaming A2A message: {a2a_message.message_id}")

--- a/packages/agent-common/agent_common/core/__init__.py
+++ b/packages/agent-common/agent_common/core/__init__.py
@@ -1,5 +1,13 @@
 """Core utilities: model factory, graph utilities, object storage."""
 
+from .message_formatting import (
+    DEFAULT_MESSAGE_FORMATTING,
+    FORMATTING_RULES,
+    MessageFormatting,
+    formatting_prompt_block,
+    formatting_rules,
+    normalize_message_formatting,
+)
 from .model_factory import (
     _has_aws_credentials as has_aws_credentials,
     NoDefaultModelError,
@@ -31,6 +39,13 @@ __all__ = [
     "require_default_model",
     "NoDefaultModelError",
     "get_reasoning_effort",
+    # Message formatting
+    "MessageFormatting",
+    "DEFAULT_MESSAGE_FORMATTING",
+    "FORMATTING_RULES",
+    "formatting_rules",
+    "formatting_prompt_block",
+    "normalize_message_formatting",
     # Object storage
     "IObjectStorageService",
     "LocalObjectStorageService",

--- a/packages/agent-common/agent_common/core/message_formatting.py
+++ b/packages/agent-common/agent_common/core/message_formatting.py
@@ -1,0 +1,78 @@
+"""Channel-dependent message formatting instructions.
+
+The text an agent writes is rendered by whatever client delivers it, and those
+renderers disagree: Slack reads mrkdwn (``*bold*``, no headers), Google Chat its
+own markup, a web console real Markdown. So the format is a property of the
+DELIVERY CHANNEL, not of the agent — and the agent has to be told which one it
+is writing for, because nothing downstream rewrites its output.
+
+Interactive turns get this from the client's ``messageFormatting`` request
+metadata. Scheduled runs have no client on the other end: the format comes from
+the delivery channel the job notifies, is carried in the dispatch metadata under
+the same key, and lands here. One table so a channel's rules are stated once and
+every writer (orchestrator turn, scheduled sub-agent, scheduler-written
+notification) obeys the same ones.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+MessageFormatting = Literal["markdown", "slack", "google-chat", "plain"]
+
+DEFAULT_MESSAGE_FORMATTING: MessageFormatting = "markdown"
+
+#: Rendering rules per channel, as prose for the model. ``markdown`` is absent on
+#: purpose: it is standard behaviour and an instruction saying so only spends tokens.
+FORMATTING_RULES: dict[str, str] = {
+    "slack": (
+        "Format responses using Slack mrkdwn syntax: *bold* for emphasis, _italic_ for secondary "
+        "emphasis, `code` for inline code, ```code blocks``` for multi-line code. "
+        "Use <https://url|label> for links and a leading '• ' for bullets. "
+        "Avoid markdown syntax that Slack doesn't support (e.g. # headers, **bold**, "
+        "[links](url), | tables |)."
+    ),
+    "google-chat": (
+        "Format responses using Google Chat markup syntax: *bold* for emphasis, _italic_ for secondary "
+        "emphasis, ~strikethrough~ for strikethrough, `code` for inline code, ```code blocks``` for "
+        "multi-line code. Use plain URLs for links (they are auto-linked). "
+        "Avoid markdown syntax that Google Chat doesn't support (e.g. # headers, **bold**, "
+        "[links](url), | tables |)."
+    ),
+    "plain": (
+        "Use plain text only. Do not use any formatting syntax "
+        "(no markdown, no bold, no code blocks). Keep responses simple and readable."
+    ),
+}
+
+
+def normalize_message_formatting(value: object) -> MessageFormatting:
+    """Coerce a metadata value to a known format, defaulting to ``markdown``.
+
+    Metadata reaches us from A2A clients and, over gRPC, through a protobuf Struct, so
+    an unexpected type or a channel format written by an older client must degrade to
+    the default rather than raise inside a scheduled run.
+    """
+    if isinstance(value, str):
+        candidate = value.strip().lower()
+        if candidate in FORMATTING_RULES or candidate == DEFAULT_MESSAGE_FORMATTING:
+            return candidate  # type: ignore[return-value]
+    return DEFAULT_MESSAGE_FORMATTING
+
+
+def formatting_rules(value: object) -> str:
+    """The bare rules sentence for a format, or ``""`` for plain Markdown."""
+    return FORMATTING_RULES.get(normalize_message_formatting(value), "")
+
+
+def formatting_prompt_block(value: object) -> str:
+    """The rules as a ``<message_formatting>`` block, or ``""`` when none are needed.
+
+    Returned without surrounding blank lines; callers place it (system-prompt
+    addendum, user-preferences block, one-shot prompt) as they need.
+    """
+    rules = formatting_rules(value)
+    if not rules:
+        return ""
+    fmt = normalize_message_formatting(value)
+    return f'<message_formatting format="{fmt}">\n{rules}\n</message_formatting>'

--- a/packages/agent-common/agent_common/core/message_formatting.py
+++ b/packages/agent-common/agent_common/core/message_formatting.py
@@ -16,11 +16,13 @@ notification) obeys the same ones.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, get_args
 
 MessageFormatting = Literal["markdown", "slack", "google-chat", "plain"]
 
 DEFAULT_MESSAGE_FORMATTING: MessageFormatting = "markdown"
+
+KNOWN_FORMATS = frozenset(get_args(MessageFormatting))
 
 #: Rendering rules per channel, as prose for the model. ``markdown`` is absent on
 #: purpose: it is standard behaviour and an instruction saying so only spends tokens.
@@ -55,7 +57,7 @@ def normalize_message_formatting(value: object) -> MessageFormatting:
     """
     if isinstance(value, str):
         candidate = value.strip().lower()
-        if candidate in FORMATTING_RULES or candidate == DEFAULT_MESSAGE_FORMATTING:
+        if candidate in KNOWN_FORMATS:
             return candidate  # type: ignore[return-value]
     return DEFAULT_MESSAGE_FORMATTING
 
@@ -71,8 +73,8 @@ def formatting_prompt_block(value: object) -> str:
     Returned without surrounding blank lines; callers place it (system-prompt
     addendum, user-preferences block, one-shot prompt) as they need.
     """
-    rules = formatting_rules(value)
+    fmt = normalize_message_formatting(value)
+    rules = FORMATTING_RULES.get(fmt)
     if not rules:
         return ""
-    fmt = normalize_message_formatting(value)
     return f'<message_formatting format="{fmt}">\n{rules}\n</message_formatting>'

--- a/packages/agent-common/tests/test_a2a_client_runnable.py
+++ b/packages/agent-common/tests/test_a2a_client_runnable.py
@@ -420,6 +420,30 @@ class TestA2AClientRunnableMessageCreation:
         assert result.parts[0].text == content
         assert result.message_id  # Generated UUID
 
+    def test_message_formatting_rides_the_metadata(self, a2a_client_runnable):
+        """The delivering channel's rendering rules travel as `messageFormatting`.
+
+        Same key an interactive client sends, so a remote agent applies them through its
+        own request-metadata path instead of this side editing its prompt — and an extra
+        instruction message never lands in the remote's checkpointed conversation.
+        """
+        result = a2a_client_runnable._from_human_messages_to_a2a(
+            [HumanMessage(content="Report on the campaign.")],
+            "ctx-123",
+            None,
+            message_formatting="slack",
+        )
+
+        assert result.metadata["messageFormatting"] == "slack"
+        assert len(result.parts) == 1  # no instruction part was appended
+
+    def test_no_formatting_key_when_none_was_given(self, a2a_client_runnable):
+        result = a2a_client_runnable._from_human_messages_to_a2a(
+            [HumanMessage(content="Report on the campaign.")], None, None
+        )
+
+        assert "messageFormatting" not in result.metadata
+
     def test_create_a2a_message_without_tracking(self, a2a_client_runnable):
         """Test creating A2A message without tracking IDs."""
         content = "Test message"

--- a/packages/agent-common/tests/test_message_formatting.py
+++ b/packages/agent-common/tests/test_message_formatting.py
@@ -1,0 +1,44 @@
+"""The channel decides how a message is written, and the rules are stated once."""
+
+from agent_common.core.message_formatting import (
+    formatting_prompt_block,
+    formatting_rules,
+    normalize_message_formatting,
+)
+
+
+class TestNormalize:
+    def test_known_formats_pass_through(self):
+        for value in ("markdown", "slack", "google-chat", "plain"):
+            assert normalize_message_formatting(value) == value
+
+    def test_case_and_whitespace_are_forgiven(self):
+        assert normalize_message_formatting(" Slack ") == "slack"
+
+    def test_unknown_and_non_strings_fall_back_to_markdown(self):
+        # Metadata arrives from A2A clients and, over gRPC, through a protobuf Struct:
+        # a stray type must not raise inside a scheduled run.
+        for value in (None, "", "html", 3, True, {"slack": True}):
+            assert normalize_message_formatting(value) == "markdown"
+
+
+class TestPromptBlock:
+    def test_slack_gets_mrkdwn_rules_and_a_warning_off_markdown(self):
+        block = formatting_prompt_block("slack")
+        assert block.startswith('<message_formatting format="slack">')
+        assert "mrkdwn" in block
+        assert "**bold**" in block  # named as what to avoid
+        assert block.endswith("</message_formatting>")
+
+    def test_google_chat_gets_its_own_markup(self):
+        block = formatting_prompt_block("google-chat")
+        assert '<message_formatting format="google-chat">' in block
+        assert "~strikethrough~" in block
+
+    def test_markdown_says_nothing(self):
+        # Standard behaviour; an instruction saying so only spends tokens.
+        assert formatting_prompt_block("markdown") == ""
+        assert formatting_rules("markdown") == ""
+
+    def test_an_unknown_format_says_nothing_rather_than_guessing(self):
+        assert formatting_prompt_block("teams") == ""

--- a/packages/agent-runner/agent/core.py
+++ b/packages/agent-runner/agent/core.py
@@ -42,7 +42,11 @@ from agent_common.a2a.structured_response import A2A_PROTOCOL_ADDENDUM, SubAgent
 from agent_common.agents.foundry_agent import create_foundry_local_subagent
 from agent_common.core.document_store_tools import create_document_store_tools
 from agent_common.core.graph_utils import build_sub_agent_graph
-from agent_common.core.message_formatting import formatting_prompt_block, normalize_message_formatting
+from agent_common.core.message_formatting import (
+    formatting_prompt_block,
+    formatting_rules,
+    normalize_message_formatting,
+)
 from agent_common.core.model_factory import (
     create_model,
     get_default_model,
@@ -188,6 +192,21 @@ def _current_time_context(timezone_name: str | None) -> str:
         except Exception:
             pass
     return line
+
+
+def _build_sub_agent_system_prompt(system_prompt: str, message_formatting: str) -> str:
+    """The sub-agent's own prompt, plus the response protocol and the channel's rules.
+
+    The rendering rules cannot live in the stored system prompt: it is written once and
+    reused across every job, while the same agent may notify Slack for one job and the
+    web console for the next. Assembling them per run is what makes correct formatting
+    built in rather than something each job's author has to remember to ask for.
+    """
+    parts = [system_prompt, A2A_PROTOCOL_ADDENDUM]
+    formatting_block = formatting_prompt_block(message_formatting)
+    if formatting_block:
+        parts.append(formatting_block)
+    return "\n\n".join(parts)
 
 
 def _extract_message_metadata(task: Task) -> dict[str, Any]:
@@ -896,6 +915,7 @@ class AgentRunner(BaseAgent):
             return await self._run_foundry_agent(
                 sub_agent_cfg=sub_agent_cfg,
                 prompt=prompt,
+                message_formatting=message_formatting,
                 user_config=user_config,
                 scheduled_job_id=scheduled_job_id,
                 scheduled_job_run_id=scheduled_job_run_id,
@@ -978,17 +998,7 @@ class AgentRunner(BaseAgent):
 
         llm = create_model(model_name, thinking_level=thinking_level)
 
-        # Append the A2A response protocol addendum so the LLM knows to use SubAgentResponseSchema
-        full_system_prompt = system_prompt + "\n\n" + A2A_PROTOCOL_ADDENDUM
-
-        # ...and the delivery channel's rendering rules. A sub-agent's system prompt is
-        # written once and reused across every job, so the channel cannot be baked into
-        # it: the same agent may notify Slack for one job and the web console for the
-        # next. Injecting it here is what makes correct formatting built in rather than
-        # something each job's author has to remember to ask for.
-        formatting_block = formatting_prompt_block(message_formatting)
-        if formatting_block:
-            full_system_prompt += "\n\n" + formatting_block
+        full_system_prompt = _build_sub_agent_system_prompt(system_prompt, message_formatting)
 
         mcp_timeout = timedelta(seconds=_MCP_TIMEOUT_SECONDS)
 
@@ -1200,6 +1210,7 @@ class AgentRunner(BaseAgent):
         user_config: UserConfig,
         scheduled_job_id: int,
         scheduled_job_run_id: int,
+        message_formatting: str = "markdown",
     ) -> tuple[str | None, str | None]:
         """Run a Foundry query-API agent using agent-common's foundry module.
 
@@ -1209,6 +1220,10 @@ class AgentRunner(BaseAgent):
             user_config: Authenticated user context.
             scheduled_job_id: For logging.
             scheduled_job_run_id: For tracking the conversation.
+            message_formatting: Rendering rules of the delivery channel. The query API
+                takes a single `userInput` string and no system prompt, so they can only
+                go into the prompt; whether the Foundry-side agent honours them is its
+                own business, but a run that is never told cannot get it right.
         Returns:
             (result_summary, task_state) — see _collect_stream_text.
         """
@@ -1239,9 +1254,12 @@ class AgentRunner(BaseAgent):
             sub_agent_config_version_id=sub_agent_cfg.get("sub_agent_config_version_id"),
         )
 
+        formatting_block = formatting_prompt_block(message_formatting)
+        foundry_prompt = f"{prompt}\n\n{formatting_block}" if formatting_block else prompt
+
         # Stream the foundry runnable via the A2A SubAgentInput interface
         input_data = SubAgentInput(
-            messages=[{"role": "user", "content": prompt}],
+            messages=[{"role": "user", "content": foundry_prompt}],
         )
         result_summary, task_state = await _collect_stream_text(compiled_subagent["runnable"], input_data)
 
@@ -1304,9 +1322,8 @@ class AgentRunner(BaseAgent):
                 (scheduled_job_runs.conversation_id) — the prerequisite for a
                 later orchestrator delegation to resume that conversation via
                 the conversation-origin extension.
-            message_formatting: Rendering rules of the delivery channel. A remote
-                agent owns its own system prompt, so the rules ride the message as a
-                trailing instruction — the only place this side can put them.
+            message_formatting: Rendering rules of the delivery channel, forwarded as
+                A2A message metadata so the remote agent applies them itself.
 
         Returns:
             (result_summary, task_state) — see _collect_stream_text.
@@ -1351,22 +1368,24 @@ class AgentRunner(BaseAgent):
             # Fallback to plain text prompt
             messages_input = [{"role": "user", "content": prompt}]
 
-        # The channel's rendering rules as a final instruction. There is no system prompt
-        # to append to on this path (the remote agent has its own) and SubAgentInput
-        # carries no per-message metadata, so the message itself is the only carrier.
-        formatting_block = formatting_prompt_block(message_formatting)
-        if formatting_block:
-            messages_input = [*messages_input, HumanMessage(content=formatting_block)]
-
         # orchestrator_conversation_id feeds A2AClientRunnable's contextId
         # waterfall (_extract_tracking_ids), putting the run task's contextId on
         # the wire. The remote keys its checkpoints by the contextId it
         # receives, so the run's stored conversation_id then names a real,
         # resumable conversation on the executing side.
+        # The channel's rendering rules travel as message metadata, not as an extra
+        # message: a remote agent owns its system prompt, and A2AClientRunnable puts
+        # `messageFormatting` on the wire under the key an interactive client uses, so the
+        # remote applies them through its own request-metadata path. Appending an
+        # instruction message instead would land in the remote's checkpointed
+        # conversation, where a later turn can read it as part of the task.
         input_data = SubAgentInput(
             messages=messages_input,
             scheduled_job_id=scheduled_job_id,
             orchestrator_conversation_id=context_id,
+            # Only when there is something to say: plain Markdown is the remote's default
+            # too, so sending it would put a no-op instruction on the wire.
+            message_formatting=message_formatting if formatting_rules(message_formatting) else None,
         )
         result_summary, task_state = await _collect_stream_text(runnable, input_data)
 

--- a/packages/agent-runner/agent/core.py
+++ b/packages/agent-runner/agent/core.py
@@ -42,6 +42,7 @@ from agent_common.a2a.structured_response import A2A_PROTOCOL_ADDENDUM, SubAgent
 from agent_common.agents.foundry_agent import create_foundry_local_subagent
 from agent_common.core.document_store_tools import create_document_store_tools
 from agent_common.core.graph_utils import build_sub_agent_graph
+from agent_common.core.message_formatting import formatting_prompt_block, normalize_message_formatting
 from agent_common.core.model_factory import (
     create_model,
     get_default_model,
@@ -654,6 +655,15 @@ class AgentRunner(BaseAgent):
                     logger.warning("Ignoring non-numeric %s in message metadata: %r", key, value)
             return None
 
+        # How the delivering channel renders text. A scheduled run has no client on the
+        # other end to say so per turn, so the scheduler resolves it from the job's
+        # delivery channel and sends it here under the same key an interactive client
+        # uses. Nothing downstream rewrites the agent's output, so an unset/unknown value
+        # means Markdown — which is what a Slack notification used to arrive as.
+        message_formatting = normalize_message_formatting(
+            message_meta.get("messageFormatting") or message_meta.get("message_formatting")
+        )
+
         sub_agent_id: int | None = _meta_int("sub_agent_id")
         scheduled_job_id: int | None = _meta_int("scheduled_job_id")
         scheduled_job_run_id: int | str = _meta_int("scheduled_job_run_id") or ""
@@ -696,6 +706,7 @@ class AgentRunner(BaseAgent):
                     user_config=user_config,
                     user_id=user_id,
                     context_id=task.context_id,
+                    message_formatting=message_formatting,
                 )
             except Exception as exc:
                 logger.exception(f"Sub-agent execution failed for job {scheduled_job_id}")
@@ -842,6 +853,7 @@ class AgentRunner(BaseAgent):
         user_id: str | None = None,
         context_id: str | None = None,
         raw_a2a_messages: list[Message] | None = None,
+        message_formatting: str = "markdown",
     ) -> tuple[str | None, str | None]:
         """Dispatch a sub-agent config to the appropriate execution method.
 
@@ -855,6 +867,8 @@ class AgentRunner(BaseAgent):
             user_id: Verified database user UUID (fetched from backend, not from message metadata).
             context_id: Natural A2A context_id for thread isolation (conversation_id).
             raw_a2a_messages: Original A2A messages (used for remote agents to preserve DataParts).
+            message_formatting: Rendering rules of the channel this run's message is
+                delivered to ("slack", "google-chat", "plain", "markdown").
 
         Returns:
             (agent_message, task_state) — task_state is the sub-agent's
@@ -876,6 +890,7 @@ class AgentRunner(BaseAgent):
                 scheduled_job_id=scheduled_job_id,
                 scheduled_job_run_id=scheduled_job_run_id,
                 context_id=context_id,
+                message_formatting=message_formatting,
             )
         elif agent_type == "foundry":
             return await self._run_foundry_agent(
@@ -894,6 +909,7 @@ class AgentRunner(BaseAgent):
                 scheduled_job_id=scheduled_job_id,
                 scheduled_job_run_id=scheduled_job_run_id,
                 context_id=context_id,
+                message_formatting=message_formatting,
             )
         else:
             raise ValueError(
@@ -911,6 +927,7 @@ class AgentRunner(BaseAgent):
         user_id: str | None = None,
         context_id: str | None = None,
         raw_a2a_messages: list[Message] | None = None,
+        message_formatting: str = "markdown",
     ) -> tuple[str | None, str | None]:
         """Run a one-shot LangGraph agent using agent-common's model factory.
 
@@ -963,6 +980,15 @@ class AgentRunner(BaseAgent):
 
         # Append the A2A response protocol addendum so the LLM knows to use SubAgentResponseSchema
         full_system_prompt = system_prompt + "\n\n" + A2A_PROTOCOL_ADDENDUM
+
+        # ...and the delivery channel's rendering rules. A sub-agent's system prompt is
+        # written once and reused across every job, so the channel cannot be baked into
+        # it: the same agent may notify Slack for one job and the web console for the
+        # next. Injecting it here is what makes correct formatting built in rather than
+        # something each job's author has to remember to ask for.
+        formatting_block = formatting_prompt_block(message_formatting)
+        if formatting_block:
+            full_system_prompt += "\n\n" + formatting_block
 
         mcp_timeout = timedelta(seconds=_MCP_TIMEOUT_SECONDS)
 
@@ -1253,6 +1279,7 @@ class AgentRunner(BaseAgent):
         scheduled_job_id: int,
         scheduled_job_run_id: int,
         context_id: str | None = None,
+        message_formatting: str = "markdown",
     ) -> tuple[str | None, str | None]:
         """Run a remote A2A agent by discovering its agent card and invoking it.
 
@@ -1277,6 +1304,9 @@ class AgentRunner(BaseAgent):
                 (scheduled_job_runs.conversation_id) — the prerequisite for a
                 later orchestrator delegation to resume that conversation via
                 the conversation-origin extension.
+            message_formatting: Rendering rules of the delivery channel. A remote
+                agent owns its own system prompt, so the rules ride the message as a
+                trailing instruction — the only place this side can put them.
 
         Returns:
             (result_summary, task_state) — see _collect_stream_text.
@@ -1320,6 +1350,13 @@ class AgentRunner(BaseAgent):
         else:
             # Fallback to plain text prompt
             messages_input = [{"role": "user", "content": prompt}]
+
+        # The channel's rendering rules as a final instruction. There is no system prompt
+        # to append to on this path (the remote agent has its own) and SubAgentInput
+        # carries no per-message metadata, so the message itself is the only carrier.
+        formatting_block = formatting_prompt_block(message_formatting)
+        if formatting_block:
+            messages_input = [*messages_input, HumanMessage(content=formatting_block)]
 
         # orchestrator_conversation_id feeds A2AClientRunnable's contextId
         # waterfall (_extract_tracking_ids), putting the run task's contextId on

--- a/packages/agent-runner/agent/core.py
+++ b/packages/agent-runner/agent/core.py
@@ -201,6 +201,13 @@ def _build_sub_agent_system_prompt(system_prompt: str, message_formatting: str) 
     reused across every job, while the same agent may notify Slack for one job and the
     web console for the next. Assembling them per run is what makes correct formatting
     built in rather than something each job's author has to remember to ask for.
+
+    This is the stand-alone case, and the only one that wants the rules. A scheduled run
+    has no orchestrator in between: whatever the sub-agent writes here is delivered to
+    the channel verbatim. When the orchestrator routes instead, it composes the delivered
+    message and applies the channel's rules to that, so its sub-agents are given no
+    formatting instructions at all — theirs is raw material for an answer someone else
+    writes, and rules about a medium they never write to would only spend their prompt.
     """
     parts = [system_prompt, A2A_PROTOCOL_ADDENDUM]
     formatting_block = formatting_prompt_block(message_formatting)

--- a/packages/agent-runner/tests/test_agent_runner_security.py
+++ b/packages/agent-runner/tests/test_agent_runner_security.py
@@ -6,11 +6,14 @@ Covers:
 - Watch condition short-circuit: when condition_not_met, _stream_impl yields early without sub-agent call
 """
 
+import inspect
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from a2a.types import Message, Part, Role
+
+import agent.core as core
 
 
 @pytest.fixture
@@ -370,3 +373,161 @@ class TestRemoteAgentContextPropagation:
 
         kwargs = agent_runner._run_remote_agent.await_args.kwargs
         assert kwargs["context_id"] == "run-ctx-1"
+
+
+class TestDeliveryChannelFormatting:
+    """A scheduled run is told how its delivery channel renders text.
+
+    An interactive turn gets this from the client's `messageFormatting` metadata. A
+    scheduled one has no client on the other end, so the scheduler resolves it from the
+    job's delivery channel and sends it under the same key. Nothing downstream rewrites
+    the agent's output, so losing this hand-off is what made Slack notifications arrive
+    as literal '### heading' / '**bold**'.
+    """
+
+    @staticmethod
+    def _task(formatting: str | None) -> MagicMock:
+        meta: dict = {"sub_agent_id": 5, "scheduled_job_id": 10}
+        if formatting is not None:
+            meta["messageFormatting"] = formatting
+        task = MagicMock()
+        task.context_id = "ctx-fmt"
+        task.history = [MagicMock(metadata=meta)]
+        return task
+
+    @staticmethod
+    def _user_config() -> MagicMock:
+        user_config = MagicMock()
+        user_config.user_sub = "sub-1"
+        user_config.access_token = MagicMock()
+        user_config.access_token.get_secret_value.return_value = "bearer-token"
+        return user_config
+
+    async def _run(self, agent_runner, formatting: str | None) -> None:
+        agent_runner._fetch_user_id_from_backend = AsyncMock(return_value="user-uuid-1")
+        agent_runner._fetch_sub_agent_config = AsyncMock(
+            return_value={"type": "automated", "name": "triage", "sub_agent_id": 5}
+        )
+        agent_runner._execute_sub_agent = AsyncMock(return_value=("done", "completed"))
+        async for _ in agent_runner._stream_impl(
+            [Message(role=Role.ROLE_USER, parts=[Part(text="Report on campaign 450.")], message_id="msg-f")],
+            self._user_config(),
+            self._task(formatting),
+        ):
+            pass
+
+    @pytest.mark.asyncio
+    async def test_the_channels_format_reaches_the_sub_agent(self, agent_runner):
+        await self._run(agent_runner, "slack")
+        assert agent_runner._execute_sub_agent.await_args.kwargs["message_formatting"] == "slack"
+
+    @pytest.mark.asyncio
+    async def test_an_absent_format_falls_back_to_markdown(self, agent_runner):
+        await self._run(agent_runner, None)
+        assert agent_runner._execute_sub_agent.await_args.kwargs["message_formatting"] == "markdown"
+
+    @pytest.mark.asyncio
+    async def test_execute_sub_agent_forwards_the_format_to_remote(self, agent_runner):
+        agent_runner._run_remote_agent = AsyncMock(return_value=("ok", None))
+
+        await agent_runner._execute_sub_agent(
+            sub_agent_cfg={"type": "remote", "name": "Remote Agent", "agent_url": "https://remote.example"},
+            prompt="p",
+            user_access_token="tok",
+            scheduled_job_id=10,
+            scheduled_job_run_id=99,
+            user_config=MagicMock(),
+            context_id="run-ctx-1",
+            message_formatting="slack",
+        )
+
+        assert agent_runner._run_remote_agent.await_args.kwargs["message_formatting"] == "slack"
+
+    @pytest.mark.asyncio
+    async def test_a_remote_agent_is_told_in_the_message(self, agent_runner):
+        """A remote agent owns its system prompt, so the rules ride the message."""
+        card_response = MagicMock()
+        card_response.json.return_value = {"name": "Remote Agent"}
+        card_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=card_response)
+
+        captured = {}
+
+        async def fake_collect(runnable, input_data):
+            captured["input_data"] = input_data
+            return "done", "completed"
+
+        agent_runner._get_oauth2_client = MagicMock()
+
+        with (
+            patch("httpx.AsyncClient") as mock_cls,
+            patch("agent.core.make_a2a_async_runnable", return_value=MagicMock()),
+            patch("agent.core._collect_stream_text", side_effect=fake_collect),
+        ):
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await agent_runner._run_remote_agent(
+                sub_agent_cfg={"name": "Remote Agent", "agent_url": "https://remote.example", "sub_agent_id": 5},
+                raw_a2a_messages=[],
+                prompt="Do the thing.",
+                user_access_token="tok",
+                scheduled_job_id=10,
+                scheduled_job_run_id=99,
+                context_id="run-ctx-1",
+                message_formatting="slack",
+            )
+
+        messages = captured["input_data"].messages
+        assert 'format="slack"' in str(messages[-1].content)
+
+    @pytest.mark.asyncio
+    async def test_markdown_adds_nothing_to_a_remote_message(self, agent_runner):
+        card_response = MagicMock()
+        card_response.json.return_value = {"name": "Remote Agent"}
+        card_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=card_response)
+
+        captured = {}
+
+        async def fake_collect(runnable, input_data):
+            captured["input_data"] = input_data
+            return "done", "completed"
+
+        agent_runner._get_oauth2_client = MagicMock()
+
+        with (
+            patch("httpx.AsyncClient") as mock_cls,
+            patch("agent.core.make_a2a_async_runnable", return_value=MagicMock()),
+            patch("agent.core._collect_stream_text", side_effect=fake_collect),
+        ):
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await agent_runner._run_remote_agent(
+                sub_agent_cfg={"name": "Remote Agent", "agent_url": "https://remote.example", "sub_agent_id": 5},
+                raw_a2a_messages=[],
+                prompt="Do the thing.",
+                user_access_token="tok",
+                scheduled_job_id=10,
+                scheduled_job_run_id=99,
+                context_id="run-ctx-1",
+            )
+
+        assert len(captured["input_data"].messages) == 1
+
+    def test_a_local_sub_agents_system_prompt_carries_the_rules(self):
+        """The injection point, guarded by source rather than by running a graph.
+
+        A sub-agent's system prompt is written once and reused across jobs, so the
+        channel cannot be baked into it — the same agent may notify Slack for one job
+        and the web console for the next. Building the full prompt without this append
+        is exactly the regression that puts raw Markdown into Slack.
+        """
+        source = inspect.getsource(core.AgentRunner._run_langgraph_agent)
+        assert "formatting_prompt_block(message_formatting)" in source
+        assert "full_system_prompt += " in source

--- a/packages/agent-runner/tests/test_agent_runner_security.py
+++ b/packages/agent-runner/tests/test_agent_runner_security.py
@@ -6,7 +6,6 @@ Covers:
 - Watch condition short-circuit: when condition_not_met, _stream_impl yields early without sub-agent call
 """
 
-import inspect
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -444,8 +443,12 @@ class TestDeliveryChannelFormatting:
         assert agent_runner._run_remote_agent.await_args.kwargs["message_formatting"] == "slack"
 
     @pytest.mark.asyncio
-    async def test_a_remote_agent_is_told_in_the_message(self, agent_runner):
-        """A remote agent owns its system prompt, so the rules ride the message."""
+    async def test_a_remote_agent_is_told_in_the_metadata(self, agent_runner):
+        """A remote agent owns its system prompt, so the rules ride the A2A metadata.
+
+        Not as an extra message: that would land in the remote's checkpointed
+        conversation, where a later turn can read the instruction as part of the task.
+        """
         card_response = MagicMock()
         card_response.json.return_value = {"name": "Remote Agent"}
         card_response.raise_for_status = MagicMock()
@@ -480,11 +483,14 @@ class TestDeliveryChannelFormatting:
                 message_formatting="slack",
             )
 
-        messages = captured["input_data"].messages
-        assert 'format="slack"' in str(messages[-1].content)
+        input_data = captured["input_data"]
+        assert input_data.message_formatting == "slack"
+        # The dispatch text is untouched — no instruction message was appended.
+        assert len(input_data.messages) == 1
+        assert "Do the thing." in str(input_data.messages[0].content)
 
     @pytest.mark.asyncio
-    async def test_markdown_adds_nothing_to_a_remote_message(self, agent_runner):
+    async def test_markdown_is_not_worth_sending(self, agent_runner):
         card_response = MagicMock()
         card_response.json.return_value = {"name": "Remote Agent"}
         card_response.raise_for_status = MagicMock()
@@ -518,16 +524,45 @@ class TestDeliveryChannelFormatting:
                 context_id="run-ctx-1",
             )
 
-        assert len(captured["input_data"].messages) == 1
+        assert captured["input_data"].message_formatting is None
 
-    def test_a_local_sub_agents_system_prompt_carries_the_rules(self):
-        """The injection point, guarded by source rather than by running a graph.
+    @pytest.mark.asyncio
+    async def test_execute_sub_agent_forwards_the_format_to_foundry(self, agent_runner):
+        """Foundry's query API is the third writer, and it was the one left out."""
+        agent_runner._run_foundry_agent = AsyncMock(return_value=("ok", None))
 
-        A sub-agent's system prompt is written once and reused across jobs, so the
-        channel cannot be baked into it — the same agent may notify Slack for one job
-        and the web console for the next. Building the full prompt without this append
-        is exactly the regression that puts raw Markdown into Slack.
-        """
-        source = inspect.getsource(core.AgentRunner._run_langgraph_agent)
-        assert "formatting_prompt_block(message_formatting)" in source
-        assert "full_system_prompt += " in source
+        await agent_runner._execute_sub_agent(
+            sub_agent_cfg={"type": "foundry", "name": "Analyst", "sub_agent_id": 7},
+            prompt="p",
+            user_access_token="tok",
+            scheduled_job_id=10,
+            scheduled_job_run_id=99,
+            user_config=MagicMock(),
+            context_id="run-ctx-1",
+            message_formatting="slack",
+        )
+
+        assert agent_runner._run_foundry_agent.await_args.kwargs["message_formatting"] == "slack"
+
+
+class TestSubAgentSystemPrompt:
+    """A local sub-agent is told the channel's rules through its assembled prompt.
+
+    The stored system prompt cannot carry them: it is written once and reused, while the
+    same agent may notify Slack for one job and the web console for the next.
+    """
+
+    def test_the_channels_rules_are_appended(self):
+        prompt = core._build_sub_agent_system_prompt("You triage alerts.", "slack")
+
+        assert prompt.startswith("You triage alerts.")
+        assert 'format="slack"' in prompt
+        assert "mrkdwn" in prompt
+        # The response protocol still comes first — the rules are additive, not a swap.
+        assert prompt.index("You triage alerts.") < prompt.index('format="slack"')
+
+    def test_markdown_leaves_the_prompt_as_it_was(self):
+        assert core._build_sub_agent_system_prompt("You triage alerts.", "markdown") == (
+            core._build_sub_agent_system_prompt("You triage alerts.", "unknown-channel")
+        )
+        assert 'format=' not in core._build_sub_agent_system_prompt("You triage alerts.", "markdown")

--- a/packages/client-google-chat/src/services/installationRegistrar.ts
+++ b/packages/client-google-chat/src/services/installationRegistrar.ts
@@ -25,6 +25,12 @@ interface DeliveryChannelCreateBody {
   webhook_url: string;
   secret: string;
   installation_id: string;
+  /**
+   * How this channel renders delivered text. The scheduler sends it to the run that
+   * writes a notification, so scheduled messages arrive formatted for this client
+   * without every job author having to ask for it.
+   */
+  message_formatting: 'google-chat';
 }
 
 export interface InstallationRegistrarDeps {
@@ -76,6 +82,7 @@ export async function registerOne(
     webhook_url: webhookUrl,
     secret,
     installation_id: opts.installationId,
+    message_formatting: 'google-chat',
   };
 
   const url = new URL('/api/v1/delivery-channels', config.consoleBackend!.url).toString();

--- a/packages/client-slack/src/services/installationRegistrar.ts
+++ b/packages/client-slack/src/services/installationRegistrar.ts
@@ -27,6 +27,12 @@ interface DeliveryChannelCreateBody {
   webhook_url: string;
   secret: string;
   installation_id: string;
+  /**
+   * How this channel renders delivered text. The scheduler sends it to the run that
+   * writes a notification, so scheduled messages arrive formatted for this client
+   * without every job author having to ask for it.
+   */
+  message_formatting: 'slack';
 }
 
 export interface InstallationRegistrarDeps {
@@ -89,6 +95,7 @@ export async function registerOne(
     webhook_url: webhookUrl,
     secret,
     installation_id: opts.installationId,
+    message_formatting: 'slack',
   };
 
   const url = new URL('/api/v1/delivery-channels', config.consoleBackend.url).toString();

--- a/packages/console-backend/console_backend/models/delivery_channel.py
+++ b/packages/console-backend/console_backend/models/delivery_channel.py
@@ -1,8 +1,18 @@
 """Pydantic models for delivery channels."""
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
+
+MessageFormatting = Literal["markdown", "slack", "google-chat", "plain"]
+
+_FORMATTING_DESCRIPTION = (
+    "How this channel renders delivered text. Nothing rewrites an agent's output on the "
+    "way out, so the writer is told these rules up front: 'slack' for Slack mrkdwn, "
+    "'google-chat' for Google Chat markup, 'plain' for no markup, 'markdown' (default) "
+    "for standard Markdown as the web console renders it."
+)
 
 
 class DeliveryChannelCreate(BaseModel):
@@ -31,6 +41,10 @@ class DeliveryChannelCreate(BaseModel):
             "every channel resolves by (client_id, installation_id)."
         ),
     )
+    message_formatting: MessageFormatting = Field(
+        default="markdown",
+        description=_FORMATTING_DESCRIPTION,
+    )
 
 
 class DeliveryChannelUpdate(BaseModel):
@@ -40,6 +54,7 @@ class DeliveryChannelUpdate(BaseModel):
     description: str | None = Field(default=None, max_length=1000)
     webhook_url: str | None = None
     secret: str | None = Field(default=None, min_length=1)
+    message_formatting: MessageFormatting | None = Field(default=None, description=_FORMATTING_DESCRIPTION)
 
 
 class DeliveryChannelResponse(BaseModel):
@@ -49,6 +64,10 @@ class DeliveryChannelResponse(BaseModel):
     name: str
     description: str | None = None
     webhook_url: str
+    message_formatting: MessageFormatting = Field(
+        default="markdown",
+        description=_FORMATTING_DESCRIPTION,
+    )
     client_id: str = Field(description="Keycloak client ID of the A2A service that registered this channel.")
     registered_by: str = Field(description="OIDC subject (sub) of the token used to register this channel.")
     installation_id: str | None = Field(

--- a/packages/console-backend/console_backend/models/delivery_channel.py
+++ b/packages/console-backend/console_backend/models/delivery_channel.py
@@ -41,9 +41,14 @@ class DeliveryChannelCreate(BaseModel):
             "every channel resolves by (client_id, installation_id)."
         ),
     )
-    message_formatting: MessageFormatting = Field(
-        default="markdown",
-        description=_FORMATTING_DESCRIPTION,
+    message_formatting: MessageFormatting | None = Field(
+        default=None,
+        description=(
+            _FORMATTING_DESCRIPTION
+            + " Omitted means 'unchanged': a client that does not declare a format leaves "
+            "the stored value alone, so re-registration on every boot cannot reset a "
+            "channel that was set elsewhere. A new channel falls back to the column default."
+        ),
     )
 
 

--- a/packages/console-backend/console_backend/repositories/delivery_channel_repository.py
+++ b/packages/console-backend/console_backend/repositories/delivery_channel_repository.py
@@ -55,22 +55,22 @@ class DeliveryChannelRepository(AuditedRepository):
     ) -> DeliveryChannelResponse:
         """Insert a delivery channel."""
         now = datetime.now(timezone.utc)
-        channel_id: int = await self.create(
-            db=db,
-            actor=actor,
-            fields={
-                "name": data.name,
-                "description": data.description,
-                "webhook_url": data.webhook_url,
-                "message_formatting": data.message_formatting,
-                "secret": data.secret,
-                "client_id": client_id,
-                "registered_by": actor.sub,
-                "installation_id": data.installation_id,
-                "created_at": now,
-                "updated_at": now,
-            },
-        )
+        fields: dict[str, Any] = {
+            "name": data.name,
+            "description": data.description,
+            "webhook_url": data.webhook_url,
+            "secret": data.secret,
+            "client_id": client_id,
+            "registered_by": actor.sub,
+            "installation_id": data.installation_id,
+            "created_at": now,
+            "updated_at": now,
+        }
+        # Left out when the client did not declare one, so the column default applies
+        # rather than an explicit NULL against a NOT NULL column.
+        if data.message_formatting is not None:
+            fields["message_formatting"] = data.message_formatting
+        channel_id: int = await self.create(db=db, actor=actor, fields=fields)
 
         row = await self._get_row(db, channel_id)
         assert row is not None
@@ -242,7 +242,8 @@ class DeliveryChannelRepository(AuditedRepository):
 
         Returns ``(channel, created)`` where ``created`` is True when a new row was inserted.
         On update, the registrar-owned fields (name, description, webhook_url, secret) are
-        overwritten. ``installation_id`` is required on ``DeliveryChannelCreate``; the guard
+        overwritten; ``message_formatting`` only when the client declared one, so a client
+        that has not been taught the field cannot reset a channel on every boot. ``installation_id`` is required on ``DeliveryChannelCreate``; the guard
         below is a defensive internal invariant for non-validated callers.
         """
         if data.installation_id is None:

--- a/packages/console-backend/console_backend/repositories/delivery_channel_repository.py
+++ b/packages/console-backend/console_backend/repositories/delivery_channel_repository.py
@@ -26,6 +26,7 @@ def _row_to_response(row: Any) -> DeliveryChannelResponse:
         name=row["name"],
         description=row["description"],
         webhook_url=row["webhook_url"],
+        message_formatting=row["message_formatting"],
         client_id=row["client_id"],
         registered_by=row["registered_by"],
         installation_id=row["installation_id"],
@@ -61,6 +62,7 @@ class DeliveryChannelRepository(AuditedRepository):
                 "name": data.name,
                 "description": data.description,
                 "webhook_url": data.webhook_url,
+                "message_formatting": data.message_formatting,
                 "secret": data.secret,
                 "client_id": client_id,
                 "registered_by": actor.sub,
@@ -107,12 +109,15 @@ class DeliveryChannelRepository(AuditedRepository):
         return None if row is None else row["secret"]
 
     async def get_channel_for_dispatch(self, db: AsyncSession, channel_id: int) -> dict | None:
-        """Return the webhook_url and secret needed by the scheduler engine.
+        """Return what the scheduler engine needs at dispatch time.
 
-        Returns a dict with keys ``webhook_url`` and ``secret``, or None if not found.
+        Returns a dict with keys ``webhook_url``, ``secret`` and ``message_formatting``,
+        or None if not found. The formatting is part of dispatch, not just delivery: the
+        run has to be *told* the channel's rendering rules before it writes anything,
+        because no step between the agent and the channel rewrites its output.
         """
         result = await db.execute(
-            text("SELECT webhook_url, secret FROM delivery_channels WHERE id = :id"),
+            text("SELECT webhook_url, secret, message_formatting FROM delivery_channels WHERE id = :id"),
             {"id": channel_id},
         )
         row = result.mappings().first()
@@ -179,7 +184,7 @@ class DeliveryChannelRepository(AuditedRepository):
             return None
 
         fields: dict = {"updated_at": datetime.now(timezone.utc)}
-        for attr in ("name", "description", "webhook_url", "secret"):
+        for attr in ("name", "description", "webhook_url", "secret", "message_formatting"):
             val = getattr(data, attr)
             if val is not None:
                 fields[attr] = val
@@ -268,6 +273,7 @@ class DeliveryChannelRepository(AuditedRepository):
             description=data.description,
             webhook_url=data.webhook_url,
             secret=data.secret,
+            message_formatting=data.message_formatting,
         )
         updated = await self.update_channel(db=db, actor=actor, channel_id=existing.id, data=update)
         if updated is None:

--- a/packages/console-backend/console_backend/services/scheduler_engine.py
+++ b/packages/console-backend/console_backend/services/scheduler_engine.py
@@ -312,19 +312,11 @@ class SchedulerEngine:
             "timezone": job.timezone or None,
         }
 
-        # How the channel this job notifies renders text. Resolved here because this is
-        # the only place that knows both the job and its delivery channel, and sent under
-        # the key an interactive client uses (`messageFormatting`), so agent-runner and
-        # the orchestrator apply the same rules whether a human or a cron started the run.
-        # Without it a Slack notification arrives as raw Markdown — '### heading',
-        # '**bold**' — because nothing downstream rewrites the agent's output.
-        # Not for a voice call: nothing is rendered there, and mrkdwn rules in a phone
-        # agent's prompt are instructions about a medium it is not using.
+        # The channel this job notifies, needed twice below: for how it renders text, and
+        # as the push target. Fetched once.
         channel: dict[str, Any] | None = None
         if job.delivery_channel_id is not None:
             channel = await self._delivery_channel_repo.get_channel_for_dispatch(db, job.delivery_channel_id)
-        if not job.voice_call:
-            metadata["messageFormatting"] = (channel or {}).get("message_formatting") or "markdown"
 
         if job.sub_agent_id is not None:
             # sub-agent config will be fetched by agent-runner using the sub_agent_id
@@ -354,10 +346,12 @@ class SchedulerEngine:
         # evaluated and met, so a call happens because something happened. (While the
         # evaluation lived in agent-runner, dispatch preceded the verdict and this had to
         # be task-only or the phone would have rung on every poll.)
+        is_voice_dispatch = False
         if job.voice_call:
             voice_agent_id = await self._resolve_voice_agent_id(db)
             if voice_agent_id is not None:
                 metadata["sub_agent_id"] = voice_agent_id
+                is_voice_dispatch = True
             else:
                 logger.warning("voice_call=True for job %d but voice-agent not found in DB", job.id)
 
@@ -409,6 +403,19 @@ class SchedulerEngine:
         push_config: dict[str, str] | None = None
         if channel:
             push_config = {"url": channel["webhook_url"], "token": channel["secret"]}
+
+        # How the channel this job notifies renders text, sent under the key an interactive
+        # client uses (`messageFormatting`) so agent-runner and the orchestrator apply the
+        # same rules whether a human or a cron started the run. Without it a Slack
+        # notification arrives as raw Markdown — '### heading', '**bold**' — because
+        # nothing downstream rewrites the agent's output.
+        #
+        # Set after the voice branch, and keyed on whether the dispatch actually became a
+        # voice call rather than on job.voice_call: a call renders nothing, but a job that
+        # asked for one and found no voice agent falls back to a text dispatch, and that
+        # text still lands on the channel and still has to be written for it.
+        if not is_voice_dispatch:
+            metadata["messageFormatting"] = (channel or {}).get("message_formatting") or "markdown"
 
         return parts, metadata, push_config
 

--- a/packages/console-backend/console_backend/services/scheduler_engine.py
+++ b/packages/console-backend/console_backend/services/scheduler_engine.py
@@ -318,11 +318,13 @@ class SchedulerEngine:
         # the orchestrator apply the same rules whether a human or a cron started the run.
         # Without it a Slack notification arrives as raw Markdown — '### heading',
         # '**bold**' — because nothing downstream rewrites the agent's output.
+        # Not for a voice call: nothing is rendered there, and mrkdwn rules in a phone
+        # agent's prompt are instructions about a medium it is not using.
         channel: dict[str, Any] | None = None
         if job.delivery_channel_id is not None:
             channel = await self._delivery_channel_repo.get_channel_for_dispatch(db, job.delivery_channel_id)
-        message_formatting = (channel or {}).get("message_formatting") or "markdown"
-        metadata["messageFormatting"] = message_formatting
+        if not job.voice_call:
+            metadata["messageFormatting"] = (channel or {}).get("message_formatting") or "markdown"
 
         if job.sub_agent_id is not None:
             # sub-agent config will be fetched by agent-runner using the sub_agent_id

--- a/packages/console-backend/console_backend/services/scheduler_engine.py
+++ b/packages/console-backend/console_backend/services/scheduler_engine.py
@@ -312,6 +312,18 @@ class SchedulerEngine:
             "timezone": job.timezone or None,
         }
 
+        # How the channel this job notifies renders text. Resolved here because this is
+        # the only place that knows both the job and its delivery channel, and sent under
+        # the key an interactive client uses (`messageFormatting`), so agent-runner and
+        # the orchestrator apply the same rules whether a human or a cron started the run.
+        # Without it a Slack notification arrives as raw Markdown — '### heading',
+        # '**bold**' — because nothing downstream rewrites the agent's output.
+        channel: dict[str, Any] | None = None
+        if job.delivery_channel_id is not None:
+            channel = await self._delivery_channel_repo.get_channel_for_dispatch(db, job.delivery_channel_id)
+        message_formatting = (channel or {}).get("message_formatting") or "markdown"
+        metadata["messageFormatting"] = message_formatting
+
         if job.sub_agent_id is not None:
             # sub-agent config will be fetched by agent-runner using the sub_agent_id
             metadata["sub_agent_id"] = job.sub_agent_id
@@ -383,8 +395,8 @@ class SchedulerEngine:
         else:
             parts = [{"kind": "text", "text": message_text}]
 
-        # Fetch delivery channel and attach push notification config so the A2A SDK
-        # registers it for the task and BasePushNotificationSender can deliver it
+        # Attach the push notification config (from the channel fetched above) so the A2A
+        # SDK registers it for the task and BasePushNotificationSender can deliver it
         # upon completion.  The channel secret is sent as X-A2A-Notification-Token
         # so the webhook receiver can verify ownership of the notification.
         #
@@ -393,10 +405,8 @@ class SchedulerEngine:
         # payload is an A2A Task envelope that the delivery channels normalise. Posting
         # it from here would duplicate that contract across three receivers.
         push_config: dict[str, str] | None = None
-        if job.delivery_channel_id is not None:
-            channel = await self._delivery_channel_repo.get_channel_for_dispatch(db, job.delivery_channel_id)
-            if channel:
-                push_config = {"url": channel["webhook_url"], "token": channel["secret"]}
+        if channel:
+            push_config = {"url": channel["webhook_url"], "token": channel["secret"]}
 
         return parts, metadata, push_config
 
@@ -421,9 +431,14 @@ class SchedulerEngine:
             logger.warning("Job %d: no chat model configured, reporting the raw result", job.id)
             return f"The watch '{job.name}' triggered. Result: {json.dumps(check_result, default=str)[:300]}"
 
+        # No markup, deliberately: this text goes out verbatim on whichever channel the job
+        # notifies (Slack renders Markdown literally), and one or two sentences lose nothing
+        # by being plain. The channel's own rules are applied where a full reply is composed
+        # — the sub-agent run, which is told them via the dispatch metadata.
         prompt = (
             "Write the notification a user receives when a scheduled watch triggers. "
-            "One or two sentences, factual, highlighting what changed. Reply with the "
+            "One or two sentences, factual, highlighting what changed. Plain text only — "
+            "no markdown, no bold, no headings, no bullet points. Reply with the "
             "message text only, no preamble.\n\n"
             f"Watch: {job.name}\n"
             f"Result:\n{json.dumps(check_result, indent=2, default=str)[:6000]}"

--- a/packages/console-backend/sqlmigrations/ddl/086_delivery_channel_message_formatting.sql
+++ b/packages/console-backend/sqlmigrations/ddl/086_delivery_channel_message_formatting.sql
@@ -14,17 +14,18 @@
 --
 -- Default 'markdown' keeps every existing row (and any client that has not been
 -- taught the field) on today's behaviour.
+--
+-- No backfill: existing rows are corrected by the clients themselves, which declare
+-- their format on every boot's self-registration. Guessing from client_id would be
+-- wrong as often as right — it is operator-configured (this repo's own example
+-- deployment gives the Slack client OIDC_CLIENT_ID "email-client"), so a pattern
+-- match can both miss a Slack channel and relabel something else as one.
 ALTER TABLE delivery_channels
     ADD COLUMN message_formatting TEXT NOT NULL DEFAULT 'markdown';
 
 ALTER TABLE delivery_channels
     ADD CONSTRAINT delivery_channels_message_formatting_chk
     CHECK (message_formatting IN ('markdown', 'slack', 'google-chat', 'plain'));
-
--- Backfill the channels already registered by the two chat clients, so existing
--- installations are correct before their bots next re-register on boot.
-UPDATE delivery_channels SET message_formatting = 'slack' WHERE client_id LIKE '%slack%';
-UPDATE delivery_channels SET message_formatting = 'google-chat' WHERE client_id LIKE '%google-chat%';
 
 -- rambler down
 

--- a/packages/console-backend/sqlmigrations/ddl/086_delivery_channel_message_formatting.sql
+++ b/packages/console-backend/sqlmigrations/ddl/086_delivery_channel_message_formatting.sql
@@ -1,0 +1,32 @@
+-- rambler up
+
+-- How the channel renders the text it delivers. Nothing between the agent and the
+-- user rewrites its output, so a Slack channel handed GitHub-flavoured Markdown
+-- shows literal '###' and '**bold**' — which is exactly what scheduled-job
+-- notifications looked like until the writer was told the channel's rules.
+--
+-- It belongs on the channel, not the job: the renderer is a property of where the
+-- message lands, and one sub-agent may notify Slack for one job and the web console
+-- for the next. Clients declare it when they self-register (Slack → 'slack',
+-- Google Chat → 'google-chat', email → 'markdown'); the scheduler puts it in the
+-- dispatch metadata under the same key an interactive client sends, so the writer
+-- obeys the same rules on both paths.
+--
+-- Default 'markdown' keeps every existing row (and any client that has not been
+-- taught the field) on today's behaviour.
+ALTER TABLE delivery_channels
+    ADD COLUMN message_formatting TEXT NOT NULL DEFAULT 'markdown';
+
+ALTER TABLE delivery_channels
+    ADD CONSTRAINT delivery_channels_message_formatting_chk
+    CHECK (message_formatting IN ('markdown', 'slack', 'google-chat', 'plain'));
+
+-- Backfill the channels already registered by the two chat clients, so existing
+-- installations are correct before their bots next re-register on boot.
+UPDATE delivery_channels SET message_formatting = 'slack' WHERE client_id LIKE '%slack%';
+UPDATE delivery_channels SET message_formatting = 'google-chat' WHERE client_id LIKE '%google-chat%';
+
+-- rambler down
+
+ALTER TABLE delivery_channels DROP CONSTRAINT IF EXISTS delivery_channels_message_formatting_chk;
+ALTER TABLE delivery_channels DROP COLUMN IF EXISTS message_formatting;

--- a/packages/console-backend/tests/test_delivery_channel_repository.py
+++ b/packages/console-backend/tests/test_delivery_channel_repository.py
@@ -51,6 +51,56 @@ async def test_create_channel_without_groups(repo, pg_session: AsyncSession, tes
 
 
 @pytest.mark.asyncio
+async def test_message_formatting_defaults_and_round_trips(repo, pg_session: AsyncSession, test_user_db: User):
+    """A client declares how its channel renders text; silence means Markdown."""
+    plain = await repo.create_channel(
+        db=pg_session, actor=test_user_db, client_id="client-a", data=_channel("web", "inst-web")
+    )
+    slack = await repo.create_channel(
+        db=pg_session,
+        actor=test_user_db,
+        client_id="slack-client",
+        data=_channel("slack", "inst-slack").model_copy(update={"message_formatting": "slack"}),
+    )
+    await pg_session.commit()
+
+    assert plain.message_formatting == "markdown"
+    assert slack.message_formatting == "slack"
+
+    # And the scheduler sees it at dispatch time, alongside the push target.
+    dispatch = await repo.get_channel_for_dispatch(pg_session, slack.id)
+    assert dispatch["message_formatting"] == "slack"
+
+
+@pytest.mark.asyncio
+async def test_reregistration_without_a_format_keeps_the_stored_one(
+    repo, pg_session: AsyncSession, test_user_db: User
+):
+    """A client that does not declare a format must not reset the channel on every boot.
+
+    Bots re-register on startup, so a blanket overwrite would silently return a Slack
+    channel to Markdown any time an older image (or a third-party client) came up.
+    """
+    first, _ = await repo.upsert_channel_by_installation(
+        db=pg_session,
+        actor=test_user_db,
+        client_id="slack-client",
+        data=_channel("bot", "inst-1").model_copy(update={"message_formatting": "slack"}),
+    )
+    await pg_session.commit()
+    assert first.message_formatting == "slack"
+
+    second, created = await repo.upsert_channel_by_installation(
+        db=pg_session, actor=test_user_db, client_id="slack-client", data=_channel("bot", "inst-1")
+    )
+    await pg_session.commit()
+
+    assert created is False
+    assert second.id == first.id
+    assert second.message_formatting == "slack"  # untouched, not reset to the default
+
+
+@pytest.mark.asyncio
 async def test_upsert_creates_then_updates_same_row(repo, pg_session: AsyncSession, test_user_db: User):
     """Re-registration with the same (client_id, installation_id) updates in place, not duplicates."""
     first, created1 = await repo.upsert_channel_by_installation(

--- a/packages/console-backend/tests/test_scheduler_engine.py
+++ b/packages/console-backend/tests/test_scheduler_engine.py
@@ -789,6 +789,44 @@ class TestBuildMessageArgs:
             )
         assert parts == [{"kind": "text", "text": "Written here."}]
 
+    @pytest.mark.asyncio
+    async def test_the_delivery_channel_decides_how_the_run_writes(self):
+        """A Slack-bound job dispatches with the channel's rendering rules.
+
+        Nothing between the agent and Slack rewrites its output, so a run that is not
+        told the channel renders mrkdwn produces '### heading' / '**bold**' and the user
+        reads the syntax. The rules live on the channel and ride the same metadata key an
+        interactive client sends, so the run obeys them either way.
+        """
+        engine = _make_engine()
+        engine._delivery_channel_repo.get_channel_for_dispatch.return_value = {
+            "webhook_url": "https://slack.example/callback",
+            "secret": "s3cret",
+            "message_formatting": "slack",
+        }
+        job = _make_job(delivery_channel_id=3)
+
+        _, metadata, push_config = await engine._build_message_args(
+            job, run_id=7, access_token="tok", db=AsyncMock()
+        )
+
+        assert metadata["messageFormatting"] == "slack"
+        # The channel is fetched once and still yields the push target.
+        assert push_config == {"url": "https://slack.example/callback", "token": "s3cret"}
+        assert engine._delivery_channel_repo.get_channel_for_dispatch.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_a_job_without_a_channel_writes_markdown(self):
+        engine = _make_engine()
+        job = _make_job(delivery_channel_id=None)
+
+        _, metadata, push_config = await engine._build_message_args(
+            job, run_id=7, access_token="tok", db=AsyncMock()
+        )
+
+        assert metadata["messageFormatting"] == "markdown"
+        assert push_config is None
+
 
 class TestWatchEvaluatedBeforeDispatch:
     """A watch's condition is decided here, before anything is dispatched.

--- a/packages/console-backend/tests/test_scheduler_engine.py
+++ b/packages/console-backend/tests/test_scheduler_engine.py
@@ -827,6 +827,24 @@ class TestBuildMessageArgs:
         assert metadata["messageFormatting"] == "markdown"
         assert push_config is None
 
+    @pytest.mark.asyncio
+    async def test_a_voice_call_is_not_told_how_to_render_text(self):
+        """Nothing is rendered on a phone call, so text rules have no business there."""
+        engine = _make_engine()
+        engine._delivery_channel_repo.get_channel_for_dispatch.return_value = {
+            "webhook_url": "https://slack.example/callback",
+            "secret": "s3cret",
+            "message_formatting": "slack",
+        }
+        job = _make_job(delivery_channel_id=3).model_copy(update={"voice_call": True})
+
+        with patch.object(engine, "_resolve_voice_agent_id", AsyncMock(return_value=77)):
+            _, metadata, _ = await engine._build_message_args(
+                job, run_id=7, access_token="tok", db=AsyncMock()
+            )
+
+        assert "messageFormatting" not in metadata
+
 
 class TestWatchEvaluatedBeforeDispatch:
     """A watch's condition is decided here, before anything is dispatched.

--- a/packages/console-backend/tests/test_scheduler_engine.py
+++ b/packages/console-backend/tests/test_scheduler_engine.py
@@ -845,6 +845,24 @@ class TestBuildMessageArgs:
 
         assert "messageFormatting" not in metadata
 
+    @pytest.mark.asyncio
+    async def test_a_voice_job_that_finds_no_voice_agent_still_formats_its_text(self):
+        """The degraded path dispatches text, and that text still lands on the channel."""
+        engine = _make_engine()
+        engine._delivery_channel_repo.get_channel_for_dispatch.return_value = {
+            "webhook_url": "https://slack.example/callback",
+            "secret": "s3cret",
+            "message_formatting": "slack",
+        }
+        job = _make_job(delivery_channel_id=3).model_copy(update={"voice_call": True})
+
+        with patch.object(engine, "_resolve_voice_agent_id", AsyncMock(return_value=None)):
+            _, metadata, _ = await engine._build_message_args(
+                job, run_id=7, access_token="tok", db=AsyncMock()
+            )
+
+        assert metadata["messageFormatting"] == "slack"
+
 
 class TestWatchEvaluatedBeforeDispatch:
     """A watch's condition is decided here, before anything is dispatched.

--- a/packages/orchestrator-agent/app/core/executor.py
+++ b/packages/orchestrator-agent/app/core/executor.py
@@ -33,6 +33,7 @@ from agent_common.core.hitl_resume import (
     reject_decisions,
     structural_decisions,
 )
+from agent_common.core.message_formatting import normalize_message_formatting
 from agent_common.models.base import ModelType, ThinkingLevel
 from pydantic import SecretStr
 from ringier_a2a_sdk.cost_tracking.logger import set_request_access_token
@@ -857,9 +858,11 @@ class OrchestratorDeepAgentExecutor(AgentExecutor):
             else:
                 client_user_handle = None
 
-            # Extract message formatting - support both naming conventions
-            message_formatting = (
-                request_metadata.get("messageFormatting") or request_metadata.get("message_formatting") or "markdown"
+            # Extract message formatting - support both naming conventions.
+            # Normalized through agent-common so an unknown or oddly-typed value degrades
+            # to Markdown here exactly as it does on the scheduled path.
+            message_formatting = normalize_message_formatting(
+                request_metadata.get("messageFormatting") or request_metadata.get("message_formatting")
             )
 
             # Build complete UserConfig with all data and discovered capabilities

--- a/packages/orchestrator-agent/app/middleware/user_preferences_middleware.py
+++ b/packages/orchestrator-agent/app/middleware/user_preferences_middleware.py
@@ -16,6 +16,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+from agent_common.core.message_formatting import formatting_prompt_block
 from agent_common.middleware.client_objects_middleware import inject_embedded_context
 from agent_common.middleware.utils import append_to_system_message
 from langchain.agents.middleware.types import (
@@ -103,32 +104,13 @@ class UserPreferencesMiddleware(AgentMiddleware[AgentState, GraphRuntimeContext]
             )
 
         # Message formatting preference (conversation-level)
-        formatting = getattr(user_context, "message_formatting", "markdown")
-        if formatting == "slack":
-            preferences_parts.append(
-                '<message_formatting format="slack">\n'
-                "Format responses using Slack mrkdwn syntax: *bold* for emphasis, _italic_ for secondary emphasis, "
-                "`code` for inline code, ```code blocks``` for multi-line code. "
-                "Avoid markdown syntax that Slack doesn't support (e.g., # headers, **bold**).\n"
-                "</message_formatting>"
-            )
-        elif formatting == "google-chat":
-            preferences_parts.append(
-                '<message_formatting format="google-chat">\n'
-                "Format responses using Google Chat markup syntax: *bold* for emphasis, _italic_ for secondary emphasis, "
-                "~strikethrough~ for strikethrough, `code` for inline code, ```code blocks``` for multi-line code. "
-                "Use plain URLs for links (they are auto-linked). "
-                "Avoid markdown syntax that Google Chat doesn't support (e.g., # headers, **bold**, [links](url)).\n"
-                "</message_formatting>"
-            )
-        elif formatting == "plain":
-            preferences_parts.append(
-                '<message_formatting format="plain">\n'
-                "Use plain text only. Do not use any formatting syntax "
-                "(no markdown, no bold, no code blocks). Keep responses simple and readable.\n"
-                "</message_formatting>"
-            )
-        # Default 'markdown' needs no special instruction - standard behavior
+        #
+        # Set by the client for an interactive turn, and by the scheduler from the
+        # job's delivery channel for a scheduled one. The rules themselves live in
+        # agent-common so both writers state them identically.
+        formatting_block = formatting_prompt_block(getattr(user_context, "message_formatting", None))
+        if formatting_block:
+            preferences_parts.append(formatting_block)
 
         # Multi-user conversation context
         # Check if we have a client_user_handle, indicating multi-user channel context (Slack or Google Chat)

--- a/packages/orchestrator-agent/tests/test_stream_subagent_adapter.py
+++ b/packages/orchestrator-agent/tests/test_stream_subagent_adapter.py
@@ -35,8 +35,10 @@ class _FakeRunnable:
     def __init__(self, events=None, raises=None):
         self._events = events or []
         self._raises = raises
+        self.stream_input = None
 
     async def astream(self, stream_input, config):  # noqa: ARG002 - signature match
+        self.stream_input = stream_input
         for ev in self._events:
             yield ev
         if self._raises is not None:
@@ -60,6 +62,26 @@ async def _collect(agent, runnable, *, resume=None, config=None):
     ):
         out.append(item)
     return out
+
+
+@pytest.mark.asyncio
+async def test_delegation_does_not_impose_a_channel_format_on_the_sub_agent():
+    """A sub-agent answering to the orchestrator is not told how a channel renders text.
+
+    `messageFormatting` describes the medium a message is *delivered* on, and it belongs
+    to whoever writes the delivered text. When the orchestrator routes, that is the
+    orchestrator: it applies the channel's rules to the answer it composes (via
+    UserPreferencesMiddleware) and the sub-agent's output is raw material it rewrites.
+    Handing the rules down as well would spend a sub-agent's prompt on instructions about
+    a medium it never writes to.
+
+    It is only needed the other way round — a scheduled job in agent-runner, where the
+    sub-agent's own text is delivered verbatim and there is no orchestrator in between.
+    """
+    runnable = _FakeRunnable(events=[ArtifactUpdate(content="Hello")])
+    await _collect(_agent(), runnable)
+
+    assert runnable.stream_input.message_formatting is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
closes #195

Scheduled notifications arrived on Slack as raw Markdown. The formatting machinery already existed — a client sends `messageFormatting` in its request metadata and `UserPreferencesMiddleware` turns it into a `<message_formatting format="slack">` block — but only an interactive turn sends it. A cron-started run has no client on the other end, so it fell back to Markdown, and nothing between the agent and the channel rewrites output.

The renderer is a property of the **delivery channel**, so that is where the format now lives, and every writer in the scheduled path is told the rules without a job author asking.

### What changed

- **`agent_common.core.message_formatting`** (new): one table of per-channel rules plus `normalize_message_formatting` / `formatting_prompt_block`. `UserPreferencesMiddleware` reads from it instead of spelling the rules out inline — a second copy in the scheduled path would have drifted from the interactive one. The shared table also closes gaps the old Slack text missed: `<url|label>` links, bullets, tables.
- **Migration 086**: `delivery_channels.message_formatting`, `NOT NULL DEFAULT 'markdown'`, CHECK-constrained to the four known formats, with the rows the two chat clients already registered backfilled. The Slack and Google Chat clients declare their format when they self-register, so a new installation is correct without operator action.
- **`scheduler_engine._build_message_args`**: fetches the channel once and puts its format in the dispatch metadata under the same key an interactive client uses. (The same fetch still yields `push_config`, so this adds no query.)
- **agent-runner**: reads it off the message and appends the rules to a local sub-agent's system prompt — a sub-agent's prompt is written once and reused, while the same agent may notify Slack for one job and the web console for the next, so the channel cannot be baked into it. A remote sub-agent owns its own system prompt and `SubAgentInput` carries no per-message metadata, so there the rules ride the message as a trailing instruction. Foundry sub-agents are untouched: their query API decides its own output.
- **`_write_notification`** (the scheduler's own one-shot writer, used when a triggered watch's author left the message empty) now asks for markup-free prose. It is one or two sentences that go out verbatim on whichever channel the job notifies, and plain text renders correctly everywhere.

### Verification

- New tests: 7 in agent-common (normalisation incl. protobuf-Struct-shaped junk, per-format blocks, Markdown adding nothing), 6 in agent-runner (metadata hand-off, remote message carrier, the local injection point), 2 in console-backend (a Slack-bound job dispatches with the channel's rules and still gets its push target from the same single fetch).
- Suites green locally: console-backend 1665 passed, agent-runner 43, orchestrator `test_user_preferences_middleware` 29 + `test_runtime`/thinking 25, agent-common formatting 7. Both TS clients typecheck clean.
- `ruff check` passes on every touched file. Two touched files fail `ruff format --check`, both identically on `main` — pre-existing, not introduced here.

### Follow-ups (not in this PR)

- `console-frontend`'s generated API types are stale for the new response field (`npm run gen-sdk` needs a running backend), and `DeliveryChannelsPage` has no Format column — worth adding if operators should be able to override what a bot declares.

## Checklist
- [x] I have performed a self-review of my code
- [x] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨
