### PR TITLE
feat(embed-sdk): stamp the user's send with sentAt for the dev timeline

### DIFF
--- a/packages/embed-sdk/src/panel/components/thread.tsx
+++ b/packages/embed-sdk/src/panel/components/thread.tsx
@@ -183,7 +183,7 @@ function CopyMessageButton({ text, className }: { text: string; className?: stri
   );
 }
 
-function UserMessage({ message }: { message: NannosUIMessage }) {
+function UserMessage({ message, showTime }: { message: NannosUIMessage; showTime: boolean }) {
   const text = message.parts
     .filter((part): part is Extract<MessagePart, { type: 'text' }> => part.type === 'text')
     .map((part) => part.text)
@@ -212,7 +212,8 @@ function UserMessage({ message }: { message: NannosUIMessage }) {
   return (
     <div className="group/nannos-message flex w-full flex-col items-end gap-0.5">
       <Message from="user">
-        <MessageContent>
+        <MessageContent className={showTime ? 'gap-1' : undefined}>
+          {showTime && <DevTimestamp ts={message.metadata?.sentAt} />}
           {text && <span className="whitespace-pre-wrap break-words">{text}</span>}
           {files.length > 0 && (
             <span className="flex flex-wrap gap-1.5">
@@ -238,10 +239,11 @@ function UserMessage({ message }: { message: NannosUIMessage }) {
 }
 
 /**
- * Arrival time, dev mode only. Every event the agent sends carries one — the
- * activity lines in `data.ts`, the answer in its provider metadata — so the
- * turn reads as a timeline down the thread. Callers gate on dev mode; an
- * unstamped part (older history) renders nothing.
+ * Arrival time, dev mode only. Every event of a turn carries one — the user's
+ * own send in `metadata.sentAt`, the activity lines in `data.ts`, the answer in
+ * its provider metadata — so the turn reads as a timeline down the thread, from
+ * the question to the answer. Callers gate on dev mode; an unstamped part or
+ * message (older history) renders nothing.
  */
 function DevTimestamp({ ts }: { ts?: number }) {
   if (ts === undefined) return null;
@@ -928,7 +930,7 @@ function ThreadMessage({
       ) : message.metadata?.display ? (
         <ContextChip message={message} />
       ) : (
-        <UserMessage message={message} />
+        <UserMessage message={message} showTime={devMode} />
       );
     if (!devMode) return rendered;
     // The badge wraps even a message whose bubble renders nothing (a HITL
@@ -941,7 +943,7 @@ function ThreadMessage({
       <DevWirePart
         label={message.metadata?.display ? 'message · user · context' : 'message · user'}
         payload={{ id: message.id, parts: message.parts, metadata: message.metadata }}
-        needle={userText ? { text: userText } : undefined}
+        needle={userText ? { text: userText, ts: message.metadata?.sentAt } : undefined}
         dir="out"
         conversationId={conversationId}
       >

--- a/packages/embed-sdk/src/panel/hooks/use-nannos-chat.ts
+++ b/packages/embed-sdk/src/panel/hooks/use-nannos-chat.ts
@@ -163,9 +163,12 @@ export function useNannosChat(conversationIdOverride?: string): UseNannosChatVal
     assistant.clearSeededPrompt();
     void sendMessage({
       text: seededPrompt.text,
-      ...(seededPrompt.displayText && {
-        metadata: { display: { kind: 'context' as const, label: seededPrompt.displayText } },
-      }),
+      metadata: {
+        sentAt: Date.now(),
+        ...(seededPrompt.displayText && {
+          display: { kind: 'context' as const, label: seededPrompt.displayText },
+        }),
+      },
     });
     engine.conversations.noteTitle(conversationId, seededPrompt.displayText ?? seededPrompt.text);
   }, [seededPrompt, conversationId, isReadOnly, engine, assistant, sendMessage]);
@@ -183,6 +186,7 @@ export function useNannosChat(conversationIdOverride?: string): UseNannosChatVal
         void sendMessage({
           text,
           metadata: {
+            sentAt: Date.now(),
             ...(opts?.displayText && {
               display: {
                 kind: opts.displayKind ?? ('context' as const),

--- a/packages/embed-sdk/src/panel/thread-parts.test.tsx
+++ b/packages/embed-sdk/src/panel/thread-parts.test.tsx
@@ -9,9 +9,10 @@
  * tool reads exactly like a tool that never needed approval (its activity
  * lines, then the answer), while dev mode keeps the raw part for inspection.
  *
- * Dev timestamps: every agent event carries its arrival time — activity lines
- * in `data.ts`, the answer in its provider metadata — so dev mode reads the
- * turn as one timeline, and the end-user view shows none of it.
+ * Dev timestamps: every event of a turn carries its time — the user's send in
+ * `metadata.sentAt`, activity lines in `data.ts`, the answer in its provider
+ * metadata — so dev mode reads the turn as one timeline from question to
+ * answer, and the end-user view shows none of it.
  */
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -65,6 +66,18 @@ function message(toolPart: Record<string, unknown>): NannosUIMessage {
     id: 'msg-1',
     role: 'assistant',
     parts: [ACTIVITY, toolPart as NannosUIMessage['parts'][number]],
+  };
+}
+
+const SENT_TEXT = 'What is in memories?';
+
+/** The send that opens a turn, stamped the way the composer's `send` stamps it. */
+function userTurn(stamped = true): NannosUIMessage {
+  return {
+    id: 'msg-0',
+    role: 'user',
+    parts: [{ type: 'text', text: SENT_TEXT }],
+    ...(stamped && { metadata: { sentAt: TS } }),
   };
 }
 
@@ -258,6 +271,27 @@ describe('dev timestamps', () => {
 
     // The activity line still has its own stamp; the answer simply has none.
     expect(screen.getAllByText(CLOCK)).toHaveLength(1);
+  });
+
+  it('times the send as well, so the turn reads from question to answer', () => {
+    mountThread([userTurn(), answeredTurn()], true);
+
+    // Three events on the one clock: the question, the tool call, the answer.
+    expect(screen.getAllByText(CLOCK)).toHaveLength(3);
+  });
+
+  it('shows no clock on the send in the end-user view', () => {
+    mountThread([userTurn()]);
+
+    expect(screen.getByText(SENT_TEXT)).toBeTruthy();
+    expect(screen.queryByText(CLOCK)).toBeNull();
+  });
+
+  it('leaves an unstamped send (older history) alone', () => {
+    mountThread([userTurn(false)], true);
+
+    expect(screen.getByText(SENT_TEXT)).toBeTruthy();
+    expect(screen.queryByText(CLOCK)).toBeNull();
   });
 });
 

--- a/packages/embed-sdk/src/transport/a2a-transport.ts
+++ b/packages/embed-sdk/src/transport/a2a-transport.ts
@@ -329,6 +329,7 @@ export class A2AChatTransport implements ChatTransport<NannosUIMessage> {
       id: sendId,
       role: 'user',
       parts: [{ type: 'text', text }],
+      metadata: { sentAt: Date.now() },
     };
     const payload = buildNewTurnPayload({
       messageId: sendId,

--- a/packages/embed-sdk/src/transport/ai-types.ts
+++ b/packages/embed-sdk/src/transport/ai-types.ts
@@ -68,6 +68,11 @@ export type NannosDataParts = {
 export interface NannosMessageMetadata {
   /** DB id the backend injects mid-turn; used as the history dedupe key. */
   persistedMessageId?: string;
+  /** When the user's message left this browser — for a restored one, the time
+   *  of its stored row. The send's own place in the turn's timeline, the way
+   *  `textArrival` stamps the answer; dev mode is the only reader. Nothing
+   *  crosses the wire: `buildNewTurnPayload` assembles its own metadata. */
+  sentAt?: number;
   /** Host-injected prompt rendered as a muted context chip instead of a user bubble. */
   /** How a user message renders when the panel, not the person, composed its
    *  text. `context` is a host-injected chip; `receipt` is a decision the user

--- a/packages/embed-sdk/src/transport/history-mapper.ts
+++ b/packages/embed-sdk/src/transport/history-mapper.ts
@@ -152,13 +152,19 @@ function userMessage(row: RestMessageRow, index: number): NannosUIMessage {
     }
   }
   const injectedDisplayText = row.metadata?.injectedDisplayText;
+  const display =
+    typeof injectedDisplayText === 'string' && injectedDisplayText
+      ? injectedDisplay(row, injectedDisplayText)
+      : undefined;
+  // 0 = the row carried no readable time; leave it unstamped rather than put a
+  // 1970 clock in the thread.
+  const sentAt = rowTime(row);
+  const metadata = { ...(sentAt > 0 && { sentAt }), ...(display && { display }) };
   return {
     id: rowId(row, `hist-u-${index}`),
     role: 'user',
     parts,
-    ...(typeof injectedDisplayText === 'string' && injectedDisplayText
-      ? { metadata: { display: injectedDisplay(row, injectedDisplayText) } }
-      : {}),
+    ...(Object.keys(metadata).length > 0 && { metadata }),
   };
 }
 


### PR DESCRIPTION
In dev mode every event of a turn already carries its arrival time — the
activity lines in `data.ts`, the answer in its provider metadata — but the
user's own message did not, so the timeline started at the first agent
event instead of the question.

- `metadata.sentAt` is set wherever a user turn is composed: the composer's
  `send` (inside `startTurn`, so the interrupt path is stamped too), the
  seeded prompt, and transport-composed turns
- history restores it from the stored row's time; a row without a readable
  time stays unstamped rather than showing a 1970 clock, and a user message
  only carries `metadata` when there is something to carry
- `UserMessage` renders the clock in dev mode only; the dev wire badge's
  needle carries the same timestamp
- tests: the send is timed, the end-user view shows no clock, unstamped
  history is left alone

Ported from the pre-merge working tree onto main (the send and the history
mapper were refactored there in the meantime).

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

closes #

## Checklist
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨
