### PR TITLE
fix(scheduler): rank draft-generator tools server-side, fail loudly on an empty draft

### DIFF
--- a/packages/console-backend/console_backend/models/scheduled_job.py
+++ b/packages/console-backend/console_backend/models/scheduled_job.py
@@ -393,7 +393,12 @@ class GenerateJobDraftRequest(BaseModel):
     """Request body for generating a scheduled job from a one-line description."""
 
     tools: list[dict[str, Any]] = Field(
-        description="List of available MCP tool objects (name, description, input_schema.)"
+        default_factory=list,
+        deprecated=True,
+        description=(
+            "Ignored. The candidate tools are selected server-side from the caller's own "
+            "catalogue; the field is kept so an older UI can still post to this endpoint."
+        ),
     )
     query: str = Field(
         min_length=1,

--- a/packages/console-backend/console_backend/models/scheduled_job.py
+++ b/packages/console-backend/console_backend/models/scheduled_job.py
@@ -390,16 +390,12 @@ class ScheduledJobCreate(BaseModel):
 
 
 class GenerateJobDraftRequest(BaseModel):
-    """Request body for generating a scheduled job from a one-line description."""
+    """Request body for generating a scheduled job from a one-line description.
 
-    tools: list[dict[str, Any]] = Field(
-        default_factory=list,
-        deprecated=True,
-        description=(
-            "Ignored. The candidate tools are selected server-side from the caller's own "
-            "catalogue; the field is kept so an older UI can still post to this endpoint."
-        ),
-    )
+    Only the request itself: the tools, sub-agents and channels the draft may reference
+    are the caller's own and are read server-side, never accepted from the body.
+    """
+
     query: str = Field(
         min_length=1,
         max_length=500,

--- a/packages/console-backend/console_backend/routers/mcp_router.py
+++ b/packages/console-backend/console_backend/routers/mcp_router.py
@@ -170,6 +170,24 @@ async def grep_mcp_tools(
             detail=f"Failed to fetch MCP tools: {type(e).__name__}",
         )
 
+    filtered_tools = rank_mcp_tools(all_tools.tools, query, top_k)
+
+    logger.info(
+        f"Grep MCP tools: query='{query}', server='{server_slug}', "
+        f"found {len(filtered_tools)}/{len(all_tools.tools)} matches (top {top_k})"
+    )
+
+    return MCPToolsResponse(tools=filtered_tools)
+
+
+def rank_mcp_tools(tools: list[MCPTool], query: str, top_k: int) -> list[MCPTool]:
+    """The `top_k` tools most relevant to `query`, best first; tools that match nothing are left out.
+
+    Pure and side-effect free so it can serve any caller that has a catalogue and a
+    sentence — the search endpoint above and the scheduled-job draft generator, which
+    uses it to pick the handful of tools worth showing a model instead of the whole
+    registry. Weights are documented on `grep_mcp_tools`.
+    """
     # Tokenize query and filter stop words
     query_lower = query.lower().strip()
     stop_words = {"the", "a", "an", "of", "in", "on", "for", "with", "and", "or", "to", "from"}
@@ -182,7 +200,7 @@ async def grep_mcp_tools(
     # Score each tool (using list of tuples instead of dict since Pydantic models aren't hashable)
     tool_scores = []
 
-    for tool in all_tools.tools:
+    for tool in tools:
         score = 0
 
         # Prepare searchable text fields
@@ -228,14 +246,7 @@ async def grep_mcp_tools(
 
     # Sort by score (descending) and take top_k
     tool_scores.sort(key=lambda x: x[0], reverse=True)
-    filtered_tools = [tool for score, tool in tool_scores[:top_k]]
-
-    logger.info(
-        f"Grep MCP tools: query='{query}', server='{server_slug}', "
-        f"found {len(filtered_tools)}/{len(all_tools.tools)} matches (top {top_k})"
-    )
-
-    return MCPToolsResponse(tools=filtered_tools)
+    return [tool for score, tool in tool_scores[:top_k]]
 
 
 def _get_console_mcp_tools(request: Request, user: User | None = None) -> list[MCPTool]:

--- a/packages/console-backend/console_backend/routers/scheduler_router.py
+++ b/packages/console-backend/console_backend/routers/scheduler_router.py
@@ -254,6 +254,22 @@ def _coerce_id(value: object, allowed: set[int]) -> int | None:
     return candidate
 
 
+def _coerce_name(value: object, allowed: set[str]) -> str | None:
+    """A generated name, or None when it is not a string or not among the offered ones.
+
+    The string guard matters: a model asked for "the single best-matching tool" answers
+    with a list when several match, and a bare `in` on a set would raise on it.
+    """
+    if not isinstance(value, str):
+        if value is not None:
+            logger.info("Discarding generated name %r: not a string", value)
+        return None
+    if value not in allowed:
+        logger.info("Discarding generated name %r outside the offered set", value)
+        return None
+    return value
+
+
 def _agent_choices(sub_agents: list[SubAgent]) -> list[dict[str, Any]]:
     """The sub-agents a generated job may pick from, as the prompt sees them.
 
@@ -309,19 +325,38 @@ async def _candidate_tools(request: Request, user: User, query: str) -> list[MCP
     except HTTPException:
         raise
     except Exception as exc:
-        logger.warning("Could not read the tool catalogue for draft generation: %s", exc)
+        # When the gateway starts failing this is the only line an operator gets, so
+        # it carries the upstream status where there is one, and the traceback.
+        upstream = getattr(getattr(exc, "response", None), "status_code", None)
+        logger.warning(
+            "Could not read the tool catalogue for draft generation (%s, upstream status %s)",
+            type(exc).__name__,
+            upstream,
+            exc_info=True,
+        )
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Could not read the tool catalogue — try again shortly.",
         ) from exc
     candidates = rank_mcp_tools(catalogue.tools, query, _DRAFT_TOOL_CANDIDATES)
-    logger.info(
-        "Draft generation offers %d of %d tools for query %r: %s",
-        len(candidates),
-        len(catalogue.tools),
-        query,
-        [t.name for t in candidates],
-    )
+    # An empty offer is legitimate — a task job needs no tool, and the request may
+    # simply share no vocabulary with the catalogue — but it is worth its own line, since
+    # the model can then only name a tool from memory, which is discarded afterwards.
+    if not candidates:
+        logger.info(
+            "Draft generation offers no tools for query %r (%d in the catalogue%s)",
+            query,
+            len(catalogue.tools),
+            "" if catalogue.tools else " — empty, e.g. under impersonation",
+        )
+    else:
+        logger.info(
+            "Draft generation offers %d of %d tools for query %r: %s",
+            len(candidates),
+            len(catalogue.tools),
+            query,
+            [t.name for t in candidates],
+        )
     return candidates
 
 
@@ -351,9 +386,11 @@ async def generate_job_draft(
     request and cut to a handful — see `_DRAFT_TOOL_CANDIDATES`.
     """
     candidate_tools = await _candidate_tools(request, current_user, data.query)
+    # Compact on purpose: pretty-printed schema is a third more tokens for whitespace the
+    # model does not need, and the whole prompt is re-sent on every CEL repair round.
     tools_summary = json.dumps(
         [{"name": t.name, "description": t.description, "input_schema": t.input_schema} for t in candidate_tools],
-        indent=2,
+        separators=(",", ":"),
     )
     allowed_tool_names = {t.name for t in candidate_tools}
     # Offer only what this user can reach: the model picks from these, and anything
@@ -506,11 +543,14 @@ async def generate_job_draft(
     generated["sub_agent_id"] = _coerce_id(result.get("sub_agent_id"), allowed_agent_ids)
     generated["delivery_channel_id"] = _coerce_id(result.get("delivery_channel_id"), allowed_channel_ids)
     # A tool name outside the offered set is an invention — the model saw only the
-    # candidates — and would produce a job whose check fails on its first run.
-    check_tool = result.get("check_tool")
-    if check_tool is not None and check_tool not in allowed_tool_names:
-        logger.info("Discarding generated check_tool %r: not among the offered tools", check_tool)
-        generated["check_tool"] = None
+    # candidates — and would produce a job whose check fails on its first run. The
+    # arguments and condition were written against that invented tool, so they go with
+    # it: the form applies each of them independently, and pre-filled arguments under a
+    # tool the user then picks by hand are exactly the first-run failure being avoided.
+    generated["check_tool"] = _coerce_name(result.get("check_tool"), allowed_tool_names)
+    if generated["check_tool"] is None and result.get("check_tool") is not None:
+        for key in ("check_args", "check_args_exprs", "cel_expr", "llm_condition"):
+            generated.pop(key, None)
     if isinstance(generated.get("check_args"), str):
         try:
             generated["check_args"] = json.loads(generated["check_args"])
@@ -522,8 +562,9 @@ async def generate_job_draft(
     # generation that produced no usable output (no JSON in the reply, or none of the
     # fields asked for). Rendering that as a 200 left the form silently empty and the
     # logs silent with it. A draft the model filled only partly is a different outcome
-    # and stays a success.
-    if not draft.model_dump(exclude_none=True):
+    # and stays a success. 422 rather than 503, as /generate-condition answers the same
+    # case: the service is up, and a retry-on-503 layer must not re-run a content miss.
+    if not draft.model_fields_set:
         logger.warning(
             "Draft generation produced nothing usable for query %r (model %s, %d candidate tools, raw keys %s)",
             data.query,
@@ -532,8 +573,8 @@ async def generate_job_draft(
             sorted(result),
         )
         raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="The model produced no usable draft — try again or rephrase the request.",
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="The model produced no usable draft — rephrase the request.",
         )
     return draft
 

--- a/packages/console-backend/console_backend/routers/scheduler_router.py
+++ b/packages/console-backend/console_backend/routers/scheduler_router.py
@@ -49,10 +49,19 @@ from ..services.llm_gateway import gateway_chat_json
 from ..services.scheduler_engine import SchedulerEngine
 from ..services.scheduler_service import _UNSET, SchedulerService
 from ..utils.timezones import resolve_timezone
+from .mcp_router import MCPTool, _list_mcp_tools, rank_mcp_tools
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/scheduler")
+
+#: How many tools the draft generator shows the model. The registry can hold hundreds
+#: of tools across dozens of servers — with every schema included that is on the order
+#: of a hundred thousand tokens for an answer of twenty lines, and the one name the
+#: model needs is buried in it (the reply came back unparseable, as a 200 of nulls).
+#: Fifteen leaves room for a query that matches a family of tools (list/get/search
+#: variants across servers) while keeping the prompt within a few thousand tokens.
+_DRAFT_TOOL_CANDIDATES = 15
 
 
 #: Why check_args must never carry a date: they are stored once and sent unchanged on
@@ -287,14 +296,45 @@ def _get_scheduler_service(request: Request) -> SchedulerService:
     return request.app.state.scheduler_service  # type: ignore[no-any-return]
 
 
+async def _candidate_tools(request: Request, user: User, query: str) -> list[MCPTool]:
+    """The tools worth offering the draft generator for `query`: the user's own catalogue,
+    ranked by the search endpoint's scorer, cut to `_DRAFT_TOOL_CANDIDATES`.
+
+    Read here rather than accepted from the caller for the same reason the sub-agents
+    and channels are: a generated job may only reference what this user can reach, and
+    the request body is not where that is decided.
+    """
+    try:
+        catalogue = await _list_mcp_tools(request, user)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.warning("Could not read the tool catalogue for draft generation: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Could not read the tool catalogue — try again shortly.",
+        ) from exc
+    candidates = rank_mcp_tools(catalogue.tools, query, _DRAFT_TOOL_CANDIDATES)
+    logger.info(
+        "Draft generation offers %d of %d tools for query %r: %s",
+        len(candidates),
+        len(catalogue.tools),
+        query,
+        [t.name for t in candidates],
+    )
+    return candidates
+
+
 @router.post(
     "/generate-job-draft",
     response_model=ScheduledJobDraft,
     summary="Draft a whole scheduled job from a one-line description.",
     description=(
-        "Given the available MCP tools and a natural-language request, returns a partial "
-        "ScheduledJobCreate: job type, schedule, check tool and arguments, condition, "
-        "outcome and delivery. Fields it cannot infer are omitted for the caller to fill in."
+        "Given a natural-language request, returns a partial ScheduledJobCreate: job type, "
+        "schedule, check tool and arguments, condition, outcome and delivery. The tools, "
+        "sub-agents and channels the draft may reference are the caller's own, read "
+        "server-side. Fields it cannot infer are omitted for the caller to fill in; a "
+        "generation that infers nothing at all is an error, not an empty draft."
     ),
 )
 async def generate_job_draft(
@@ -305,17 +345,17 @@ async def generate_job_draft(
 ) -> ScheduledJobDraft:
     """Generate a whole job from one sentence: type, schedule, tool, condition, outcome.
 
-    The sub-agents and delivery channels the model may choose from are read here rather
-    than accepted from the caller, so a generated job can only ever reference something
-    the user can already reach.
+    The tools, sub-agents and delivery channels the model may choose from are read here
+    rather than accepted from the caller, so a generated job can only ever reference
+    something the user can already reach. Tools are additionally ranked against the
+    request and cut to a handful — see `_DRAFT_TOOL_CANDIDATES`.
     """
+    candidate_tools = await _candidate_tools(request, current_user, data.query)
     tools_summary = json.dumps(
-        [
-            {"name": t.get("name"), "description": t.get("description"), "input_schema": t.get("input_schema")}
-            for t in data.tools
-        ],
+        [{"name": t.name, "description": t.description, "input_schema": t.input_schema} for t in candidate_tools],
         indent=2,
     )
+    allowed_tool_names = {t.name for t in candidate_tools}
     # Offer only what this user can reach: the model picks from these, and anything
     # outside the offered ids is discarded after the call.
     # The same set create_job validates against — offering anything wider produces a
@@ -465,13 +505,37 @@ async def generate_job_draft(
     generated["schedule_kind"] = _coerce_enum(ScheduleKind, result.get("schedule_kind"))
     generated["sub_agent_id"] = _coerce_id(result.get("sub_agent_id"), allowed_agent_ids)
     generated["delivery_channel_id"] = _coerce_id(result.get("delivery_channel_id"), allowed_channel_ids)
+    # A tool name outside the offered set is an invention — the model saw only the
+    # candidates — and would produce a job whose check fails on its first run.
+    check_tool = result.get("check_tool")
+    if check_tool is not None and check_tool not in allowed_tool_names:
+        logger.info("Discarding generated check_tool %r: not among the offered tools", check_tool)
+        generated["check_tool"] = None
     if isinstance(generated.get("check_args"), str):
         try:
             generated["check_args"] = json.loads(generated["check_args"])
         except json.JSONDecodeError:
             generated["check_args"] = None
 
-    return _build_draft(generated)
+    draft = _build_draft(generated)
+    # A draft with nothing in it is not "the request implied nothing" — it is a
+    # generation that produced no usable output (no JSON in the reply, or none of the
+    # fields asked for). Rendering that as a 200 left the form silently empty and the
+    # logs silent with it. A draft the model filled only partly is a different outcome
+    # and stays a success.
+    if not draft.model_dump(exclude_none=True):
+        logger.warning(
+            "Draft generation produced nothing usable for query %r (model %s, %d candidate tools, raw keys %s)",
+            data.query,
+            model,
+            len(candidate_tools),
+            sorted(result),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="The model produced no usable draft — try again or rephrase the request.",
+        )
+    return draft
 
 
 @router.post(

--- a/packages/console-backend/console_backend/services/llm_gateway.py
+++ b/packages/console-backend/console_backend/services/llm_gateway.py
@@ -183,7 +183,15 @@ async def gateway_chat_json(
         # knows why it is empty, so the shape of the reply is recorded here.
         logger.warning("No JSON object in the model's reply (%d chars) for model %s", len(text), model)
         return {}
-    parsed = json.loads(match.group())
+    try:
+        parsed = json.loads(match.group())
+    except json.JSONDecodeError as exc:
+        # The match is greedy, so prose holding two objects spans from the first `{`
+        # to the last `}` and is not JSON. Same contract as above: no object found.
+        logger.warning(
+            "Unparseable JSON in the model's reply (%d chars) for model %s: %s", len(text), model, exc
+        )
+        return {}
     return parsed if isinstance(parsed, dict) else {}
 
 

--- a/packages/console-backend/console_backend/services/llm_gateway.py
+++ b/packages/console-backend/console_backend/services/llm_gateway.py
@@ -179,6 +179,9 @@ async def gateway_chat_json(
     cleaned = re.sub(r"```(?:json)?\s*", "", text).strip().rstrip("`")
     match = re.search(r"\{.*\}", cleaned, re.DOTALL)
     if not match:
+        # The caller decides what an empty answer means; this is the only place that
+        # knows why it is empty, so the shape of the reply is recorded here.
+        logger.warning("No JSON object in the model's reply (%d chars) for model %s", len(text), model)
         return {}
     parsed = json.loads(match.group())
     return parsed if isinstance(parsed, dict) else {}

--- a/packages/console-backend/tests/test_generate_job_draft_endpoint.py
+++ b/packages/console-backend/tests/test_generate_job_draft_endpoint.py
@@ -115,16 +115,12 @@ class TestToolsAreSelectedServerSide:
         catalogue.assert_awaited_once()
         assert catalogue.await_args.args[1].id == "user-1"
 
-    def test_the_request_body_tools_are_ignored(self, draft_client, gateway, catalogue):
-        # An older UI still posts the field; a caller may also try to offer the model
-        # tools this user cannot reach. Neither makes it into the prompt.
-        gateway.return_value = {"job_type": "watch", "check_tool": "console_list_bug_reports"}
-        smuggled = [{"name": "admin_delete_everything", "description": "bug report", "input_schema": {}}]
+    def test_the_request_body_carries_no_tools(self):
+        # The body used to carry the whole catalogue, and with it the chance to offer
+        # the model tools this user cannot reach. The field is gone, not just ignored.
+        from console_backend.models.scheduled_job import GenerateJobDraftRequest
 
-        resp = draft_client.post(URL, json={"query": QUERY, "tools": smuggled})
-
-        assert resp.status_code == 200
-        assert "admin_delete_everything" not in _prompt(gateway)
+        assert set(GenerateJobDraftRequest.model_fields) == {"query"}
 
     def test_the_relevant_tool_is_offered_and_chosen(self, draft_client, gateway, catalogue):
         gateway.return_value = {

--- a/packages/console-backend/tests/test_generate_job_draft_endpoint.py
+++ b/packages/console-backend/tests/test_generate_job_draft_endpoint.py
@@ -7,6 +7,7 @@ model, and when that model then produced nothing parseable the endpoint returned
 request implied nothing".
 """
 
+import json
 import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -22,61 +23,62 @@ from console_backend.routers import scheduler_router
 from console_backend.routers.mcp_router import MCPTool, MCPToolsResponse, rank_mcp_tools
 
 QUERY = "notify me every time a new bug report is filed"
+URL = "/api/v1/scheduler/generate-job-draft"
 
 
 def _tool(name: str, description: str = "", server: str = "s") -> MCPTool:
     return MCPTool(
         name=name,
         description=description,
-        input_schema={
-            "type": "object",
-            "properties": {"created_after": {"type": "string"}},
-        },
+        input_schema={"type": "object", "properties": {"created_after": {"type": "string"}}},
         server=server,
     )
 
 
 #: A catalogue shaped like the real one: one relevant tool among many unrelated ones,
 #: more than the candidate cap in total.
-CATALOGUE = [
-    _tool(
-        "console_list_bug_reports",
-        "List bug reports filed in the console, newest first",
-    )
-] + [_tool(f"crm_get_account_{i}", "Read one CRM account") for i in range(30)]
+CATALOGUE = [_tool("console_list_bug_reports", "List bug reports filed in the console, newest first")] + [
+    _tool(f"crm_get_account_{i}", "Read one CRM account") for i in range(30)
+]
 
 
 @pytest.fixture
-def client():
+def draft_client():
+    """A sync TestClient over this router alone — named apart from conftest's async `client`."""
     app = FastAPI()
     app.include_router(scheduler_router.router)
-    app.dependency_overrides[scheduler_router.require_auth] = lambda: SimpleNamespace(
-        id="user-1", sub="sub-1"
-    )
+    app.dependency_overrides[scheduler_router.require_auth] = lambda: SimpleNamespace(id="user-1", sub="sub-1")
     app.dependency_overrides[get_db_session] = lambda: MagicMock()
 
     scheduler_service = MagicMock()
     scheduler_service.schedulable_sub_agents = AsyncMock(return_value=[])
     scheduler_service._resolve_timezone = AsyncMock(return_value="Europe/Zurich")
     app.state.scheduler_service = scheduler_service
-    app.state.delivery_channel_repository = MagicMock(
-        list_all_channels=AsyncMock(return_value=[])
-    )
+    app.state.delivery_channel_repository = MagicMock(list_all_channels=AsyncMock(return_value=[]))
     return TestClient(app)
 
 
 @pytest.fixture
-def gateway():
+def model_default():
+    with patch.object(
+        scheduler_router.ModelDefaultsRepository, "get_all", AsyncMock(return_value={"chat:low": "m"})
+    ):
+        yield
+
+
+@pytest.fixture
+def gateway(model_default):
     """The model's reply, as `gateway_chat_json` would parse it; records every prompt it saw."""
     mock = AsyncMock(return_value={})
-    with (
-        patch.object(scheduler_router, "gateway_chat_json", mock),
-        patch.object(
-            scheduler_router.ModelDefaultsRepository,
-            "get_all",
-            AsyncMock(return_value={"chat:low": "m"}),
-        ),
-    ):
+    with patch.object(scheduler_router, "gateway_chat_json", mock):
+        yield mock
+
+
+@pytest.fixture
+def raw_gateway(model_default):
+    """The model's reply as raw text — one level deeper, so the JSON salvage runs for real."""
+    mock = AsyncMock(return_value="")
+    with patch("console_backend.services.llm_gateway.gateway_chat", mock):
         yield mock
 
 
@@ -91,54 +93,40 @@ def _prompt(gateway: AsyncMock) -> str:
     return gateway.await_args_list[0].args[0]
 
 
-class TestToolsAreSelectedServerSide:
-    def test_the_prompt_carries_a_ranked_handful_not_the_registry(
-        self, client, gateway, catalogue
-    ):
-        gateway.return_value = {
-            "job_type": "watch",
-            "check_tool": "console_list_bug_reports",
-        }
+def _filled(resp) -> dict:
+    return {k: v for k, v in resp.json().items() if v is not None}
 
-        resp = client.post(
-            "/api/v1/scheduler/generate-job-draft", json={"query": QUERY}
-        )
+
+class TestToolsAreSelectedServerSide:
+    def test_the_prompt_carries_a_ranked_handful_not_the_registry(self, draft_client, gateway, catalogue):
+        gateway.return_value = {"job_type": "watch", "check_tool": "console_list_bug_reports"}
+
+        resp = draft_client.post(URL, json={"query": QUERY})
 
         assert resp.status_code == 200
         prompt = _prompt(gateway)
         assert "console_list_bug_reports" in prompt
         # The cap, not the catalogue size, bounds what the model sees.
-        offered = [t.name for t in CATALOGUE if f'"name": "{t.name}"' in prompt]
+        offered = [t.name for t in CATALOGUE if f'"name":"{t.name}"' in prompt]
+        assert offered, "tools are serialised compactly — the probe must match that shape"
         assert len(offered) <= scheduler_router._DRAFT_TOOL_CANDIDATES
         assert len(offered) < len(CATALOGUE)
         # The catalogue was read for this user, not taken from the body.
         catalogue.assert_awaited_once()
         assert catalogue.await_args.args[1].id == "user-1"
 
-    def test_the_request_body_tools_are_ignored(self, client, gateway, catalogue):
+    def test_the_request_body_tools_are_ignored(self, draft_client, gateway, catalogue):
         # An older UI still posts the field; a caller may also try to offer the model
         # tools this user cannot reach. Neither makes it into the prompt.
-        gateway.return_value = {
-            "job_type": "watch",
-            "check_tool": "console_list_bug_reports",
-        }
-        smuggled = [
-            {
-                "name": "admin_delete_everything",
-                "description": "bug report",
-                "input_schema": {},
-            }
-        ]
+        gateway.return_value = {"job_type": "watch", "check_tool": "console_list_bug_reports"}
+        smuggled = [{"name": "admin_delete_everything", "description": "bug report", "input_schema": {}}]
 
-        resp = client.post(
-            "/api/v1/scheduler/generate-job-draft",
-            json={"query": QUERY, "tools": smuggled},
-        )
+        resp = draft_client.post(URL, json={"query": QUERY, "tools": smuggled})
 
         assert resp.status_code == 200
         assert "admin_delete_everything" not in _prompt(gateway)
 
-    def test_the_relevant_tool_is_offered_and_chosen(self, client, gateway, catalogue):
+    def test_the_relevant_tool_is_offered_and_chosen(self, draft_client, gateway, catalogue):
         gateway.return_value = {
             "job_type": "watch",
             "name": "New bug reports",
@@ -146,85 +134,111 @@ class TestToolsAreSelectedServerSide:
             "destroy_after_trigger": False,
         }
 
-        resp = client.post(
-            "/api/v1/scheduler/generate-job-draft", json={"query": QUERY}
-        )
+        resp = draft_client.post(URL, json={"query": QUERY})
 
         assert resp.status_code == 200
         assert resp.json()["check_tool"] == "console_list_bug_reports"
         assert resp.json()["destroy_after_trigger"] is False
 
-    def test_a_tool_the_model_invented_is_discarded(self, client, gateway, catalogue):
-        # The model only saw the candidates, so a name outside them is a hallucination
-        # that would make the job fail on its first check.
+    def test_a_tool_the_model_invented_goes_with_its_arguments_and_condition(self, draft_client, gateway, catalogue):
+        # The model only saw the candidates, so a name outside them is a hallucination.
+        # Its arguments and condition were written against that tool: left in the draft
+        # they would be applied under whatever tool the user then picks by hand.
         gateway.return_value = {
             "job_type": "watch",
             "name": "Bugs",
             "check_tool": "github_list_issues",
+            "check_args": {"repo": "x"},
+            "check_args_exprs": {"since": "string(now)"},
+            "cel_expr": "size(result.issues) > 0",
+            "llm_condition": "looks like a bug",
         }
 
-        resp = client.post(
-            "/api/v1/scheduler/generate-job-draft", json={"query": QUERY}
-        )
+        resp = draft_client.post(URL, json={"query": QUERY})
+
+        assert resp.status_code == 200
+        assert _filled(resp) == {"job_type": "watch", "name": "Bugs"}
+
+    def test_a_non_string_tool_name_is_dropped_not_a_500(self, draft_client, gateway, catalogue):
+        # "The single best-matching tool" comes back as a list when several match.
+        gateway.return_value = {"job_type": "watch", "name": "Bugs", "check_tool": ["a", "b"]}
+
+        resp = draft_client.post(URL, json={"query": QUERY})
 
         assert resp.status_code == 200
         assert resp.json()["check_tool"] is None
-        assert resp.json()["name"] == "Bugs"
 
-    def test_an_unreadable_catalogue_is_an_error_not_a_toolless_prompt(
-        self, client, gateway
-    ):
-        with patch.object(
-            scheduler_router,
-            "_list_mcp_tools",
-            AsyncMock(side_effect=RuntimeError("gateway down")),
-        ):
-            resp = client.post(
-                "/api/v1/scheduler/generate-job-draft", json={"query": QUERY}
-            )
+    def test_an_unreadable_catalogue_is_an_error_not_a_toolless_prompt(self, draft_client, gateway):
+        with patch.object(scheduler_router, "_list_mcp_tools", AsyncMock(side_effect=RuntimeError("gateway down"))):
+            resp = draft_client.post(URL, json={"query": QUERY})
 
         assert resp.status_code == 503
         gateway.assert_not_awaited()
 
+    def test_an_empty_offer_is_logged_and_still_generates(self, draft_client, gateway, caplog):
+        # Under impersonation the catalogue is empty by design, and a request can share
+        # no vocabulary with any tool. A task job needs no tool, so the call still
+        # happens — but the operator can see why the draft came back without one.
+        gateway.return_value = {"job_type": "task", "name": "Digest"}
+        with patch.object(scheduler_router, "_list_mcp_tools", AsyncMock(return_value=MCPToolsResponse(tools=[]))):
+            with caplog.at_level("INFO"):
+                resp = draft_client.post(URL, json={"query": "send me a digest"})
+
+        assert resp.status_code == 200
+        assert any("offers no tools" in r.getMessage() for r in caplog.records)
+
 
 class TestAnEmptyGenerationFailsLoudly:
-    def test_no_json_in_the_reply_is_a_503(self, client, gateway, catalogue, caplog):
-        # `gateway_chat_json` answers {} when the reply holds no object; that used to
-        # flow through to a 200 with every field null.
-        gateway.return_value = {}
+    def test_no_json_in_the_reply_is_a_422(self, draft_client, raw_gateway, catalogue, caplog):
+        # A reply with no JSON object used to flow through as a 200 with every field
+        # null. Patched at the raw-text level so the salvage in gateway_chat_json runs.
+        raw_gateway.return_value = "I am not able to help with scheduling."
 
         with caplog.at_level("WARNING"):
-            resp = client.post(
-                "/api/v1/scheduler/generate-job-draft", json={"query": QUERY}
-            )
+            resp = draft_client.post(URL, json={"query": QUERY})
 
-        assert resp.status_code == 503
+        assert resp.status_code == 422
         assert "no usable draft" in resp.json()["detail"]
-        # Diagnosable next time: the query is in the log.
-        assert any(QUERY in record.getMessage() for record in caplog.records)
+        messages = [r.getMessage() for r in caplog.records]
+        # Diagnosable next time: the reply's shape from the gateway, the query from here.
+        assert any("No JSON object" in m for m in messages)
+        assert any(QUERY in m for m in messages)
 
-    def test_a_reply_with_no_known_field_is_a_503(self, client, gateway, catalogue):
+    def test_two_objects_in_prose_are_a_422_not_a_gateway_outage(self, draft_client, raw_gateway, catalogue, caplog):
+        # The greedy salvage spans from the first `{` to the last `}`; that is not JSON,
+        # and used to surface as "AI generation service unavailable".
+        raw_gateway.return_value = 'Either {"job_type": "watch"} or perhaps {"job_type": "task"}.'
+
+        with caplog.at_level("WARNING"):
+            resp = draft_client.post(URL, json={"query": QUERY})
+
+        assert resp.status_code == 422
+        assert any("Unparseable JSON" in r.getMessage() for r in caplog.records)
+
+    def test_a_reply_with_no_known_field_is_a_422(self, draft_client, gateway, catalogue):
         gateway.return_value = {"answer": "I cannot help with that"}
 
-        resp = client.post(
-            "/api/v1/scheduler/generate-job-draft", json={"query": QUERY}
-        )
+        resp = draft_client.post(URL, json={"query": QUERY})
 
-        assert resp.status_code == 503
+        assert resp.status_code == 422
 
-    def test_a_partial_draft_is_still_a_success(self, client, gateway, catalogue):
+    def test_a_partial_draft_is_still_a_success(self, draft_client, gateway, catalogue):
         # Inferring only some fields is the endpoint working as designed — the form
         # fills the rest — and must not be confused with inferring nothing.
         gateway.return_value = {"job_type": "task", "name": "Weekly digest"}
 
-        resp = client.post(
-            "/api/v1/scheduler/generate-job-draft",
-            json={"query": "send me a weekly digest"},
-        )
+        resp = draft_client.post(URL, json={"query": "send me a weekly digest"})
 
         assert resp.status_code == 200
-        body = {k: v for k, v in resp.json().items() if v is not None}
-        assert body == {"job_type": "task", "name": "Weekly digest"}
+        assert _filled(resp) == {"job_type": "task", "name": "Weekly digest"}
+
+    def test_a_valid_reply_survives_the_raw_path(self, draft_client, raw_gateway, catalogue):
+        raw_gateway.return_value = "```json\n" + json.dumps({"job_type": "watch", "name": "Bugs"}) + "\n```"
+
+        resp = draft_client.post(URL, json={"query": QUERY})
+
+        assert resp.status_code == 200
+        assert _filled(resp) == {"job_type": "watch", "name": "Bugs"}
 
 
 class TestRankMcpTools:
@@ -236,12 +250,7 @@ class TestRankMcpTools:
         assert len(ranked) <= 15
 
     def test_tools_that_match_nothing_are_left_out(self):
-        assert (
-            rank_mcp_tools(
-                [_tool("unrelated_tool", "nothing in common")], "bug report", 15
-            )
-            == []
-        )
+        assert rank_mcp_tools([_tool("unrelated_tool", "nothing in common")], "bug report", 15) == []
 
     def test_it_does_not_mutate_or_reorder_the_input(self):
         tools = [_tool("b_bug", "bug"), _tool("a_bug_report", "bug report")]

--- a/packages/console-backend/tests/test_generate_job_draft_endpoint.py
+++ b/packages/console-backend/tests/test_generate_job_draft_endpoint.py
@@ -1,0 +1,250 @@
+"""Endpoint tests for POST /api/v1/scheduler/generate-job-draft.
+
+Two defects motivated these, stacked on top of each other: the request body carried the
+whole tool catalogue (hundreds of tools, every schema) into a prompt answered by a small
+model, and when that model then produced nothing parseable the endpoint returned a
+`200` with every field null — indistinguishable, to the UI and in the logs, from "the
+request implied nothing".
+"""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("ECS_CONTAINER_METADATA_URI", "true")
+
+from console_backend.db.session import get_db_session
+from console_backend.routers import scheduler_router
+from console_backend.routers.mcp_router import MCPTool, MCPToolsResponse, rank_mcp_tools
+
+QUERY = "notify me every time a new bug report is filed"
+
+
+def _tool(name: str, description: str = "", server: str = "s") -> MCPTool:
+    return MCPTool(
+        name=name,
+        description=description,
+        input_schema={
+            "type": "object",
+            "properties": {"created_after": {"type": "string"}},
+        },
+        server=server,
+    )
+
+
+#: A catalogue shaped like the real one: one relevant tool among many unrelated ones,
+#: more than the candidate cap in total.
+CATALOGUE = [
+    _tool(
+        "console_list_bug_reports",
+        "List bug reports filed in the console, newest first",
+    )
+] + [_tool(f"crm_get_account_{i}", "Read one CRM account") for i in range(30)]
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(scheduler_router.router)
+    app.dependency_overrides[scheduler_router.require_auth] = lambda: SimpleNamespace(
+        id="user-1", sub="sub-1"
+    )
+    app.dependency_overrides[get_db_session] = lambda: MagicMock()
+
+    scheduler_service = MagicMock()
+    scheduler_service.schedulable_sub_agents = AsyncMock(return_value=[])
+    scheduler_service._resolve_timezone = AsyncMock(return_value="Europe/Zurich")
+    app.state.scheduler_service = scheduler_service
+    app.state.delivery_channel_repository = MagicMock(
+        list_all_channels=AsyncMock(return_value=[])
+    )
+    return TestClient(app)
+
+
+@pytest.fixture
+def gateway():
+    """The model's reply, as `gateway_chat_json` would parse it; records every prompt it saw."""
+    mock = AsyncMock(return_value={})
+    with (
+        patch.object(scheduler_router, "gateway_chat_json", mock),
+        patch.object(
+            scheduler_router.ModelDefaultsRepository,
+            "get_all",
+            AsyncMock(return_value={"chat:low": "m"}),
+        ),
+    ):
+        yield mock
+
+
+@pytest.fixture
+def catalogue():
+    mock = AsyncMock(return_value=MCPToolsResponse(tools=CATALOGUE))
+    with patch.object(scheduler_router, "_list_mcp_tools", mock):
+        yield mock
+
+
+def _prompt(gateway: AsyncMock) -> str:
+    return gateway.await_args_list[0].args[0]
+
+
+class TestToolsAreSelectedServerSide:
+    def test_the_prompt_carries_a_ranked_handful_not_the_registry(
+        self, client, gateway, catalogue
+    ):
+        gateway.return_value = {
+            "job_type": "watch",
+            "check_tool": "console_list_bug_reports",
+        }
+
+        resp = client.post(
+            "/api/v1/scheduler/generate-job-draft", json={"query": QUERY}
+        )
+
+        assert resp.status_code == 200
+        prompt = _prompt(gateway)
+        assert "console_list_bug_reports" in prompt
+        # The cap, not the catalogue size, bounds what the model sees.
+        offered = [t.name for t in CATALOGUE if f'"name": "{t.name}"' in prompt]
+        assert len(offered) <= scheduler_router._DRAFT_TOOL_CANDIDATES
+        assert len(offered) < len(CATALOGUE)
+        # The catalogue was read for this user, not taken from the body.
+        catalogue.assert_awaited_once()
+        assert catalogue.await_args.args[1].id == "user-1"
+
+    def test_the_request_body_tools_are_ignored(self, client, gateway, catalogue):
+        # An older UI still posts the field; a caller may also try to offer the model
+        # tools this user cannot reach. Neither makes it into the prompt.
+        gateway.return_value = {
+            "job_type": "watch",
+            "check_tool": "console_list_bug_reports",
+        }
+        smuggled = [
+            {
+                "name": "admin_delete_everything",
+                "description": "bug report",
+                "input_schema": {},
+            }
+        ]
+
+        resp = client.post(
+            "/api/v1/scheduler/generate-job-draft",
+            json={"query": QUERY, "tools": smuggled},
+        )
+
+        assert resp.status_code == 200
+        assert "admin_delete_everything" not in _prompt(gateway)
+
+    def test_the_relevant_tool_is_offered_and_chosen(self, client, gateway, catalogue):
+        gateway.return_value = {
+            "job_type": "watch",
+            "name": "New bug reports",
+            "check_tool": "console_list_bug_reports",
+            "destroy_after_trigger": False,
+        }
+
+        resp = client.post(
+            "/api/v1/scheduler/generate-job-draft", json={"query": QUERY}
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["check_tool"] == "console_list_bug_reports"
+        assert resp.json()["destroy_after_trigger"] is False
+
+    def test_a_tool_the_model_invented_is_discarded(self, client, gateway, catalogue):
+        # The model only saw the candidates, so a name outside them is a hallucination
+        # that would make the job fail on its first check.
+        gateway.return_value = {
+            "job_type": "watch",
+            "name": "Bugs",
+            "check_tool": "github_list_issues",
+        }
+
+        resp = client.post(
+            "/api/v1/scheduler/generate-job-draft", json={"query": QUERY}
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["check_tool"] is None
+        assert resp.json()["name"] == "Bugs"
+
+    def test_an_unreadable_catalogue_is_an_error_not_a_toolless_prompt(
+        self, client, gateway
+    ):
+        with patch.object(
+            scheduler_router,
+            "_list_mcp_tools",
+            AsyncMock(side_effect=RuntimeError("gateway down")),
+        ):
+            resp = client.post(
+                "/api/v1/scheduler/generate-job-draft", json={"query": QUERY}
+            )
+
+        assert resp.status_code == 503
+        gateway.assert_not_awaited()
+
+
+class TestAnEmptyGenerationFailsLoudly:
+    def test_no_json_in_the_reply_is_a_503(self, client, gateway, catalogue, caplog):
+        # `gateway_chat_json` answers {} when the reply holds no object; that used to
+        # flow through to a 200 with every field null.
+        gateway.return_value = {}
+
+        with caplog.at_level("WARNING"):
+            resp = client.post(
+                "/api/v1/scheduler/generate-job-draft", json={"query": QUERY}
+            )
+
+        assert resp.status_code == 503
+        assert "no usable draft" in resp.json()["detail"]
+        # Diagnosable next time: the query is in the log.
+        assert any(QUERY in record.getMessage() for record in caplog.records)
+
+    def test_a_reply_with_no_known_field_is_a_503(self, client, gateway, catalogue):
+        gateway.return_value = {"answer": "I cannot help with that"}
+
+        resp = client.post(
+            "/api/v1/scheduler/generate-job-draft", json={"query": QUERY}
+        )
+
+        assert resp.status_code == 503
+
+    def test_a_partial_draft_is_still_a_success(self, client, gateway, catalogue):
+        # Inferring only some fields is the endpoint working as designed — the form
+        # fills the rest — and must not be confused with inferring nothing.
+        gateway.return_value = {"job_type": "task", "name": "Weekly digest"}
+
+        resp = client.post(
+            "/api/v1/scheduler/generate-job-draft",
+            json={"query": "send me a weekly digest"},
+        )
+
+        assert resp.status_code == 200
+        body = {k: v for k, v in resp.json().items() if v is not None}
+        assert body == {"job_type": "task", "name": "Weekly digest"}
+
+
+class TestRankMcpTools:
+    """The scorer shared with /mcp/tools/search, used here as the candidate picker."""
+
+    def test_the_best_match_comes_first_and_the_cap_holds(self):
+        ranked = rank_mcp_tools(CATALOGUE, QUERY, 15)
+        assert ranked[0].name == "console_list_bug_reports"
+        assert len(ranked) <= 15
+
+    def test_tools_that_match_nothing_are_left_out(self):
+        assert (
+            rank_mcp_tools(
+                [_tool("unrelated_tool", "nothing in common")], "bug report", 15
+            )
+            == []
+        )
+
+    def test_it_does_not_mutate_or_reorder_the_input(self):
+        tools = [_tool("b_bug", "bug"), _tool("a_bug_report", "bug report")]
+        before = [t.name for t in tools]
+        rank_mcp_tools(tools, "bug report", 15)
+        assert [t.name for t in tools] == before

--- a/packages/console-frontend/src/api/generated/@tanstack/react-query.gen.ts
+++ b/packages/console-frontend/src/api/generated/@tanstack/react-query.gen.ts
@@ -3493,7 +3493,7 @@ export const markAllNotificationsAsReadApiV1NotificationsMarkAllReadPutMutation 
 /**
  * Draft a whole scheduled job from a one-line description.
  *
- * Given the available MCP tools and a natural-language request, returns a partial ScheduledJobCreate: job type, schedule, check tool and arguments, condition, outcome and delivery. Fields it cannot infer are omitted for the caller to fill in.
+ * Given a natural-language request, returns a partial ScheduledJobCreate: job type, schedule, check tool and arguments, condition, outcome and delivery. The tools, sub-agents and channels the draft may reference are the caller's own, read server-side. Fields it cannot infer are omitted for the caller to fill in; a generation that infers nothing at all is an error, not an empty draft.
  */
 export const generateJobDraftApiV1SchedulerGenerateJobDraftPostMutation = (options?: Partial<Options<GenerateJobDraftApiV1SchedulerGenerateJobDraftPostData>>): UseMutationOptions<GenerateJobDraftApiV1SchedulerGenerateJobDraftPostResponse, GenerateJobDraftApiV1SchedulerGenerateJobDraftPostError, Options<GenerateJobDraftApiV1SchedulerGenerateJobDraftPostData>> => {
     const mutationOptions: UseMutationOptions<GenerateJobDraftApiV1SchedulerGenerateJobDraftPostResponse, GenerateJobDraftApiV1SchedulerGenerateJobDraftPostError, Options<GenerateJobDraftApiV1SchedulerGenerateJobDraftPostData>> = {

--- a/packages/console-frontend/src/api/generated/sdk.gen.ts
+++ b/packages/console-frontend/src/api/generated/sdk.gen.ts
@@ -1860,7 +1860,7 @@ export const markAllNotificationsAsReadApiV1NotificationsMarkAllReadPut = <Throw
 /**
  * Draft a whole scheduled job from a one-line description.
  *
- * Given the available MCP tools and a natural-language request, returns a partial ScheduledJobCreate: job type, schedule, check tool and arguments, condition, outcome and delivery. Fields it cannot infer are omitted for the caller to fill in.
+ * Given a natural-language request, returns a partial ScheduledJobCreate: job type, schedule, check tool and arguments, condition, outcome and delivery. The tools, sub-agents and channels the draft may reference are the caller's own, read server-side. Fields it cannot infer are omitted for the caller to fill in; a generation that infers nothing at all is an error, not an empty draft.
  */
 export const generateJobDraftApiV1SchedulerGenerateJobDraftPost = <ThrowOnError extends boolean = false>(options: Options<GenerateJobDraftApiV1SchedulerGenerateJobDraftPostData, ThrowOnError>) => (options.client ?? client).post<GenerateJobDraftApiV1SchedulerGenerateJobDraftPostResponses, GenerateJobDraftApiV1SchedulerGenerateJobDraftPostErrors, ThrowOnError>({
     url: '/api/v1/scheduler/generate-job-draft',

--- a/packages/console-frontend/src/api/generated/types.gen.ts
+++ b/packages/console-frontend/src/api/generated/types.gen.ts
@@ -2025,9 +2025,11 @@ export type GenerateJobDraftRequest = {
     /**
      * Tools
      *
-     * List of available MCP tool objects (name, description, input_schema.)
+     * Ignored. The candidate tools are selected server-side from the caller's own catalogue; the field is kept so an older UI can still post to this endpoint.
+     *
+     * @deprecated
      */
-    tools: Array<{
+    tools?: Array<{
         [key: string]: unknown;
     }>;
     /**

--- a/packages/console-frontend/src/api/generated/types.gen.ts
+++ b/packages/console-frontend/src/api/generated/types.gen.ts
@@ -2020,18 +2020,11 @@ export type GenerateConditionResponse = {
  * GenerateJobDraftRequest
  *
  * Request body for generating a scheduled job from a one-line description.
+ *
+ * Only the request itself: the tools, sub-agents and channels the draft may reference
+ * are the caller's own and are read server-side, never accepted from the body.
  */
 export type GenerateJobDraftRequest = {
-    /**
-     * Tools
-     *
-     * Ignored. The candidate tools are selected server-side from the caller's own catalogue; the field is kept so an older UI can still post to this endpoint.
-     *
-     * @deprecated
-     */
-    tools?: Array<{
-        [key: string]: unknown;
-    }>;
     /**
      * Query
      *

--- a/packages/console-frontend/src/api/scheduler.ts
+++ b/packages/console-frontend/src/api/scheduler.ts
@@ -159,14 +159,13 @@ export type { ScheduledJobDraft } from './generated/types.gen';
 /**
  * Draft a whole scheduled job from a one-line description: job type, schedule, check
  * tool and arguments, condition, outcome and delivery. Fields the generator cannot infer
- * are omitted for the form to fill in.
+ * are omitted for the form to fill in. The tools the draft may pick from are the user's
+ * own catalogue, ranked against the query on the backend — nothing is posted from here.
+ * A generation that infers nothing at all is an error, not an empty draft.
  */
-export async function generateJobDraft(
-  tools: Record<string, unknown>[],
-  query: string,
-): Promise<ScheduledJobDraft> {
+export async function generateJobDraft(query: string): Promise<ScheduledJobDraft> {
   const { data, error } = await generateJobDraftApiV1SchedulerGenerateJobDraftPost({
-    body: { tools, query },
+    body: { query },
   });
   if (error) throw error;
   return data as ScheduledJobDraft;

--- a/packages/console-frontend/src/pages/SchedulerJobDetailPage.tsx
+++ b/packages/console-frontend/src/pages/SchedulerJobDetailPage.tsx
@@ -388,7 +388,7 @@ function EditForm({ job }: { job: ScheduledJob }) {
     setAiLoading(true);
     setError(null);
     try {
-      const draft = await generateJobDraft(mcpTools as unknown as Record<string, unknown>[], aiQuery);
+      const draft = await generateJobDraft(aiQuery);
       setWatch((w) => {
         const next = { ...w };
         if (draft.check_tool) next.check_tool = draft.check_tool;
@@ -707,7 +707,7 @@ function EditForm({ job }: { job: ScheduledJob }) {
                     />
                     <Button
                       type="button"
-                      disabled={!aiQuery.trim() || aiLoading || mcpTools.length === 0}
+                      disabled={!aiQuery.trim() || aiLoading}
                       onClick={handleAiGenerate}
                     >
                       {aiLoading ? <Loader2 className="size-4 animate-spin" /> : 'Generate'}

--- a/packages/console-frontend/src/pages/SchedulerPage.tsx
+++ b/packages/console-frontend/src/pages/SchedulerPage.tsx
@@ -323,10 +323,7 @@ function CreateJobDialog({
     setAiLoading(true);
     setError(null);
     try {
-      const result = await generateJobDraft(
-        mcpTools as unknown as Record<string, unknown>[],
-        aiQuery,
-      );
+      const result = await generateJobDraft(aiQuery);
       const filled = new Set<string>();
       setAiUndo(form);
       setForm((f) => {
@@ -594,7 +591,7 @@ function CreateJobDialog({
                 />
                 <Button
                   type="button"
-                  disabled={!aiQuery.trim() || aiLoading || mcpTools.length === 0}
+                  disabled={!aiQuery.trim() || aiLoading}
                   onClick={handleAiGenerate}
                 >
                   {aiLoading ? <Loader2 className="size-4 animate-spin" /> : 'Generate'}

--- a/packages/console-frontend/src/pages/SchedulerPage.tsx
+++ b/packages/console-frontend/src/pages/SchedulerPage.tsx
@@ -53,6 +53,7 @@ import {
   type ScheduleKind,
   type ScheduledJobCreateExtended,
   getDeliveryChannels,
+  formatApiError,
   generateJobDraft,
   createScheduledJob,
   type DeliveryChannel,
@@ -415,8 +416,10 @@ function CreateJobDialog({
       });
       setAiFilled(filled);
       setFieldErrors({});
-    } catch {
-      setError('AI generation failed. Please fill in the fields manually.');
+    } catch (e) {
+      // The backend's detail says which remedy applies — rephrase, retry later, or
+      // have an admin configure a model — so it is shown rather than swallowed.
+      setError(`AI generation failed: ${formatApiError(e)}. Please fill in the fields manually.`);
     } finally {
       setAiLoading(false);
     }


### PR DESCRIPTION
closes ringier-data/nannos#200

## What

`POST /api/v1/scheduler/generate-job-draft` answered `200 OK` with every field `null` for a request as ordinary as *"notify me every time a new bug report is filed"*. Two defects, stacked (see the issue):

1. **The prompt carried the whole tool catalogue.** The UI posted every MCP tool with its full `input_schema`; the endpoint serialised all of it into a `chat:low` prompt. The one tool name the model needed was buried in ~100k tokens of schema and the reply came back unparseable. Tools were also the only offer that came from the request body, unlike sub-agents and channels which are read server-side so a draft can only reference what the user can reach.
2. **An empty generation was rendered as a successful draft.** `gateway_chat_json` returns `{}` when it finds no JSON object, by contract; the draft path had no fallback, so `{}` became `ScheduledJobDraft()` and a total failure was reported as success with nothing in the logs.

## How

**Backend** (`console-backend`)
- The scorer behind `/mcp/tools/search` is extracted into a pure `rank_mcp_tools(tools, query, top_k)`; the search endpoint calls it unchanged.
- `generate_job_draft` reads the user's own catalogue via `_list_mcp_tools`, ranks it against the query and offers the top `_DRAFT_TOOL_CANDIDATES = 15` with schemas. A `check_tool` outside the offered set is discarded, like an unreachable sub-agent id. An unreadable catalogue is a 503, not a tool-less prompt.
- A draft with nothing in it is a **422** (`"The model produced no usable draft — rephrase the request."`) with the query, model, candidate count and raw reply keys logged; `gateway_chat_json` now also logs (and returns `{}`) when it finds no object or an unparseable one. A partly-filled draft stays a 200.
  - ⚠️ **Deviation from the issue:** #200 proposed 503. Review round 1 pointed out that `generate-condition` answers the identical case with 422 and that a retry-on-503 layer would re-run a deterministic content miss, so this PR uses 422. Easy to flip back if 503 is preferred.
- An invented `check_tool` is discarded together with its `check_args`/`check_args_exprs`/`cel_expr`/`llm_condition`; a non-string `check_tool` is dropped rather than 500ing.
- `GenerateJobDraftRequest.tools` is removed. Backend and frontend ship as one console package, so there is no older UI to keep compatible.

**Frontend** (`console-frontend`)
- `generateJobDraft(query)` no longer posts the catalogue; the Generate button no longer waits for the catalogue to load. The create dialog now shows the backend error detail instead of a generic message. The full tool list is still fetched for the form's tool picker, as before.
- SDK regenerated from the exported OpenAPI spec (only the request type and endpoint description changed).

## Verification

- New `tests/test_generate_job_draft_endpoint.py` (15 tests): a bounded, ranked handful in the prompt; the request body carries only `query`; the bug-report query offers and accepts `console_list_bug_reports`; invented tool discarded; unreadable catalogue → 503; no-JSON, two-objects-in-prose and unknown-fields replies → 422 with the query logged (patched at the raw-text level so the salvage runs); partial draft → 200; `rank_mcp_tools` ordering/cap/purity.
- console-backend full suite: 1709 passed. `ruff check` clean on touched files.
- console-frontend: `tsc -b` and `eslint` clean.
- Not verified against a live model: the acceptance criterion "the bug-report request produces a watch on `console_list_bug_reports`" is covered at the ranking level (that tool ranks first for the query against a 31-tool catalogue) and by the endpoint accepting it; a manual run against a real deployment is worth doing before closing.

## Checklist
- [x] I have performed a self-review of my code
- [x] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨 — The `tools` request field is removed from `generate-job-draft`. Frontend and backend deploy together as the console, so no consumer is left behind.

