### PR TITLE
fix(scheduler): stop the model's reasoning from eating the draft's output budget

### DIFF
--- a/packages/console-backend/console_backend/routers/scheduler_router.py
+++ b/packages/console-backend/console_backend/routers/scheduler_router.py
@@ -45,7 +45,7 @@ from ..services.cel_condition import (
     evaluate_arg_exprs,
     validate_cel_expression,
 )
-from ..services.llm_gateway import gateway_chat_json
+from ..services.llm_gateway import GatewayReplyTruncated, gateway_chat_json
 from ..services.scheduler_engine import SchedulerEngine
 from ..services.scheduler_service import _UNSET, SchedulerService
 from ..utils.timezones import resolve_timezone
@@ -117,6 +117,17 @@ _EXPRESSION_RULES = (
     "Every watch needs cel_expr, llm_condition, or both.\n\n"
 )
 
+
+#: Thinking off for the draft and condition generators. Both are mechanical JSON-filling
+#: from a prompt that already states the rules, and reasoning tokens count against
+#: `max_tokens`: on the low tier a reasoning model spent 979 of a 1024 budget thinking
+#: and was cut off 41 tokens into the answer, which read as "no usable draft". The proxy
+#: drops the parameter for models that have no such control.
+_GENERATION_REASONING = "none"
+
+#: What the person sees when the model's reply hit the output budget. Not a request to
+#: rephrase — the request was fine.
+_TRUNCATED_DETAIL = "The model's reply was cut off before it finished — try again."
 
 #: How many times a generated expression that fails to compile or evaluate is sent
 #: back with its error. Two is deliberate: the first retry fixes most syntax slips,
@@ -491,10 +502,13 @@ async def generate_job_draft(
             model=model,
             max_tokens=1024,
             metadata={"user_sub": current_user.sub},  # OIDC subject — the gateway/proxy attributes by sub, not internal id
+            reasoning_effort=_GENERATION_REASONING,
         )
 
     try:
         result = await _generate(prompt)
+    except GatewayReplyTruncated as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=_TRUNCATED_DETAIL) from exc
     except Exception as exc:
         logger.warning("Watch-param generation via gateway failed: %s", exc)
         raise HTTPException(
@@ -646,6 +660,7 @@ async def generate_condition(
             model=model,
             max_tokens=1024,
             metadata={"user_sub": current_user.sub},
+            reasoning_effort=_GENERATION_REASONING,
         )
 
     notes: list[str] = []
@@ -656,6 +671,8 @@ async def generate_condition(
     for _ in range(1 + _GENERATE_CONDITION_RETRIES):
         try:
             candidate = await _generate(instruction)
+        except GatewayReplyTruncated as exc:
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=_TRUNCATED_DETAIL) from exc
         except Exception as exc:
             logger.warning("Condition generation via gateway failed: %s", exc)
             raise HTTPException(

--- a/packages/console-backend/console_backend/services/llm_gateway.py
+++ b/packages/console-backend/console_backend/services/llm_gateway.py
@@ -48,9 +48,9 @@ def _completions_url() -> str:
     return f"{config.model_gateway.url.rstrip('/')}/v1/chat/completions"
 
 
-def _first_message(resp_json: dict) -> dict:
-    """The first choice's ``message`` from an OpenAI-shaped completion, or ``{}`` when the
-    provider returned no choices.
+def _first_choice(resp_json: dict) -> dict:
+    """The first ``choice`` of an OpenAI-shaped completion, or ``{}`` when the provider
+    returned no choices.
 
     A 2xx with ``choices: []`` is a *successful* response with no output (content-filter block,
     moderation refusal, a provider error the gateway mapped to 200) — not a transport failure,
@@ -58,7 +58,38 @@ def _first_message(resp_json: dict) -> dict:
     empty-output handling instead of raising IndexError on ``choices[0]``.
     """
     choices = resp_json.get("choices") or []
-    return choices[0].get("message", {}) if choices else {}
+    return choices[0] if choices else {}
+
+
+def _first_message(resp_json: dict) -> dict:
+    """The first choice's ``message``, or ``{}`` — see `_first_choice`."""
+    return _first_choice(resp_json).get("message", {})
+
+
+class GatewayText(str):
+    """The assistant text of a completion, carrying the provider's ``finish_reason``.
+
+    A plain ``str`` to every caller — the utility paths do string work on it and tests
+    stub it with literals — but a reply that was cut off (``finish_reason == "length"``)
+    reads exactly like one that simply said little, and only the finish reason tells the
+    two apart. That was the difference between "the model answered nothing usable" and
+    "the model ran out of output budget mid-object" going unlogged for a month.
+    """
+
+    finish_reason: str | None
+
+    def __new__(cls, content: str, finish_reason: str | None = None) -> "GatewayText":
+        text = super().__new__(cls, content)
+        text.finish_reason = finish_reason
+        return text
+
+
+class GatewayReplyTruncated(RuntimeError):
+    """The model's reply hit ``max_tokens`` before it finished, so there is no object to read.
+
+    Distinct from "no object found" because the remedy is different: the request was fine,
+    the output budget was not — typically because a reasoning model spent it thinking.
+    """
 
 
 async def gateway_registered_aliases(timeout: float = 10.0) -> set[str] | None:
@@ -149,9 +180,10 @@ async def gateway_chat(
     # *successful* response with no text, not a transport failure. Return "" so callers'
     # str ops (re.sub/.strip) don't crash; they treat empty as "no usable output" and
     # apply their own fallback, distinct from the gateway error path (which raises above).
-    # _first_message tolerates an empty choices array the same way (returns {} → "").
-    content = _first_message(resp.json()).get("content")
-    return content or ""
+    # _first_choice tolerates an empty choices array the same way (returns {} → "").
+    choice = _first_choice(resp.json())
+    content = choice.get("message", {}).get("content")
+    return GatewayText(content or "", finish_reason=choice.get("finish_reason"))
 
 
 async def gateway_chat_json(
@@ -160,6 +192,7 @@ async def gateway_chat_json(
     model: str,
     max_tokens: int = 1024,
     metadata: dict | None = None,
+    reasoning_effort: str | None = None,
     timeout: float = 60.0,
 ) -> dict[str, Any]:
     """`gateway_chat`, for the common case of asking for a single JSON object.
@@ -171,28 +204,58 @@ async def gateway_chat_json(
     would let one path succeed while another silently read `{}`.
 
     Returns `{}` when there is no object to be found, which every caller already treats as
-    "no usable output" and answers with its own fallback.
+    "no usable output" and answers with its own fallback. Raises `GatewayReplyTruncated`
+    instead when the reason there is no object is that the reply hit `max_tokens` — a
+    reasoning model on a small budget spends it thinking and is stopped a few tokens into
+    the answer, which is a budget problem, not a content miss, and callers word it
+    differently. Pass ``reasoning_effort="none"`` for mechanical JSON-filling so that
+    budget goes to the answer.
     """
     text = await gateway_chat(
-        prompt, model=model, max_tokens=max_tokens, metadata=metadata, timeout=timeout
+        prompt,
+        model=model,
+        max_tokens=max_tokens,
+        metadata=metadata,
+        reasoning_effort=reasoning_effort,
+        timeout=timeout,
     )
+    # Tests stub gateway_chat with plain strings; a plain str simply has no finish reason.
+    finish_reason = getattr(text, "finish_reason", None)
     cleaned = re.sub(r"```(?:json)?\s*", "", text).strip().rstrip("`")
     match = re.search(r"\{.*\}", cleaned, re.DOTALL)
-    if not match:
-        # The caller decides what an empty answer means; this is the only place that
-        # knows why it is empty, so the shape of the reply is recorded here.
-        logger.warning("No JSON object in the model's reply (%d chars) for model %s", len(text), model)
-        return {}
-    try:
-        parsed = json.loads(match.group())
-    except json.JSONDecodeError as exc:
-        # The match is greedy, so prose holding two objects spans from the first `{`
-        # to the last `}` and is not JSON. Same contract as above: no object found.
-        logger.warning(
-            "Unparseable JSON in the model's reply (%d chars) for model %s: %s", len(text), model, exc
+    if match:
+        try:
+            parsed = json.loads(match.group())
+        except json.JSONDecodeError as exc:
+            # The match is greedy, so prose holding two objects spans from the first `{`
+            # to the last `}` and is not JSON. Same contract as below: no object found.
+            problem = f"unparseable JSON ({exc})"
+        else:
+            return parsed if isinstance(parsed, dict) else {}
+    else:
+        problem = "no JSON object"
+    # The caller decides what an empty answer means; this is the only place that knows
+    # why it is empty, so the reply's shape — finish reason and how it starts — is
+    # recorded here. The snippet is what makes the next occurrence diagnosable without
+    # reproducing the call.
+    logger.warning(
+        "%s in the model's reply for model %s (finish_reason=%s, %d chars): %r",
+        problem[0].upper() + problem[1:],
+        model,
+        finish_reason,
+        len(text),
+        text[:_REPLY_SNIPPET_CHARS],
+    )
+    if finish_reason == "length":
+        raise GatewayReplyTruncated(
+            f"The reply from {model} was cut off at max_tokens={max_tokens} before it finished"
         )
-        return {}
-    return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+#: How much of an unusable reply goes into the log. Enough to see what the model was
+#: doing (prose, a refusal, the opening of an object) without logging the whole thing.
+_REPLY_SNIPPET_CHARS = 200
 
 
 def _extract_citations(resp_json: dict) -> list[dict]:

--- a/packages/console-backend/console_backend/services/mcp_tool_client.py
+++ b/packages/console-backend/console_backend/services/mcp_tool_client.py
@@ -50,7 +50,7 @@ def _console_mcp_url() -> str:
     Deliberately loopback rather than a configured public URL: the call must reach *this*
     instance, and it has no business leaving the pod to do it.
     """
-    return f"http://127.0.0.1:{os.getenv('API_PORT', '5001')}/mcp"
+    return f"http://127.0.0.1:{os.getenv('API_PORT', '5001')}/mcp/"
 
 
 async def token_for(tool_name: str, user_access_token: str) -> str:
@@ -221,6 +221,7 @@ async def call_tool(
                 "params": {"name": tool_name, "arguments": arguments or {}},
             },
             timeout=timeout,
+            # follow_redirects=True,
         )
         response.raise_for_status()
         data = parse_envelope(response, expect_id=_CALL_ID)

--- a/packages/console-backend/console_backend/services/mcp_tool_client.py
+++ b/packages/console-backend/console_backend/services/mcp_tool_client.py
@@ -221,7 +221,6 @@ async def call_tool(
                 "params": {"name": tool_name, "arguments": arguments or {}},
             },
             timeout=timeout,
-            # follow_redirects=True,
         )
         response.raise_for_status()
         data = parse_envelope(response, expect_id=_CALL_ID)

--- a/packages/console-backend/console_backend/services/scheduler_engine.py
+++ b/packages/console-backend/console_backend/services/scheduler_engine.py
@@ -453,7 +453,10 @@ class SchedulerEngine:
             f"Result:\n{json.dumps(check_result, indent=2, default=str)[:6000]}"
         )
         try:
-            message = await gateway_chat(prompt, model=model, max_tokens=256)
+            # Thinking off: two sentences of plain text need no reasoning, and on the low
+            # tier a reasoning model spends the budget thinking and is cut off mid-sentence
+            # — which would then be sent to the person verbatim.
+            message = await gateway_chat(prompt, model=model, max_tokens=256, reasoning_effort="none")
             written = message.strip().strip('"')
             if written:
                 logger.info("Job %d: wrote notification %r", job.id, written[:100])

--- a/packages/console-backend/tests/test_generate_condition.py
+++ b/packages/console-backend/tests/test_generate_condition.py
@@ -177,3 +177,21 @@ class TestGenerateCondition:
                 GenerateConditionRequest(query="x"), AsyncMock(), _user()
             )
         assert exc.value.status_code == 503
+
+
+class TestReasoningBudget:
+    """The generator turns thinking off and names a cut-off reply for what it is."""
+
+    @pytest.mark.asyncio
+    async def test_thinking_is_off(self, monkeypatch):
+        _, chat = await _call(monkeypatch, ['{"cel_expr": "%s"}' % GOOD], query="q", result=PAYLOAD)
+        assert chat.await_args.kwargs["reasoning_effort"] == "none"
+
+    @pytest.mark.asyncio
+    async def test_a_truncated_reply_is_a_422_that_says_so(self, monkeypatch):
+        from console_backend.services.llm_gateway import GatewayText
+
+        with pytest.raises(HTTPException) as exc:
+            await _call(monkeypatch, [GatewayText('{"cel_expr": "resu', finish_reason="length")], query="q", result=PAYLOAD)
+        assert exc.value.status_code == 422
+        assert "cut off" in exc.value.detail

--- a/packages/console-backend/tests/test_generate_job_draft_endpoint.py
+++ b/packages/console-backend/tests/test_generate_job_draft_endpoint.py
@@ -184,6 +184,37 @@ class TestToolsAreSelectedServerSide:
         assert any("offers no tools" in r.getMessage() for r in caplog.records)
 
 
+class TestReasoningBudget:
+    """Why the bug-report request still failed after the catalogue was trimmed.
+
+    The low tier resolved to a reasoning model; reasoning tokens count against
+    `max_tokens=1024`, so it spent 979 of them thinking and was stopped 41 tokens into
+    the JSON. The salvage found no object and the person was told to rephrase.
+    """
+
+    def test_thinking_is_off_for_draft_generation(self, draft_client, raw_gateway, catalogue):
+        raw_gateway.return_value = '{"job_type": "watch", "check_tool": "console_list_bug_reports"}'
+
+        resp = draft_client.post(URL, json={"query": QUERY})
+
+        assert resp.status_code == 200
+        assert raw_gateway.await_args.kwargs["reasoning_effort"] == "none"
+
+    def test_a_reply_cut_off_by_the_budget_is_reported_as_such(self, draft_client, raw_gateway, catalogue, caplog):
+        from console_backend.services.llm_gateway import GatewayText
+
+        raw_gateway.return_value = GatewayText('{\n  "job_type": "watch",\n  "name": "New Bug Report Watcher",\n  "sch', "length")
+
+        with caplog.at_level("WARNING"):
+            resp = draft_client.post(URL, json={"query": QUERY})
+
+        assert resp.status_code == 422
+        assert "cut off" in resp.json()["detail"]
+        assert "rephrase" not in resp.json()["detail"]
+        message = next(r.getMessage() for r in caplog.records if "finish_reason=length" in r.getMessage())
+        assert "New Bug Report Watcher" in message
+
+
 class TestAnEmptyGenerationFailsLoudly:
     def test_no_json_in_the_reply_is_a_422(self, draft_client, raw_gateway, catalogue, caplog):
         # A reply with no JSON object used to flow through as a 200 with every field

--- a/packages/console-backend/tests/test_llm_gateway.py
+++ b/packages/console-backend/tests/test_llm_gateway.py
@@ -42,3 +42,66 @@ class TestGatewayChatPayload:
         body = fake_client.post.call_args.kwargs["json"]
         assert "reasoning_effort" not in body
         assert body["messages"] == [{"role": "user", "content": "hello"}]
+
+
+def _completion_with(content, finish_reason):
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value={"choices": [{"message": {"content": content}, "finish_reason": finish_reason}]})
+    return resp
+
+
+class TestFinishReason:
+    """A cut-off reply reads like a short one; only the finish reason tells them apart.
+
+    Reasoning models spend `max_tokens` thinking and are stopped a few tokens into the
+    answer. For a month that surfaced as "no JSON object in the reply" with nothing else
+    to go on, because `gateway_chat` returned the text and dropped the reason.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_text_carries_the_finish_reason(self):
+        fake_client = SimpleNamespace(post=AsyncMock(return_value=_completion_with('{"a": 1', "length")))
+        with patch.object(llm_gateway._client, "get", return_value=fake_client):
+            text = await llm_gateway.gateway_chat("x", model="m")
+
+        assert text == '{"a": 1'  # still a str to every caller
+        assert text.finish_reason == "length"
+
+    @pytest.mark.asyncio
+    async def test_a_reply_cut_off_before_the_object_closes_raises(self):
+        fake_client = SimpleNamespace(post=AsyncMock(return_value=_completion_with('{\n  "job_type": "watch",\n  "na', "length")))
+        with patch.object(llm_gateway._client, "get", return_value=fake_client):
+            with pytest.raises(llm_gateway.GatewayReplyTruncated, match="max_tokens=1024"):
+                await llm_gateway.gateway_chat_json("x", model="m")
+
+    @pytest.mark.asyncio
+    async def test_a_complete_reply_that_merely_stopped_at_the_limit_is_returned(self):
+        # finish_reason=length with a whole object in it: the object is what matters.
+        fake_client = SimpleNamespace(post=AsyncMock(return_value=_completion_with('{"a": 1}', "length")))
+        with patch.object(llm_gateway._client, "get", return_value=fake_client):
+            assert await llm_gateway.gateway_chat_json("x", model="m") == {"a": 1}
+
+    @pytest.mark.asyncio
+    async def test_an_unusable_reply_logs_finish_reason_and_a_snippet(self, caplog):
+        fake_client = SimpleNamespace(post=AsyncMock(return_value=_completion_with("I would rather not.", "stop")))
+        with patch.object(llm_gateway._client, "get", return_value=fake_client), caplog.at_level("WARNING"):
+            assert await llm_gateway.gateway_chat_json("x", model="m") == {}
+
+        message = caplog.records[-1].getMessage()
+        assert "finish_reason=stop" in message
+        assert "I would rather not." in message
+
+    @pytest.mark.asyncio
+    async def test_a_plain_string_stub_has_no_finish_reason_and_still_works(self):
+        # Every existing test stubs gateway_chat with a literal; the contract holds for it.
+        with patch.object(llm_gateway, "gateway_chat", AsyncMock(return_value="nothing here")):
+            assert await llm_gateway.gateway_chat_json("x", model="m") == {}
+
+    @pytest.mark.asyncio
+    async def test_json_calls_forward_reasoning_effort(self):
+        fake_client = SimpleNamespace(post=AsyncMock(return_value=_completion_with("{}", "stop")))
+        with patch.object(llm_gateway._client, "get", return_value=fake_client):
+            await llm_gateway.gateway_chat_json("x", model="m", reasoning_effort="none")
+
+        assert fake_client.post.call_args.kwargs["json"]["reasoning_effort"] == "none"

--- a/packages/console-backend/tests/test_scheduler_engine.py
+++ b/packages/console-backend/tests/test_scheduler_engine.py
@@ -1098,10 +1098,8 @@ class TestWriteNotification:
     async def test_the_model_writes_it(self):
         engine = _make_engine()
         job = _make_job(job_type=JobType.WATCH, sub_agent_id=None)
-        with patch(
-            "console_backend.services.scheduler_engine.gateway_chat",
-            AsyncMock(return_value='  "Campaign 4821 stopped syncing."  '),
-        ):
+        chat = AsyncMock(return_value='  "Campaign 4821 stopped syncing."  ')
+        with patch("console_backend.services.scheduler_engine.gateway_chat", chat):
             with patch(
                 "console_backend.services.scheduler_engine.ModelDefaultsRepository.get_all",
                 AsyncMock(return_value={"chat:low": "some-model"}),
@@ -1111,6 +1109,9 @@ class TestWriteNotification:
                 )
         # Quotes and padding stripped: this goes straight to a person.
         assert written == "Campaign 4821 stopped syncing."
+        # Thinking off: a reasoning model on the low tier would otherwise spend the
+        # 256-token budget thinking and send a cut-off sentence to the person.
+        assert chat.await_args.kwargs["reasoning_effort"] == "none"
 
     @pytest.mark.asyncio
     async def test_an_unreachable_model_still_says_something(self):


### PR DESCRIPTION
closes ringier-data/nannos#208

## What

Follow-up to #205. With the catalogue trimmed, *"notify me every time a new bug report is filed"* still failed on the `chat:low` tier, now as a 422 telling the user to rephrase. The log showed ranking had worked (`console_list_bug_reports` offered first) and the model had replied with 94 characters of non-JSON.

**Cause:** the tier resolves to a reasoning model (Gemini 3.5 Flash locally). Reasoning tokens count against `max_tokens=1024`; the model spent 979 of them thinking and was stopped 41 tokens into the JSON object. `gateway_chat` discarded `finish_reason`, so the cutoff was indistinguishable from a content miss.

## How

- **Thinking off for the generators.** Draft and condition generation pass `reasoning_effort="none"` (as conversation titling already does): mechanical JSON-filling from a prompt that states the rules. The proxy drops the parameter for models without the control.
- **Finish reason kept.** `gateway_chat` returns `GatewayText`, a `str` subclass carrying `finish_reason`, so every existing caller and every test stubbing it with a literal keeps working. `gateway_chat_json` reads it (tolerating plain strings).
- **Diagnosable log line.** On a no-object or unparseable reply, `gateway_chat_json` logs the finish reason and the first 200 characters of the reply, not just its length.
- **Truncation named.** When the reason there is no object is `finish_reason == "length"`, `gateway_chat_json` raises `GatewayReplyTruncated`; both scheduler generators turn that into a 422 saying the reply was cut off, not a request to rephrase. A complete object that merely stopped at the limit is still returned.

- **Trigger-notification writer** (`scheduler_engine._write_notification`, `max_tokens=256`) also gets `reasoning_effort="none"` after review: plain-text writing, and a cut-off sentence would reach the person verbatim.

Not touched: the watch judge (`watch_evaluator`, `max_tokens=512`, no `reasoning_effort`) has the same exposure on a reasoning model — a cutoff there reads as "condition not met". Judging is semantic, so whether to disable thinking or raise the budget is a separate call; noting it rather than folding it in.

Also on this branch: Andrea's trailing-slash fix for `_console_mcp_url` (1e92666e), with its debugging leftover removed.

## Verification

- Live, against the local proxy with a prompt the size of the real one (~10.9k tokens), through the patched `gateway_chat_json`:
  - thinking on, `max_tokens=1024` → `GatewayReplyTruncated`, log shows `finish_reason=length` and the opening of the object
  - `reasoning_effort="none"` → `job_type=watch`, `check_tool=console_list_bug_reports`, a CEL expression over `prev`
- New tests: `test_llm_gateway.py` (finish reason carried; cutoff raises; complete-at-limit returned; snippet + finish reason logged; plain-string stubs unaffected; `reasoning_effort` forwarded), `test_generate_job_draft_endpoint.py` and `test_generate_condition.py` (thinking off; truncated reply → 422 "cut off").
- console-backend full suite: 1719 passed. `ruff check` clean on touched files.

## Checklist
- [x] I have performed a self-review of my code
- [x] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨 — No. `gateway_chat` still returns a `str`; `gateway_chat_json` gains an optional parameter and a new exception on a path that previously returned `{}` for a cut-off reply (both callers handle it; the watch judge already catches `Exception`).
