### PR TITLE
fix(orchestrator-agent): derive the turn budget from the compiled graph

### DIFF
--- a/packages/orchestrator-agent/app/core/graph_factory.py
+++ b/packages/orchestrator-agent/app/core/graph_factory.py
@@ -913,8 +913,8 @@ class GraphFactory:
         # Override deepagents' recursion_limit default of 1000, which is too high to
         # catch a runaway loop. The budget is configured in model calls and converted
         # here, against *this* graph: the multiplier is the middleware stack's per-call
-        # node cost, which differs between configurations (the PTC middlewares come and
-        # go with CODE_INTERPRETER_PTC), so it cannot be a constant.
+        # node cost, so it goes stale the moment a middleware with model hooks is added
+        # or removed — which is why it is counted rather than written down.
         recursion_limit = recursion_limit_for(compiled_graph, self.config.MAX_MODEL_CALLS_PER_TURN)
         compiled_graph = compiled_graph.with_config({"recursion_limit": recursion_limit})
         logger.info(

--- a/packages/orchestrator-agent/app/core/graph_factory.py
+++ b/packages/orchestrator-agent/app/core/graph_factory.py
@@ -72,6 +72,7 @@ from ..models.config import AgentSettings, GraphRuntimeContext
 from ..models.schemas import FinalResponseSchema
 from .file_tools import create_presigned_url_tool
 from .steering_state import get_all_active_subagent_dispatches, get_orchestrator_pending_messages
+from .step_budget import recursion_limit_for
 from .time_tools import create_time_tool
 
 logger = logging.getLogger(__name__)
@@ -909,10 +910,19 @@ class GraphFactory:
             context_schema=GraphRuntimeContext,
             response_format=response_format,
         )
-        # Override deepagents default recursion_limit (1000) with configured value
-        # This prevents infinite loops from reaching the high default limit
-        compiled_graph = compiled_graph.with_config({"recursion_limit": self.config.MAX_RECURSION_LIMIT})
-        logger.info(f"Graph created for model: {model_type} with recursion_limit={self.config.MAX_RECURSION_LIMIT}")
+        # Override deepagents' recursion_limit default of 1000, which is too high to
+        # catch a runaway loop. The budget is configured in model calls and converted
+        # here, against *this* graph: the multiplier is the middleware stack's per-call
+        # node cost, which differs between configurations (the PTC middlewares come and
+        # go with CODE_INTERPRETER_PTC), so it cannot be a constant.
+        recursion_limit = recursion_limit_for(compiled_graph, self.config.MAX_MODEL_CALLS_PER_TURN)
+        compiled_graph = compiled_graph.with_config({"recursion_limit": recursion_limit})
+        logger.info(
+            "Graph created for model: %s with recursion_limit=%d (%d model calls per turn)",
+            model_type,
+            recursion_limit,
+            self.config.MAX_MODEL_CALLS_PER_TURN,
+        )
 
         return compiled_graph
 

--- a/packages/orchestrator-agent/app/core/step_budget.py
+++ b/packages/orchestrator-agent/app/core/step_budget.py
@@ -101,15 +101,3 @@ def recursion_limit_for(graph: Any, max_model_calls: int) -> int:
         max_model_calls,
     )
     return limit
-
-
-def affordable_model_calls(graph: Any, recursion_limit: int) -> int:
-    """Inverse of :func:`recursion_limit_for` -- what a given limit actually buys.
-
-    Exists to make the old failure legible: it answers "50 steps was how many
-    model calls?" (six), which is the number nobody could see at the call site.
-    """
-    per_call = steps_per_model_call(graph)
-    if per_call <= 0:
-        return 0
-    return max((recursion_limit - base_steps(graph)) // per_call, 0)

--- a/packages/orchestrator-agent/app/core/step_budget.py
+++ b/packages/orchestrator-agent/app/core/step_budget.py
@@ -1,0 +1,115 @@
+"""Convert a turn budget in model calls into LangGraph's super-step budget.
+
+LangGraph's ``recursion_limit`` counts **super-steps**, not model calls. Every
+middleware hook is its own graph node, so one model call costs several of them.
+That multiplier is invisible at the call site, which is how the limit came to be
+50 -- a sensible number of model calls and a crippling number of steps. At 50 a
+turn was capped at six model calls, and the orchestrator spends calls on
+write_todos bookkeeping and filesystem exploration between delegations, so an
+ordinary two-delegation request ("look up X and post it to Slack") exhausted the
+budget and the user was asked to continue a task that had already completed
+correctly.
+
+The multiplier is therefore **derived from the compiled graph** rather than
+written down. A hardcoded number is wrong twice over: it goes stale the moment a
+middleware is added, and it cannot be right for more than one configuration --
+the PTC middlewares appear and disappear with ``CODE_INTERPRETER_PTC``, so the
+orchestrator's real stack differs between deployments.
+
+How the derivation works
+------------------------
+Middleware hook nodes are named ``<Middleware>.<hook>``, so the hook type is
+readable off the node name:
+
+- ``.before_model`` / ``.after_model`` run once per **model call**
+- ``.before_agent`` / ``.after_agent`` run once per **turn**
+- ``model`` and ``tools`` are the core of each cycle
+
+Measured against real graph runs (see ``tests/test_step_budget.py``): the
+marginal cost of a model call is exactly ``per_call_hooks + 2``, and a turn of N
+calls costs ``per_turn_hooks - 1 + N * (per_call_hooks + 2)``. The ``- 1`` is
+real, not a fudge: the final model call emits ``FinalResponseSchema`` and ends
+the turn without entering ``tools``, so one cycle is a step short.
+
+Node count is an **upper bound** on the steps a cycle can spend, which is the
+safe direction: a hook that returns early still occupies a node, while a skipped
+branch simply does not run. Over-estimating gives the model at least the intended
+number of calls; under-estimating is the bug this replaces.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+PER_MODEL_CALL_HOOKS = (".before_model", ".after_model")
+PER_TURN_HOOKS = (".before_agent", ".after_agent")
+CORE_CYCLE_NODES = ("model", "tools")
+TERMINAL_NODES = ("__start__", "__end__")
+
+
+def classify_nodes(graph: Any) -> dict[str, list[str]]:
+    """Partition a compiled graph's nodes by how often they run.
+
+    Every node lands in exactly one bucket. ``unclassified`` is the important
+    one: it is empty today, and anything appearing in it means LangGraph grew a
+    node shape this module does not understand -- at which point the derivation
+    below is quietly wrong and the test asserting it is empty fails.
+    """
+    buckets: dict[str, list[str]] = {"per_model_call": [], "per_turn": [], "core": [], "terminal": [], "unclassified": []}
+    for name in graph.get_graph().nodes:
+        if name.endswith(PER_MODEL_CALL_HOOKS):
+            buckets["per_model_call"].append(name)
+        elif name.endswith(PER_TURN_HOOKS):
+            buckets["per_turn"].append(name)
+        elif name in CORE_CYCLE_NODES:
+            buckets["core"].append(name)
+        elif name in TERMINAL_NODES:
+            buckets["terminal"].append(name)
+        else:
+            buckets["unclassified"].append(name)
+    return buckets
+
+
+def steps_per_model_call(graph: Any) -> int:
+    """Super-steps one model call costs in *graph*: its hooks, plus model and tools."""
+    buckets = classify_nodes(graph)
+    return len(buckets["per_model_call"]) + len(CORE_CYCLE_NODES)
+
+
+def base_steps(graph: Any) -> int:
+    """Super-steps a turn costs regardless of how many model calls it makes.
+
+    The per-turn hooks, minus one for the ``tools`` step the closing model call
+    never takes -- it emits the final-response envelope and the turn ends.
+    """
+    return max(len(classify_nodes(graph)["per_turn"]) - 1, 0)
+
+
+def recursion_limit_for(graph: Any, max_model_calls: int) -> int:
+    """LangGraph ``recursion_limit`` that affords *max_model_calls* model calls."""
+    per_call = steps_per_model_call(graph)
+    base = base_steps(graph)
+    limit = base + per_call * max_model_calls
+    logger.info(
+        "Derived recursion_limit=%d from the compiled graph: %d base + %d per model call x %d calls",
+        limit,
+        base,
+        per_call,
+        max_model_calls,
+    )
+    return limit
+
+
+def affordable_model_calls(graph: Any, recursion_limit: int) -> int:
+    """Inverse of :func:`recursion_limit_for` -- what a given limit actually buys.
+
+    Exists to make the old failure legible: it answers "50 steps was how many
+    model calls?" (six), which is the number nobody could see at the call site.
+    """
+    per_call = steps_per_model_call(graph)
+    if per_call <= 0:
+        return 0
+    return max((recursion_limit - base_steps(graph)) // per_call, 0)

--- a/packages/orchestrator-agent/app/core/step_budget.py
+++ b/packages/orchestrator-agent/app/core/step_budget.py
@@ -11,10 +11,8 @@ budget and the user was asked to continue a task that had already completed
 correctly.
 
 The multiplier is therefore **derived from the compiled graph** rather than
-written down. A hardcoded number is wrong twice over: it goes stale the moment a
-middleware is added, and it cannot be right for more than one configuration --
-the PTC middlewares appear and disappear with ``CODE_INTERPRETER_PTC``, so the
-orchestrator's real stack differs between deployments.
+written down: it changes whenever a middleware carrying model hooks is added or
+removed, and nothing forces a hand-maintained constant to be updated with it.
 
 How the derivation works
 ------------------------
@@ -25,16 +23,27 @@ readable off the node name:
 - ``.before_agent`` / ``.after_agent`` run once per **turn**
 - ``model`` and ``tools`` are the core of each cycle
 
-Measured against real graph runs (see ``tests/test_step_budget.py``): the
-marginal cost of a model call is exactly ``per_call_hooks + 2``, and a turn of N
-calls costs ``per_turn_hooks - 1 + N * (per_call_hooks + 2)``. The ``- 1`` is
-real, not a fudge: the final model call emits ``FinalResponseSchema`` and ends
-the turn without entering ``tools``, so one cycle is a step short.
+Deliberately an over-estimate
+-----------------------------
+The budget must never be *below* what a turn really costs -- that is the bug
+being replaced -- so every judgement here rounds up.
 
-Node count is an **upper bound** on the steps a cycle can spend, which is the
-safe direction: a hook that returns early still occupies a node, while a skipped
-branch simply does not run. Over-estimating gives the model at least the intended
-number of calls; under-estimating is the bug this replaces.
+- Node count is an upper bound on a cycle's steps: a hook that returns early
+  still occupies a node, while a skipped branch simply does not run.
+- Nodes this module does not recognise are counted as *per model call*, the most
+  expensive assumption, and logged. Ignoring them would shrink the budget toward
+  exactly the truncation this exists to prevent.
+- ``base_steps`` counts every per-turn hook, even though on some graphs the
+  closing model call ends the turn without entering ``tools`` and one cycle is a
+  step short. Whether it does depends on the structured-output strategy:
+  ``ToolStrategy`` (no thinking) exits without ``tools``, while a graph that
+  binds ``FinalResponseSchema`` as a ``return_direct`` tool -- thinking enabled
+  on Anthropic/Bedrock, or Gemini's builtin-tools path, i.e. when
+  ``select_response_format`` returns ``(None, True)`` -- routes the closing call
+  through ``tools`` like any other. Subtracting the difference would be exact for
+  the first and one step short for the second, and one step short is a
+  ``GraphRecursionError`` fired after the answer is composed. So it is not
+  subtracted. Measured in ``tests/test_step_budget.py`` against both paths.
 """
 
 from __future__ import annotations
@@ -53,13 +62,25 @@ TERMINAL_NODES = ("__start__", "__end__")
 def classify_nodes(graph: Any) -> dict[str, list[str]]:
     """Partition a compiled graph's nodes by how often they run.
 
+    Reads ``graph.nodes`` -- the compiled ``Pregel``'s own dict -- rather than
+    ``graph.get_graph().nodes``, which runs langgraph's edge-discovery simulation
+    to build a drawable graph just to list names. The two differ only by
+    ``__end__``, which is never counted.
+
     Every node lands in exactly one bucket. ``unclassified`` is the important
-    one: it is empty today, and anything appearing in it means LangGraph grew a
-    node shape this module does not understand -- at which point the derivation
-    below is quietly wrong and the test asserting it is empty fails.
+    one: anything in it means LangGraph grew a node shape this module does not
+    understand, so the callers below charge it at the per-model-call rate and say
+    so out loud.
     """
-    buckets: dict[str, list[str]] = {"per_model_call": [], "per_turn": [], "core": [], "terminal": [], "unclassified": []}
-    for name in graph.get_graph().nodes:
+    buckets: dict[str, list[str]] = {
+        "per_model_call": [],
+        "per_turn": [],
+        "core": [],
+        "terminal": [],
+        "unclassified": [],
+    }
+    for raw in graph.nodes:
+        name = str(raw)
         if name.endswith(PER_MODEL_CALL_HOOKS):
             buckets["per_model_call"].append(name)
         elif name.endswith(PER_TURN_HOOKS):
@@ -73,31 +94,45 @@ def classify_nodes(graph: Any) -> dict[str, list[str]]:
     return buckets
 
 
+def _warn_unclassified(buckets: dict[str, list[str]]) -> None:
+    if buckets["unclassified"]:
+        logger.warning(
+            "Unrecognised graph nodes %s are being charged at the per-model-call rate. "
+            "app/core/step_budget.py needs to learn how often they run; until then the "
+            "turn budget is a safe over-estimate rather than a correct one.",
+            sorted(buckets["unclassified"]),
+        )
+
+
+def _steps_per_model_call(buckets: dict[str, list[str]]) -> int:
+    # `core` is counted, not assumed to be 2: langchain only adds a `tools` node
+    # when the graph has tools, and a rename would land both in `unclassified`.
+    return len(buckets["per_model_call"]) + len(buckets["core"]) + len(buckets["unclassified"])
+
+
+def _base_steps(buckets: dict[str, list[str]]) -> int:
+    return len(buckets["per_turn"])
+
+
 def steps_per_model_call(graph: Any) -> int:
     """Super-steps one model call costs in *graph*: its hooks, plus model and tools."""
     buckets = classify_nodes(graph)
-    return len(buckets["per_model_call"]) + len(CORE_CYCLE_NODES)
+    _warn_unclassified(buckets)
+    return _steps_per_model_call(buckets)
 
 
 def base_steps(graph: Any) -> int:
-    """Super-steps a turn costs regardless of how many model calls it makes.
-
-    The per-turn hooks, minus one for the ``tools`` step the closing model call
-    never takes -- it emits the final-response envelope and the turn ends.
-    """
-    return max(len(classify_nodes(graph)["per_turn"]) - 1, 0)
+    """Super-steps a turn costs regardless of how many model calls it makes."""
+    return _base_steps(classify_nodes(graph))
 
 
 def recursion_limit_for(graph: Any, max_model_calls: int) -> int:
-    """LangGraph ``recursion_limit`` that affords *max_model_calls* model calls."""
-    per_call = steps_per_model_call(graph)
-    base = base_steps(graph)
-    limit = base + per_call * max_model_calls
-    logger.info(
-        "Derived recursion_limit=%d from the compiled graph: %d base + %d per model call x %d calls",
-        limit,
-        base,
-        per_call,
-        max_model_calls,
-    )
-    return limit
+    """LangGraph ``recursion_limit`` that affords *max_model_calls* model calls.
+
+    Classifies once: the two components are derived from a single pass, since
+    this runs on every ``_create_graph`` including the cold path that rebuilds
+    per turn.
+    """
+    buckets = classify_nodes(graph)
+    _warn_unclassified(buckets)
+    return _base_steps(buckets) + _steps_per_model_call(buckets) * max_model_calls

--- a/packages/orchestrator-agent/app/models/config.py
+++ b/packages/orchestrator-agent/app/models/config.py
@@ -41,6 +41,10 @@ def _int_env(name: str, default: int) -> int:
 # using the compiled graph, so no multiplier is written down anywhere.
 MAX_MODEL_CALLS_PER_TURN_ENV = "ORCHESTRATOR_MAX_MODEL_CALLS_PER_TURN"
 DEFAULT_MAX_MODEL_CALLS_PER_TURN = 25
+MIN_MAX_MODEL_CALLS_PER_TURN = 1
+SANE_MAX_MODEL_CALLS_PER_TURN = 200
+"""Not a limit — only the point above which a value is more likely a typo than an
+intent, and worth a warning because the runaway guard stops being one."""
 
 # Deliberately *not* read any more. `MAX_RECURSION_LIMIT` is a shared env name:
 # ringier-a2a-sdk and agent-runner default it to 50, agent-common's dynamic_agent
@@ -70,7 +74,39 @@ def _resolve_max_model_calls_per_turn() -> int:
             legacy,
             MAX_MODEL_CALLS_PER_TURN_ENV,
         )
-    return _int_env(MAX_MODEL_CALLS_PER_TURN_ENV, DEFAULT_MAX_MODEL_CALLS_PER_TURN)
+
+    value = _int_env(MAX_MODEL_CALLS_PER_TURN_ENV, DEFAULT_MAX_MODEL_CALLS_PER_TURN)
+
+    # A budget of 0 or less is not a small budget, it is a broken deployment: the
+    # derived limit collapses to the per-turn overhead, so every request exhausts
+    # it within its first super-steps and the user gets "I've been working on this
+    # for a while and need to take a break" having had no work done at all. Clamp
+    # rather than crash, matching how a malformed value is handled above, but say
+    # so — nothing else in the logs would point at this variable.
+    if value < MIN_MAX_MODEL_CALLS_PER_TURN:
+        logger.warning(
+            "%s=%d is below the minimum of %d and would exhaust the turn budget "
+            "immediately; using %d.",
+            MAX_MODEL_CALLS_PER_TURN_ENV,
+            value,
+            MIN_MAX_MODEL_CALLS_PER_TURN,
+            MIN_MAX_MODEL_CALLS_PER_TURN,
+        )
+        return MIN_MAX_MODEL_CALLS_PER_TURN
+
+    # No clamp at the top end — an operator may legitimately want a long budget —
+    # but a typo'd 2500 becomes ~20k super-steps, which is no runaway protection
+    # at all, and that is worth noticing before it costs a fortune.
+    if value > SANE_MAX_MODEL_CALLS_PER_TURN:
+        logger.warning(
+            "%s=%d is unusually high (over %d model calls per turn). Honouring it, but "
+            "the runaway-loop guard is effectively disabled at this size.",
+            MAX_MODEL_CALLS_PER_TURN_ENV,
+            value,
+            SANE_MAX_MODEL_CALLS_PER_TURN,
+        )
+
+    return value
 
 
 # Message formatting literal for type safety
@@ -370,8 +406,9 @@ class AgentSettings:
 
     # Turn budget, in model calls (overrides deepagents' recursion_limit default of
     # 1000). GraphFactory converts this to a super-step limit per compiled graph via
-    # app/core/step_budget.py — the multiplier depends on the middleware stack, so it
-    # is counted from the graph rather than written here.
+    # app/core/step_budget.py — the multiplier is the middleware stack's per-call node
+    # cost, which changes whenever a middleware with model hooks is added or removed,
+    # so it is counted from the graph rather than written here.
     MAX_MODEL_CALLS_PER_TURN = _resolve_max_model_calls_per_turn()
 
     # Toolset selection configuration (used by ToolsetSelectorMiddleware in custom GP graph)

--- a/packages/orchestrator-agent/app/models/config.py
+++ b/packages/orchestrator-agent/app/models/config.py
@@ -36,6 +36,43 @@ def _int_env(name: str, default: int) -> int:
         return default
 
 
+# How many model calls one turn may spend. This is the unit the budget is
+# expressed in; app/core/step_budget.py converts it to LangGraph super-steps
+# using the compiled graph, so no multiplier is written down anywhere.
+MAX_MODEL_CALLS_PER_TURN_ENV = "ORCHESTRATOR_MAX_MODEL_CALLS_PER_TURN"
+DEFAULT_MAX_MODEL_CALLS_PER_TURN = 25
+
+# Deliberately *not* read any more. `MAX_RECURSION_LIMIT` is a shared env name:
+# ringier-a2a-sdk and agent-runner default it to 50, agent-common's dynamic_agent
+# to 75. One value cannot serve all four -- a deployment pinning 50 (the
+# orchestrator's own former default) would silently reinstate the turn truncation
+# this budget exists to prevent, while an operator exporting a value large enough
+# for the orchestrator would quadruple every sub-agent's runaway-loop bound.
+LEGACY_RECURSION_LIMIT_ENV = "MAX_RECURSION_LIMIT"
+
+
+def _resolve_max_model_calls_per_turn() -> int:
+    """Model calls allowed per turn, warning if the old shared env var is set.
+
+    The legacy name is not honoured, because inheriting it is the bug. Silence
+    would be worse than either choice, so an operator who set it is told that it
+    no longer applies here and what to set instead.
+    """
+    legacy = os.getenv(LEGACY_RECURSION_LIMIT_ENV)
+    if legacy and legacy.strip():
+        logger.warning(
+            "%s=%s is set but no longer configures the orchestrator: it is a shared "
+            "name used by agent-runner, agent-common and ringier-a2a-sdk with "
+            "different defaults, and inheriting a sub-agent's super-step budget is "
+            "what truncated orchestrator turns. Use %s instead -- it is counted in "
+            "model calls, not super-steps.",
+            LEGACY_RECURSION_LIMIT_ENV,
+            legacy,
+            MAX_MODEL_CALLS_PER_TURN_ENV,
+        )
+    return _int_env(MAX_MODEL_CALLS_PER_TURN_ENV, DEFAULT_MAX_MODEL_CALLS_PER_TURN)
+
+
 # Message formatting literal for type safety
 
 if TYPE_CHECKING:
@@ -331,8 +368,11 @@ class AgentSettings:
     MAX_RETRIES = 3
     BACKOFF_FACTOR = 3.0
 
-    # Recursion limit configuration (overrides deepagents default of 1000)
-    MAX_RECURSION_LIMIT = int(os.getenv("MAX_RECURSION_LIMIT", "50"))
+    # Turn budget, in model calls (overrides deepagents' recursion_limit default of
+    # 1000). GraphFactory converts this to a super-step limit per compiled graph via
+    # app/core/step_budget.py — the multiplier depends on the middleware stack, so it
+    # is counted from the graph rather than written here.
+    MAX_MODEL_CALLS_PER_TURN = _resolve_max_model_calls_per_turn()
 
     # Toolset selection configuration (used by ToolsetSelectorMiddleware in custom GP graph)
     TOOLSET_SELECTION_THRESHOLD = int(os.getenv("TOOLSET_SELECTION_THRESHOLD", "50"))

--- a/packages/orchestrator-agent/tests/test_orchestrator_thinking_integration.py
+++ b/packages/orchestrator-agent/tests/test_orchestrator_thinking_integration.py
@@ -189,6 +189,9 @@ class TestGraphCreationWithThinking:
         mock_config.POSTGRES_SCHEMA = "public"
         mock_config.MAX_RETRIES = 3
         mock_config.BACKOFF_FACTOR = 2
+        # The turn budget is converted to a super-step limit from the compiled graph
+        # (app/core/step_budget.py), so a Mock(spec=AgentSettings) needs a real int here.
+        mock_config.MAX_MODEL_CALLS_PER_TURN = 25
 
         # Graph creation resolves the model's provider via the gateway. Keep it hermetic:
         # LLM_GATEWAY_URL lets create_model build its client, and get_model_provider is
@@ -201,7 +204,13 @@ class TestGraphCreationWithThinking:
             patch("agent_common.core.model_factory.get_model_provider", return_value="bedrock_converse"),
             patch("agent_common.a2a.structured_response.get_model_provider", return_value="bedrock_converse"),
         ):
-            mock_create_deep_agent.return_value = Mock()
+            # `_create_graph` now derives the recursion limit by counting the compiled
+            # graph's nodes, so a bare Mock is no longer enough — it must expose an
+            # iterable node list. The names only need to be classifiable; this test is
+            # about caching, not about the budget arithmetic.
+            mock_graph = Mock()
+            mock_graph.get_graph.return_value.nodes = ["__start__", "model", "tools", "__end__"]
+            mock_create_deep_agent.return_value = mock_graph
 
             factory = GraphFactory(mock_config)
 

--- a/packages/orchestrator-agent/tests/test_orchestrator_thinking_integration.py
+++ b/packages/orchestrator-agent/tests/test_orchestrator_thinking_integration.py
@@ -206,10 +206,10 @@ class TestGraphCreationWithThinking:
         ):
             # `_create_graph` now derives the recursion limit by counting the compiled
             # graph's nodes, so a bare Mock is no longer enough — it must expose an
-            # iterable node list. The names only need to be classifiable; this test is
+            # iterable `nodes`. The names only need to be classifiable; this test is
             # about caching, not about the budget arithmetic.
             mock_graph = Mock()
-            mock_graph.get_graph.return_value.nodes = ["__start__", "model", "tools", "__end__"]
+            mock_graph.nodes = ["__start__", "model", "tools"]
             mock_create_deep_agent.return_value = mock_graph
 
             factory = GraphFactory(mock_config)

--- a/packages/orchestrator-agent/tests/test_step_budget.py
+++ b/packages/orchestrator-agent/tests/test_step_budget.py
@@ -34,7 +34,6 @@ from pydantic import Field, PrivateAttr
 
 from app.core.graph_factory import GraphFactory
 from app.core.step_budget import (
-    affordable_model_calls,
     base_steps,
     classify_nodes,
     recursion_limit_for,
@@ -222,14 +221,6 @@ def test_every_node_is_classified():
     assert buckets["per_model_call"], "no per-model-call hooks found — hook naming changed"
 
 
-def test_the_derived_limit_affords_the_configured_model_calls():
-    """End to end: what the graph is actually configured with."""
-    graph = _compiled_graph()
-    limit = recursion_limit_for(graph, AgentSettings.MAX_MODEL_CALLS_PER_TURN)
-
-    assert affordable_model_calls(graph, limit) == AgentSettings.MAX_MODEL_CALLS_PER_TURN
-
-
 def test_fifty_steps_was_six_model_calls():
     """The reported bug, in the unit that makes it obvious.
 
@@ -238,7 +229,11 @@ def test_fifty_steps_was_six_model_calls():
     exceeds. If this number ever climbs to something comfortable, the middleware
     stack got cheaper and the incident is worth re-reading.
     """
-    assert affordable_model_calls(_compiled_graph(), 50) == 6
+    graph = _compiled_graph()
+
+    affordable = (50 - base_steps(graph)) // steps_per_model_call(graph)
+
+    assert affordable == 6
 
 
 def test_the_graph_is_compiled_with_the_derived_limit():

--- a/packages/orchestrator-agent/tests/test_step_budget.py
+++ b/packages/orchestrator-agent/tests/test_step_budget.py
@@ -1,0 +1,300 @@
+"""The turn budget: model calls in, LangGraph super-steps out.
+
+The reported bug was that `MAX_RECURSION_LIMIT=50` capped a turn at six model
+calls, because the limit counts super-steps and every middleware hook is its own
+node. The fix expresses the budget in model calls and derives the multiplier from
+the compiled graph.
+
+These tests exist to stop the derivation going quietly wrong, which is the only
+way this bug can come back. Two of them do real work:
+
+- `test_marginal_cost_of_a_model_call_matches_the_derivation` measures the
+  super-steps of an actual graph run and compares them against what
+  `step_budget` computed from the node names. If LangGraph renames a hook, or
+  starts running one twice per cycle, the measurement and the derivation diverge
+  and this fails.
+- `test_every_node_is_classified` fails when the graph grows a node shape the
+  derivation does not understand, rather than silently mis-counting it.
+
+Everything here runs offline: no gateway, no credentials, no model.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.store.memory import InMemoryStore
+from pydantic import Field, PrivateAttr
+
+from app.core.graph_factory import GraphFactory
+from app.core.step_budget import (
+    affordable_model_calls,
+    base_steps,
+    classify_nodes,
+    recursion_limit_for,
+    steps_per_model_call,
+)
+from app.core.time_tools import create_time_tool
+from app.models.config import (
+    DEFAULT_MAX_MODEL_CALLS_PER_TURN,
+    LEGACY_RECURSION_LIMIT_ENV,
+    MAX_MODEL_CALLS_PER_TURN_ENV,
+    AgentSettings,
+    GraphRuntimeContext,
+    _resolve_max_model_calls_per_turn,
+)
+
+MODEL_TYPE = "claude-sonnet-4.5"
+
+
+class _ScriptedModel(BaseChatModel):
+    """Replays canned turns. Deliberately local to this module.
+
+    langchain's stock fakes inherit a `bind_tools` that raises
+    NotImplementedError, and the orchestrator graph always binds tools, so a turn
+    dies before it starts. This is the minimum needed to drive a real graph and
+    count its steps.
+    """
+
+    responses: list[AIMessage] = Field(default_factory=list)
+    _cursor: int = PrivateAttr(default=0)
+
+    @property
+    def _llm_type(self) -> str:
+        return "scripted-step-budget"
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        if self._cursor >= len(self.responses):
+            raise AssertionError(
+                f"scripted model exhausted after {self._cursor} calls; the turn took an unexpected path"
+            )
+        message = self.responses[self._cursor]
+        self._cursor += 1
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+    def bind_tools(self, tools: Any, **kwargs: Any) -> BaseChatModel:
+        return self
+
+
+def _compiled_graph(model: BaseChatModel | None = None):
+    """A real compiled orchestrator graph with test doubles for the stores.
+
+    Reaches past the public API because GraphFactory offers no injection seam.
+    Only the persistence layer and the model are substituted; the middleware
+    stack, and therefore the node count this module measures, is production's.
+
+    A model is always substituted, even for the tests that never run a turn:
+    `_create_graph` builds one eagerly, and the real factory refuses without
+    `LLM_GATEWAY_URL` — which would make these tests need a gateway to count
+    nodes.
+    """
+    factory = GraphFactory(config=AgentSettings(), cost_logger=None)
+    factory._checkpointer = MemorySaver()
+    factory._store = InMemoryStore()
+    factory._store_setup_complete = True
+    factory._static_tools_cache = [create_time_tool()]
+    factory._create_model = lambda *_a, **_k: model or _ScriptedModel(responses=[])  # type: ignore[method-assign]
+    return factory._create_graph(MODEL_TYPE, None)
+
+
+def _runtime_context() -> GraphRuntimeContext:
+    return GraphRuntimeContext(
+        user_id="test-user",
+        user_sub="test-sub",
+        name="Test User",
+        email="test@local",
+        tool_registry={},
+        subagent_registry={},
+    )
+
+
+def _tool_turn(index: int) -> AIMessage:
+    """A model turn that calls a real static tool, so the cycle enters `tools`."""
+    return AIMessage(
+        content="",
+        tool_calls=[{"id": f"c{index}", "name": "get_current_time", "args": {}, "type": "tool_call"}],
+    )
+
+
+def _final_turn() -> AIMessage:
+    return AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "id": "final",
+                "name": "FinalResponseSchema",
+                "args": {"task_state": "completed", "message": "Done.", "include_subagent_output": False},
+                "type": "tool_call",
+            }
+        ],
+    )
+
+
+async def _measure_super_steps(model_calls: int) -> int:
+    """Run a turn spending exactly *model_calls* model calls; count super-steps.
+
+    `stream_mode="updates"` yields once per node execution, which is what
+    `recursion_limit` counts.
+    """
+    script = [_tool_turn(i) for i in range(model_calls - 1)] + [_final_turn()]
+    graph = _compiled_graph(_ScriptedModel(responses=script))
+
+    steps = 0
+    async for _ in graph.astream(
+        {"messages": [HumanMessage("go")]},
+        config={"configurable": {"thread_id": f"budget-{model_calls}"}},
+        context=_runtime_context(),
+        stream_mode="updates",
+    ):
+        steps += 1
+    return steps
+
+
+# ---------------------------------------------------------------------------
+# The derivation, checked against reality
+# ---------------------------------------------------------------------------
+
+
+async def test_marginal_cost_of_a_model_call_matches_the_derivation():
+    """The load-bearing assertion of this whole module.
+
+    Every extra model call must cost exactly what `steps_per_model_call` counted
+    from the node names. Measured across several turn lengths, because a single
+    data point cannot distinguish a per-call cost from a fixed overhead.
+    """
+    graph = _compiled_graph(_ScriptedModel(responses=[_final_turn()]))
+    derived = steps_per_model_call(graph)
+
+    measurements = {n: await _measure_super_steps(n) for n in (1, 2, 3, 4)}
+    marginals = [measurements[n + 1] - measurements[n] for n in (1, 2, 3)]
+
+    assert set(marginals) == {derived}, (
+        f"derived {derived} steps per model call, but measured marginals {marginals} "
+        f"from {measurements}. The middleware stack and the derivation disagree."
+    )
+
+
+async def test_base_steps_matches_the_measured_fixed_overhead():
+    """The part of a turn that does not scale with model calls.
+
+    Notably one less than the per-turn hook count: the closing model call emits
+    `FinalResponseSchema` and ends the turn without entering `tools`, so the last
+    cycle is a step short. That `- 1` is measured here rather than trusted.
+    """
+    graph = _compiled_graph(_ScriptedModel(responses=[_final_turn()]))
+    per_call = steps_per_model_call(graph)
+
+    measured_for_one = await _measure_super_steps(1)
+
+    assert base_steps(graph) == measured_for_one - per_call, (
+        f"base_steps()={base_steps(graph)} but a 1-call turn measured {measured_for_one} "
+        f"super-steps against {per_call} per call"
+    )
+
+
+def test_every_node_is_classified():
+    """An unclassified node means the derivation is silently mis-counting.
+
+    This is the guard that makes the whole approach safe to leave unattended: if
+    LangGraph adds a hook type (a `.before_tools`, say) it lands in
+    `unclassified` and this fails, instead of being quietly omitted from the
+    per-call cost and tightening every turn's budget.
+    """
+    buckets = classify_nodes(_compiled_graph())
+
+    assert buckets["unclassified"] == [], (
+        f"unrecognised graph nodes: {buckets['unclassified']}. "
+        "app/core/step_budget.py needs to learn how often they run."
+    )
+    assert buckets["core"], "neither `model` nor `tools` was found — node naming changed"
+    assert buckets["per_model_call"], "no per-model-call hooks found — hook naming changed"
+
+
+def test_the_derived_limit_affords_the_configured_model_calls():
+    """End to end: what the graph is actually configured with."""
+    graph = _compiled_graph()
+    limit = recursion_limit_for(graph, AgentSettings.MAX_MODEL_CALLS_PER_TURN)
+
+    assert affordable_model_calls(graph, limit) == AgentSettings.MAX_MODEL_CALLS_PER_TURN
+
+
+def test_fifty_steps_was_six_model_calls():
+    """The reported bug, in the unit that makes it obvious.
+
+    Keeps the finding legible: the old default was not "50 of something
+    generous", it was six model calls, which an ordinary two-delegation turn
+    exceeds. If this number ever climbs to something comfortable, the middleware
+    stack got cheaper and the incident is worth re-reading.
+    """
+    assert affordable_model_calls(_compiled_graph(), 50) == 6
+
+
+def test_the_graph_is_compiled_with_the_derived_limit():
+    """The wiring, not just the arithmetic: GraphFactory must apply it."""
+    graph = _compiled_graph()
+    expected = recursion_limit_for(graph, AgentSettings.MAX_MODEL_CALLS_PER_TURN)
+
+    assert graph.config is not None
+    assert graph.config.get("recursion_limit") == expected
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+def test_the_shared_env_var_no_longer_configures_the_orchestrator(monkeypatch):
+    """The reported design bug.
+
+    `MAX_RECURSION_LIMIT` is read by agent-runner and ringier-a2a-sdk (default
+    50) and agent-common (75). A deployment pinning 50 — the orchestrator's own
+    former default — used to silently reinstate the truncation, and CI could not
+    catch it: the env var is unset there, so the tests stayed green against the
+    intended budget.
+    """
+    monkeypatch.setenv(LEGACY_RECURSION_LIMIT_ENV, "50")
+
+    assert _resolve_max_model_calls_per_turn() == DEFAULT_MAX_MODEL_CALLS_PER_TURN
+
+
+def test_setting_the_legacy_name_warns(monkeypatch, caplog):
+    """Ignoring it silently would be worse than either honouring or refusing it —
+    an operator who set it must be told it no longer applies, and what to set."""
+    monkeypatch.setenv(LEGACY_RECURSION_LIMIT_ENV, "50")
+
+    with caplog.at_level("WARNING"):
+        _resolve_max_model_calls_per_turn()
+
+    assert MAX_MODEL_CALLS_PER_TURN_ENV in caplog.text
+
+
+def test_the_orchestrator_budget_is_configurable(monkeypatch):
+    monkeypatch.setenv(MAX_MODEL_CALLS_PER_TURN_ENV, "40")
+
+    assert _resolve_max_model_calls_per_turn() == 40
+
+
+def test_a_malformed_budget_falls_back_rather_than_crashing(monkeypatch):
+    """This is read at import time, so raising would take the process down."""
+    monkeypatch.setenv(MAX_MODEL_CALLS_PER_TURN_ENV, "40s")
+
+    assert _resolve_max_model_calls_per_turn() == DEFAULT_MAX_MODEL_CALLS_PER_TURN
+
+
+@pytest.mark.parametrize("raw", ["", "   "])
+def test_an_empty_budget_falls_back(monkeypatch, raw):
+    monkeypatch.setenv(MAX_MODEL_CALLS_PER_TURN_ENV, raw)
+
+    assert _resolve_max_model_calls_per_turn() == DEFAULT_MAX_MODEL_CALLS_PER_TURN

--- a/packages/orchestrator-agent/tests/test_step_budget.py
+++ b/packages/orchestrator-agent/tests/test_step_budget.py
@@ -28,13 +28,13 @@ from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
+from agent_common.models.base import ThinkingLevel
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.store.memory import InMemoryStore
 from pydantic import Field, PrivateAttr
 
 from app.core.graph_factory import GraphFactory
 from app.core.step_budget import (
-    base_steps,
     classify_nodes,
     recursion_limit_for,
     steps_per_model_call,
@@ -44,6 +44,7 @@ from app.models.config import (
     DEFAULT_MAX_MODEL_CALLS_PER_TURN,
     LEGACY_RECURSION_LIMIT_ENV,
     MAX_MODEL_CALLS_PER_TURN_ENV,
+    MIN_MAX_MODEL_CALLS_PER_TURN,
     AgentSettings,
     GraphRuntimeContext,
     _resolve_max_model_calls_per_turn,
@@ -87,7 +88,7 @@ class _ScriptedModel(BaseChatModel):
         return self
 
 
-def _compiled_graph(model: BaseChatModel | None = None):
+def _compiled_graph(model: BaseChatModel | None = None, *, thinking: ThinkingLevel | None = None):
     """A real compiled orchestrator graph with test doubles for the stores.
 
     Reaches past the public API because GraphFactory offers no injection seam.
@@ -105,7 +106,7 @@ def _compiled_graph(model: BaseChatModel | None = None):
     factory._store_setup_complete = True
     factory._static_tools_cache = [create_time_tool()]
     factory._create_model = lambda *_a, **_k: model or _ScriptedModel(responses=[])  # type: ignore[method-assign]
-    return factory._create_graph(MODEL_TYPE, None)
+    return factory._create_graph(MODEL_TYPE, thinking)
 
 
 def _runtime_context() -> GraphRuntimeContext:
@@ -141,19 +142,19 @@ def _final_turn() -> AIMessage:
     )
 
 
-async def _measure_super_steps(model_calls: int) -> int:
+async def _measure_super_steps(model_calls: int, thinking: ThinkingLevel | None = None) -> int:
     """Run a turn spending exactly *model_calls* model calls; count super-steps.
 
     `stream_mode="updates"` yields once per node execution, which is what
     `recursion_limit` counts.
     """
     script = [_tool_turn(i) for i in range(model_calls - 1)] + [_final_turn()]
-    graph = _compiled_graph(_ScriptedModel(responses=script))
+    graph = _compiled_graph(_ScriptedModel(responses=script), thinking=thinking)
 
     steps = 0
     async for _ in graph.astream(
         {"messages": [HumanMessage("go")]},
-        config={"configurable": {"thread_id": f"budget-{model_calls}"}},
+        config={"configurable": {"thread_id": f"budget-{thinking}-{model_calls}"}},
         context=_runtime_context(),
         stream_mode="updates",
     ):
@@ -166,17 +167,22 @@ async def _measure_super_steps(model_calls: int) -> int:
 # ---------------------------------------------------------------------------
 
 
-async def test_marginal_cost_of_a_model_call_matches_the_derivation():
+@pytest.mark.parametrize("thinking", [None, ThinkingLevel.high], ids=["tool_strategy", "thinking"])
+async def test_marginal_cost_of_a_model_call_matches_the_derivation(thinking):
     """The load-bearing assertion of this whole module.
 
     Every extra model call must cost exactly what `steps_per_model_call` counted
     from the node names. Measured across several turn lengths, because a single
     data point cannot distinguish a per-call cost from a fixed overhead.
+
+    Both structured-output strategies are covered. They build the *same* nodes but
+    traverse them differently, and an earlier version of this test only ran the
+    `thinking=None` path — which is how the base-step off-by-one below survived.
     """
-    graph = _compiled_graph(_ScriptedModel(responses=[_final_turn()]))
+    graph = _compiled_graph(thinking=thinking)
     derived = steps_per_model_call(graph)
 
-    measurements = {n: await _measure_super_steps(n) for n in (1, 2, 3, 4)}
+    measurements = {n: await _measure_super_steps(n, thinking) for n in (1, 2, 3, 4)}
     marginals = [measurements[n + 1] - measurements[n] for n in (1, 2, 3)]
 
     assert set(marginals) == {derived}, (
@@ -185,22 +191,73 @@ async def test_marginal_cost_of_a_model_call_matches_the_derivation():
     )
 
 
-async def test_base_steps_matches_the_measured_fixed_overhead():
-    """The part of a turn that does not scale with model calls.
+@pytest.mark.parametrize("thinking", [None, ThinkingLevel.high], ids=["tool_strategy", "thinking"])
+@pytest.mark.parametrize("model_calls", [1, 2, 3])
+async def test_the_budget_is_never_below_what_a_turn_actually_costs(thinking, model_calls):
+    """The invariant that matters, on every path.
 
-    Notably one less than the per-turn hook count: the closing model call emits
-    `FinalResponseSchema` and ends the turn without entering `tools`, so the last
-    cycle is a step short. That `- 1` is measured here rather than trusted.
+    A budget one step short is a `GraphRecursionError` fired *after* the answer is
+    composed — the exact user-visible bug this PR fixes — so the derived limit must
+    cover the real cost with slack to spare, never the reverse.
+
+    This is why `base_steps` counts all per-turn hooks instead of subtracting the
+    `tools` step the closing call skips. It skips it only under `ToolStrategy`:
+    with thinking enabled, `FinalResponseSchema` is bound as a `return_direct`
+    tool and the closing call routes through `tools` like any other. Subtracting
+    would be exact for the first and one short for the second.
     """
-    graph = _compiled_graph(_ScriptedModel(responses=[_final_turn()]))
-    per_call = steps_per_model_call(graph)
+    graph = _compiled_graph(thinking=thinking)
+    derived = recursion_limit_for(graph, model_calls)
 
-    measured_for_one = await _measure_super_steps(1)
+    measured = await _measure_super_steps(model_calls, thinking)
 
-    assert base_steps(graph) == measured_for_one - per_call, (
-        f"base_steps()={base_steps(graph)} but a 1-call turn measured {measured_for_one} "
-        f"super-steps against {per_call} per call"
+    assert derived >= measured, (
+        f"derived budget {derived} is below the measured cost {measured} for "
+        f"{model_calls} model call(s) at thinking={thinking}. A turn would die one "
+        f"step from the end, after composing its answer."
     )
+    # Slack is expected, but a whole extra cycle would mean the derivation has
+    # drifted into guesswork rather than counting.
+    assert derived - measured < steps_per_model_call(graph), (
+        f"derived budget {derived} exceeds the measured {measured} by a full model "
+        f"call or more; the derivation is over-counting, not rounding up."
+    )
+
+
+def test_an_unknown_node_inflates_the_budget_and_warns(caplog):
+    """Production must not treat a node it does not understand as free.
+
+    A `.before_tools`, an async-named hook, a renamed core node: anything
+    unrecognised is charged at the per-model-call rate, so the budget errs large,
+    and logged so it gets fixed. Counting it as zero would shrink the budget
+    toward the truncation this module exists to prevent — and unlike
+    `test_every_node_is_classified` below, this holds for stacks that only exist
+    in a deployment, not in CI.
+    """
+
+    class _GraphWithMysteryNode:
+        nodes = ["__start__", "model", "tools", "Some.before_model", "Mystery.before_tools"]
+
+    with caplog.at_level("WARNING"):
+        per_call = steps_per_model_call(_GraphWithMysteryNode())
+
+    # 1 known hook + 2 core + 1 unknown, charged as if it ran every cycle.
+    assert per_call == 4
+    assert "Mystery.before_tools" in caplog.text
+
+
+def test_the_core_cycle_cost_is_counted_not_assumed():
+    """`model` and `tools` are counted from the classification, not hardcoded to 2.
+
+    langchain only adds a `tools` node when the graph has tools, and a rename
+    would land both in `unclassified` — either way an assumed 2 would be a
+    plausible-looking wrong number.
+    """
+
+    class _GraphWithoutTools:
+        nodes = ["__start__", "model", "Some.after_model"]
+
+    assert steps_per_model_call(_GraphWithoutTools()) == 2  # model + 1 hook, no tools
 
 
 def test_every_node_is_classified():
@@ -219,21 +276,6 @@ def test_every_node_is_classified():
     )
     assert buckets["core"], "neither `model` nor `tools` was found — node naming changed"
     assert buckets["per_model_call"], "no per-model-call hooks found — hook naming changed"
-
-
-def test_fifty_steps_was_six_model_calls():
-    """The reported bug, in the unit that makes it obvious.
-
-    Keeps the finding legible: the old default was not "50 of something
-    generous", it was six model calls, which an ordinary two-delegation turn
-    exceeds. If this number ever climbs to something comfortable, the middleware
-    stack got cheaper and the incident is worth re-reading.
-    """
-    graph = _compiled_graph()
-
-    affordable = (50 - base_steps(graph)) // steps_per_model_call(graph)
-
-    assert affordable == 6
 
 
 def test_the_graph_is_compiled_with_the_derived_limit():
@@ -293,3 +335,33 @@ def test_an_empty_budget_falls_back(monkeypatch, raw):
     monkeypatch.setenv(MAX_MODEL_CALLS_PER_TURN_ENV, raw)
 
     assert _resolve_max_model_calls_per_turn() == DEFAULT_MAX_MODEL_CALLS_PER_TURN
+
+
+@pytest.mark.parametrize("raw", ["0", "-1"])
+def test_a_non_positive_budget_is_clamped_rather_than_bricking_every_turn(monkeypatch, caplog, raw):
+    """0 is not a small budget, it is a broken deployment.
+
+    The derived limit would collapse to the per-turn overhead, so every request
+    would exhaust it in its first super-steps and answer "I've been working on
+    this for a while and need to take a break" having done nothing — with nothing
+    in the logs pointing at the env var.
+    """
+    monkeypatch.setenv(MAX_MODEL_CALLS_PER_TURN_ENV, raw)
+
+    with caplog.at_level("WARNING"):
+        resolved = _resolve_max_model_calls_per_turn()
+
+    assert resolved == MIN_MAX_MODEL_CALLS_PER_TURN
+    assert MAX_MODEL_CALLS_PER_TURN_ENV in caplog.text
+
+
+def test_an_implausibly_large_budget_is_honoured_but_flagged(monkeypatch, caplog):
+    """Not clamped — a long budget can be deliberate — but a typo'd 2500 leaves no
+    runaway protection at all, which is worth noticing before it costs money."""
+    monkeypatch.setenv(MAX_MODEL_CALLS_PER_TURN_ENV, "2500")
+
+    with caplog.at_level("WARNING"):
+        resolved = _resolve_max_model_calls_per_turn()
+
+    assert resolved == 2500
+    assert "runaway" in caplog.text.lower()


### PR DESCRIPTION
Extracted from #128 at review request, and rewritten rather than cherry-picked so
it answers the second question too: the multiplier is now derived from the graph
instead of being a constant someone has to remember to update.

## The bug

`MAX_RECURSION_LIMIT` was 50, chosen as though it counted model calls. It counts
LangGraph **super-steps**, and every middleware hook is its own graph node, so one
model call costs a whole lap:

```
SteeringMiddleware.before_model            1
A2ATaskTrackingMiddleware.before_model     2
model                                      3
TodoListMiddleware.after_model             4
_PTCToleranceCodeInterpreterMiddleware...  5
RepeatedToolCallMiddleware.after_model     6
ConditionalHumanInTheLoopMiddleware...     7
tools                                      8
```

So `50` was **six model calls per turn**. The orchestrator spends calls on
`write_todos` bookkeeping and filesystem exploration between delegations, so an
ordinary two-delegation request ("look up X and post it to Slack") ran out. Live
traces showed it completing the request correctly and then having the finished
answer discarded and replaced with the "shall I continue?" prompt.

The multiplier always existed as a fact about the middleware stack. It just was
never written down, so the limit was set at an implied exchange rate of 1.

## The fix

The budget is expressed in the unit people reason about —
`ORCHESTRATOR_MAX_MODEL_CALLS_PER_TURN`, default 25 — and converted per compiled
graph in `app/core/step_budget.py`. `MAX_RECURSION_LIMIT` is gone from
`AgentSettings` entirely; there is nothing left for it to name.

## Can it be derived? Yes

Hook nodes are named `<Middleware>.<hook>`, so how often a node runs is readable
off its name:

| bucket | count | runs |
| --- | --- | --- |
| `.before_model` / `.after_model` | 6 | once per model call |
| `model`, `tools` | 2 | the cycle core |
| `.before_agent` / `.after_agent` | 3 | once per turn |
| `__start__` | 1 | never billed |

Giving `steps_per_model_call = 8`, `base_steps = 3`, and a limit of **203** for 25
model calls. Nothing is hardcoded — the core cost is counted from the
classification too, since langchain only adds a `tools` node when the graph has
tools and a rename would land both in `unclassified`.

Checked against real graph runs rather than asserted, on **both**
structured-output paths:

| model calls | `ToolStrategy` | thinking enabled | derived |
| --- | --- | --- | --- |
| 1 | 10 | 11 | 11 |
| 2 | 18 | 19 | 19 |
| 3 | 26 | 27 | 27 |

Exact for the thinking path, one step generous for `ToolStrategy`. That asymmetry
is deliberate and is the subject of the review round below.

## Why deriving beats a better constant

A literal goes stale the moment a middleware with model hooks is added or
removed, and nothing forces the update. That is the fragility raised in review,
and it is the whole justification.

An earlier version of this description also claimed the constant was *already*
wrong because the PTC middlewares appear and disappear with
`CODE_INTERPRETER_PTC`. **That was false** — see below.

## How it is tested

`tests/test_step_budget.py`, 21 tests. Four do real work; the rest are
configuration.

- **`test_marginal_cost_of_a_model_call_matches_the_derivation`**, parametrized
  over `[None, ThinkingLevel.high]`, runs turns of 1 to 4 model calls, counts
  super-steps, and asserts every marginal equals what was derived from the node
  names. If LangGraph renames a hook or starts running one twice per cycle,
  measurement and derivation diverge and this fails.
- **`test_the_budget_is_never_below_what_a_turn_actually_costs`**, over both paths
  and three turn lengths. This is the invariant that matters: a budget one step
  short is a `GraphRecursionError` fired *after* the answer is composed. It also
  asserts the slack stays under one full cycle, so "round up" cannot drift into
  "guess big".
- **`test_every_node_is_classified`** fails if the compiled graph grows a node
  shape the derivation does not recognise.
- **`test_an_unknown_node_inflates_the_budget_and_warns`** covers the same case at
  *runtime*, which is the one that survives a stack difference between CI and a
  deployment.

## Limitations, stated rather than discovered

- **Node count is an upper bound on a cycle's steps.** A hook that returns early
  still occupies a node; a skipped branch simply does not run. Over-estimating
  gives the model at least the intended number of calls, which is the safe
  direction — under-estimating is the bug being replaced.
- **Unknown nodes are charged at the per-model-call rate**, the most expensive
  assumption, and logged. Counting them as free would shrink the budget toward
  exactly the truncation this fixes.
- **Interrupt and resume are not modelled.** Resuming re-enters nodes, so a turn
  with several HITL approvals costs slightly more than the formula says. At 25
  model calls there is ample headroom, but it is not exact.
- **Assumes one node per super-step.** True for this graph, which has no parallel
  node execution. If that changes, the measured tests above are what catch it.

## What review found

Eight comments, and two were defects in the first commit rather than style
points. Both were found by measuring, and both are fixed:

1. **The PTC justification was factually wrong.**
   `build_code_interpreter_middlewares` unconditionally returns one
   `_PTCToleranceCodeInterpreterMiddleware`; `CODE_INTERPRETER_PTC` changes tool
   exposure inside `eval`, never the node count. Verified by compiling the graph
   both ways — the node sets are identical. The claim had conflated the
   orchestrator's stack with the **general-purpose sub-agent's**, where
   `ToolsetSelectorMiddleware` genuinely is PTC-gated. It appeared in three
   comments, the first commit message and this description; the code comments are
   corrected and staleness alone carries the argument.
2. **`base_steps` was off by one on half the graphs.** It subtracted a step for
   the `tools` node the closing model call skips, which holds only under
   `ToolStrategy`. When `select_response_format` returns `(None, True)` — thinking
   on Anthropic/Bedrock, or Gemini's builtin-tools path — `FinalResponseSchema` is
   bound as a `return_direct` tool and the closing call routes through `tools`
   like any other. Measured at 11/19/27 against a derived 10/18/26: one step
   short, i.e. a `GraphRecursionError` after the answer was composed. The
   subtraction is gone and both paths are now measured. The original test pinned
   `thinking_level=None`, which is how it survived.

Also fixed: `steps_per_model_call` hardcoded the core cost while discarding the
count it had just computed; `ORCHESTRATOR_MAX_MODEL_CALLS_PER_TURN` had no lower
bound, so `0` bricked every turn with no log pointing at the variable; the
`unclassified` guard existed only in tests while production counted unknown nodes
as free. Two efficiency points too — `recursion_limit_for` classified the graph
twice, and `classify_nodes` used `graph.get_graph().nodes`, which runs langgraph's
edge-discovery simulation just to list names (0.00ms vs 14.27ms per twenty calls
against the compiled `Pregel`'s own `nodes` dict).

`test_fifty_steps_was_six_model_calls` is deleted rather than updated. Review
argued it documented rather than protected, and dropping the `- 1` proved the
point immediately by flipping it to 5. Editing the constant would have asserted a
historical fact that is no longer true of the current stack, so the figure lives
in the module docstring instead.

### Still open

- **The legacy warning is half-misleading.** `MAX_RECURSION_LIMIT` still
  configures sub-agents running in this same process — agent-common's
  `dynamic_agent` reads it at default 75 — so an operator who follows the advice
  and unsets it silently changes every sub-agent's bound. `dynamic_agent.py:117`
  also still references the attribute this PR deletes. Needs a wording change here
  plus a follow-up for porting the model-call budget to the three sibling
  packages, which still have the same 50-steps-is-six-calls truncation one layer
  down.
- **Sub-agent graphs inherit the derived limit**, with a fresh budget per `task`
  dispatch, via langgraph's ambient config propagation. Where a sub-agent
  previously inherited 50 super-steps it now inherits ~203, against a leaner stack
  it was not derived from. I have not verified the propagation claim yet; if it
  holds, the nested runaway ceiling rises materially and sub-agent graphs may need
  their own explicit limit. Worth settling before merge.

## Files

- `app/core/step_budget.py` — new. The classification and the conversion.
- `app/core/graph_factory.py` — computes the limit from the graph it just compiled.
- `app/models/config.py` — `MAX_MODEL_CALLS_PER_TURN` replaces `MAX_RECURSION_LIMIT`,
  with a lower clamp and an upper sanity warning; the legacy name logs a warning
  naming the replacement rather than being ignored in silence.
- `tests/test_step_budget.py` — new.
- `tests/test_orchestrator_thinking_integration.py` — two lines. It mocks
  `create_deep_agent`, and `_create_graph` now inspects the graph it gets back, so
  the mock needs an iterable `nodes`. Called out so it does not read as unrelated
  churn.

`844 passed` locally, no gateway or credentials needed.

## Sequencing with #128

#128 carries an earlier version of this fix with the multiplier as a literal. Once
this lands, that needs reverting there — otherwise the next `main` merge conflicts
on `config.py` and two versions of the same fix sit under review at once.

Worth being explicit that this **inverts the merge order**: "extract it" sounds
independent, but #128's real tier depends on this fix. `chains_analyst_then_slack`
is the scenario that surfaced the bug, dying on `GraphRecursionError` at 50. So
this should merge first.

## Checklist
- [x] I have performed a self-review of my code
- [x] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨 — behavioural, and intended: the
      orchestrator stops reading `MAX_RECURSION_LIMIT` and reads
      `ORCHESTRATOR_MAX_MODEL_CALLS_PER_TURN` instead. A deployment setting the old
      name gets a warning and the new default (25 model calls, 203 steps) rather
      than silent truncation at six. Nothing in this repo sets it — checked every
      yaml, template and shell script including
      `example-k8s-deployment/base/orchestrator.yaml` — but the infra repo is worth
      a grep before merge so the warning does not arrive unexplained.
