### PR TITLE
feat(scheduler): recover runs interrupted by a process death

### DIFF
--- a/docs/adr/0007-interrupted-runs-get-one-fresh-attempt.md
+++ b/docs/adr/0007-interrupted-runs-get-one-fresh-attempt.md
@@ -1,0 +1,150 @@
+---
+status: accepted (2026-09-05)
+---
+
+# An interrupted scheduled run gets one fresh attempt, never a resumption
+
+When the process executing a scheduled run dies, the run is abandoned: the agent's trace stops
+mid-flight, the run row is recorded `failed` with `delivered=False`, and nobody tells the user. This
+is not hypothetical — it has happened in production and cost a user their scheduled result. We
+decided that **an interruption is a distinct terminal outcome, not a failure**, that **recovery is a
+fresh attempt of the job rather than a resumption of the interrupted run**, and that the user hears
+about it **only once recovery is exhausted**.
+
+Concretely: `JobRunStatus.INTERRUPTED` is excluded from `consecutive_failures`; recovery is fired by
+a durable `retry_at` marker that any healthy scheduler process claims through the existing
+`FOR UPDATE SKIP LOCKED` path; every run records why it was started (`trigger`: `scheduled`,
+`retry` or `manual`), and only a `scheduled` run's interruption earns the one retry; run liveness
+is a `last_seen_at` heartbeat swept on staleness; and the terminal notice is delivered by
+dispatching an **ephemeral notification-only job** — an A2A message carrying the text and the job's
+push config but no `sub_agent_id`, so the runner delivers it and runs no agent. The notice is
+recorded on the run as owed (`notice_due_at`) and delivered by a later tick, not sent where the loss
+is detected. A `run_now` manual run is marked interrupted but never retried — the user is present,
+and reviving a test press through the claim path would turn it into a scheduled execution.
+
+The unbounded parsing of MCP tool *outputs* is a separate track and deliberately out of scope here.
+
+## Why
+
+- **Not resuming is what keeps side effects out of the recovery path.** The Postgres checkpoint of
+  an interrupted run is forensic only. Because no half-executed run is ever continued, no
+  already-sent email or already-written record can be replayed, and we never have to reason about
+  where the checkpoint boundary sits relative to a tool node. The price — discarding the LLM spend
+  and completed tool calls of the dead attempt, and repeating non-idempotent writes on the new one —
+  is accepted knowingly.
+- **An interruption is evidence about the runtime, not about the job.** Recording it as `failed` let
+  process churn write itself into user state: enough restarts landing on the same job cross
+  `max_failures` (default 3) and auto-disable it with a `paused_reason` blaming the job. It also
+  made the run history unable to answer "did my job fail, or did the process die?" without going
+  outside the product to read logs.
+- **The retry must survive the death that caused it.** The process best placed to notice an
+  interruption is often the one dying, so the retry cannot live in its memory. Putting the marker in
+  the database and letting the existing claim loop pick it up means the retry works precisely when
+  the noticing process does not. `retry_at` is a separate column from `next_run_at` because writing a
+  retry into the schedule would overwrite the field users read, and for `ScheduleKind.ONCE` — where
+  `compute_next_run` returns `None` — it would give a "never repeats" job a next run.
+- **One retry, because whatever killed the first attempt is often still there.** A process failing
+  repeatedly will fail the retry too, and an unbounded retry turns one unhealthy process into a
+  stampede across every scheduled job. One retry bounds the worst case at twice normal traffic.
+- **Liveness needs a heartbeat only for the death nobody is watching.** A dead `agent-runner`
+  already surfaces to the dispatching process within five minutes through the stream itself
+  (`dispatch_streaming` sets `read=300.0` as the inter-event timeout). A dead `console-backend`
+  leaves the stream unobserved, so the run carries `last_seen_at` and the healer sweeps on staleness
+  rather than age. This is also what makes the healer correct when more than one scheduler process
+  is running: `_in_flight` is an in-memory `set[int]`, so a second process has no way to know a run
+  is alive elsewhere, and an age-based bound alone would let it interrupt a healthy long run and
+  fire a duplicate attempt. Runs written before heartbeats existed keep the old age bound, so a
+  rolling deploy does not sweep a run the previous release is still executing.
+- **Only the dispatch can say the agent died.** The a2a SDK wraps every httpx error before it
+  reaches a caller, so classifying by httpx type in the scheduler misses the case this exists for —
+  a runner still restarting when the card cache is empty. `dispatch_streaming` raises one typed
+  `AgentUnreachable` for a transport error, a dropped stream or a gateway 502/503/504, and nothing
+  else is an interruption: a Keycloak or database error on the way to the dispatch is a failure of
+  the run, since nothing was executing.
+- **The retry marker has one consumer and is never cleared by a completion.** Runs of one job can
+  finish out of order — a manual run completing after the healer marked a scheduled one lost — so
+  `complete_job` only writes `retry_at` (COALESCE). The claim consumes it; pausing, resuming or
+  disabling the job clears it, because the user has made a decision about the job and a fresh
+  attempt for an earlier interruption is not it. The retry branch ignores `enabled` (a retired
+  `once` job is disabled too) and trusts `paused_reason`, so every deliberate stop writes one.
+- **One loss, one attempt.** The schedule does not advance until a run completes, so a job whose
+  run was stranded still has a due `next_run_at`; without a guard a restart would re-claim it as an
+  ordinary run *and* the healer would then grant a retry. `claim_due_jobs` skips a job while any
+  of its runs is `running`, which also means runs of one job never overlap. And a run the healer
+  has called interrupted stays interrupted even if its dispatcher turns out to be alive and
+  finishes: the retry is already on its way, and a row flipping back to success would hide that
+  the job ran twice.
+- **Silence is correct when recovery works.** An interruption the system absorbed is not news. Only
+  the terminal case is worth a message, which also keeps the notifier quiet during an incident
+  instead of amplifying it.
+
+## Alternatives considered
+
+- **Resume the interrupted thread from its checkpoint.** Preserves the work already paid for, and
+  the checkpointer plus S3 offload already exist. Rejected because it makes replay safety a
+  permanent design obligation — every side-effecting tool call becomes a question of whether it
+  already fired — and because it needs durable ownership to stop two processes driving one thread.
+- **A recovery policy derived from each job's declared side effects** (read-only jobs resume,
+  writing jobs do not). The most correct option and the most machinery; revisit only if discarded
+  work becomes expensive enough to justify tracking which tools already fired.
+- **A full lease with `owner_id`** instead of a bare `last_seen_at`. Rejected as more than the
+  problem needs; the cost is that nothing fences a resurrected process, and the run carries no
+  record of who owned it.
+- **A Postgres advisory lock per run.** Clock-free and instant, but pins a database connection for
+  the whole run and turns any connection blip into a false interrupt plus a duplicate attempt.
+- **Routing every A2A client's notifications through `console-backend`.** Tempting as a single place
+  for auth, retry and audit. Rejected because delivery is currently decentralised on purpose:
+  `agent-runner`, `orchestrator-agent` and `voice-agent` each own a push sender and the webhook is
+  registered on the A2A task at dispatch, so a `console-backend` death today strands the bookkeeping
+  but **not** the user's answer. Brokering would put the scheduler on the hot path of every result
+  and make it a single point of failure the A2A model does not ask for.
+- **Giving `console-backend` its own narrow delivery path** for scheduler lifecycle facts only,
+  sharing the payload and token contract through `ringier-a2a-sdk`. This was the original decision
+  here, and it was wrong: `scheduler_engine._build_message_args` already carries a comment saying
+  why, written when notification-only watches were designed — *"delivery is the push sender's job,
+  and the payload is an A2A Task envelope that the delivery channels normalise. Posting it from here
+  would duplicate that contract across three receivers."* A second producer would also have needed a
+  new `scheduler_status` case, or a safe default, in each of the Slack, Google Chat and email
+  adapters. The ephemeral dispatch needs none: the notice arrives in the envelope they already
+  normalise.
+- **Not notifying at all when the runner is unreachable.** The objection to the ephemeral dispatch is
+  that it needs the very component whose death is being reported. In practice the runner is not gone
+  — it restarts in seconds, the retry is a minute behind the interruption, and the notify dispatch is
+  trivial where the failed job was not: no tools, no accumulated context, no sandbox, so it survives
+  the memory pressure that killed the job. And because the notice is owed rather than sent, an agent
+  that is briefly absent costs nothing: the debt is simply carried to a later tick. Only an outage
+  outlasting the give-up bound loses the notice, which a direct path would have lost immediately.
+
+## Consequences
+
+- `scheduled_job_runs` gains `last_seen_at`, `trigger`, `notice_due_at` and a fourth terminal
+  status (migrations 091/092); `scheduled_jobs` gains `retry_at`. Every consumer that branches on
+  run status — the console UI and the Slack, Google Chat and email adapters — needs an
+  `interrupted` case or a safe default render; the console's run badge has both.
+- The number of processes that deliver to a channel stays at three. `console-backend` gains no
+  outbound capability, and the client adapters need no new case.
+- The notice must stay outside the run machinery it reports on: it records no run and uses a short
+  timeout because nothing is being computed. A notify dispatch that created a run row would be swept
+  by the healer when it went stale, marked interrupted, and earn the job another retry — a loop
+  assembled out of the recovery mechanism itself.
+- The notice is an **obligation recorded on the run** (`notice_due_at`), not a call made where the
+  loss is detected. Delivering it inline would aim at an agent that is, by construction, mid-restart:
+  the failure lands at connect, where no read timeout helps because nothing is listening. It would
+  also miss half the cases — a run interrupted by the healer is swept in bulk, and the process that
+  owed the notice may be the one that went away. A marker is delivered by whoever ticks next, after a
+  delay that lets the agent come back. Unlike the job's retry it *is* re-attempted, because re-POSTing
+  one sentence is not an agent turn; it is still bounded, and abandoned once the news is stale.
+- A notice is also abandoned when **a later run of the same job has completed**, because delivering
+  it then would contradict newer news the user already has — a fresh result, followed by a message
+  saying the job could not run. Supersession is keyed on a later run *completing* rather than on the
+  schedule coming round: if the next run is lost too, nothing has superseded anything and the notice
+  is still owed. Ordering by `(completed_at, id)` means an outage that costs a job several runs
+  produces one message rather than a burst.
+- Three kinds of run now exist, told apart by the `trigger` recorded on the row rather than by a
+  parameter only one code path receives: a scheduled run's interruption earns a retry, a retry's
+  earns the user a notice, a manual run's earns neither.
+- A finished run that cannot be recorded is closed with a minimal write (`close_run_minimally`)
+  rather than left for the healer: a run left `running` after its result was delivered would be
+  swept, called interrupted, and re-executed.
+- The healer stops being a periodic backstop for a single scheduler process and becomes the
+  mechanism that keeps run liveness correct when several run concurrently.

--- a/packages/console-backend/AGENTS.md
+++ b/packages/console-backend/AGENTS.md
@@ -632,6 +632,61 @@ The activation service manages the lifecycle:
 - `upsert_locked()` — Called by config version approval workflow
 - `list_for_agent()` — All activations for a sub-agent (with update-available status)
 
+### Scheduled Run Vocabulary and Interruption (services/scheduler_engine.py)
+
+The reasoning lives in `docs/adr/0007-interrupted-runs-get-one-fresh-attempt.md`; this section is
+the vocabulary and the contract the code implements (migrations 091/092, `scheduler_engine.py`,
+`scheduled_job_repository.py`, `utils/a2a_dispatch.py`).
+
+A **job** is the user's standing instruction (`scheduled_jobs`) — a schedule plus a prompt. A
+**run** is one recorded execution of it (`scheduled_job_runs`), created at dispatch and closed by
+`_finalize`. Runs of the same job are independent **attempts**: nothing is carried between them, and
+they never overlap — `claim_due_jobs` skips a job while any of its runs is still `running`.
+
+Every run records a **trigger** (`RunTrigger`): `scheduled` for an ordinary occurrence, `retry` for
+the one fresh attempt an interruption earns, `manual` for a user's run-now. The trigger is decided
+where the run is created — by the claim (which returns it as `ClaimedJob.trigger`) or by the run-now
+route — and the healer reads it off the row, so both paths that notice an interruption agree on
+what it is worth.
+
+An **interrupted run** (`JobRunStatus.INTERRUPTED`) is one that ended because the process executing
+it died. It is *not* a failure: `complete_job` leaves `consecutive_failures` untouched, so process
+churn can never trip `max_failures`. Only `dispatch_streaming` can say the agent died — it raises
+`AgentUnreachable` for a transport error, a dropped or timed-out stream, or a 502/503/504, looking
+through the a2a SDK's wrapping — and `_dispatch_job` classifies on that exception alone. A Keycloak
+or database error on the way to the dispatch is a failure of the run.
+
+What an interruption earns depends on the trigger:
+
+- `scheduled` → the job gets `retry_at` (a **retry marker**, `RETRY_DELAY_SECONDS` out). It is a
+  separate column from `next_run_at` so the schedule users read is never rewritten, and it is the
+  claim loop's second wake-up reason. `complete_job` only ever *writes* it (COALESCE), because runs
+  of one job can complete out of order; the claim consumes it, and pause/resume/PATCH-disable clear
+  it. The retry branch ignores `enabled` (a retired `once` job is disabled too) and trusts
+  `paused_reason IS NULL`, so every deliberate stop — pause, auto-pause, PATCH `enabled=false`,
+  an unresolvable timezone — writes a reason.
+- `retry` → recovery is exhausted. The run is marked as owing the user a notice (`notice_due_at`,
+  written in the same statement as the run's outcome) and no further attempt is scheduled.
+- `manual` → nothing. The user is present and can press again.
+
+**Liveness.** A dead `agent-runner` is seen by the dispatcher through the stream (`read=300.0` is
+the inter-event timeout). A dead `console-backend` is seen by the healer: the dispatcher heartbeats
+`last_seen_at` every `HEARTBEAT_INTERVAL_SECONDS`, and `interrupt_stale_runs` sweeps on staleness
+(`STALE_RUN_AFTER_SECONDS`), never on age, so a slow run is never shot and the healer stays correct
+with several scheduler processes. A run with *no* heartbeat was written by the previous release and
+may still be executing there during a rolling deploy; it keeps the old age bound
+(`HEARTBEATLESS_RUN_AFTER_SECONDS`). `complete_run` only finalises a run still `running`, so a run the
+healer already called interrupted stays interrupted if its dispatcher turns out to be alive; if
+`complete_run` itself fails, `close_run_minimally` still closes the row, because a finished run left
+`running` would be swept and re-executed.
+
+**The user is told only when recovery is exhausted**, via `_notify_recovery_exhausted`: an
+ephemeral notification-only A2A dispatch (text plus the job's push config, no `sub_agent_id`, no
+run row) that agent-runner delivers while running no agent. Result delivery otherwise stays with
+the executing agent — do not add a fourth deliverer. Notices are owed, not sent, where the loss is
+detected; `_deliver_due_notices` claims them on a later tick, retries a failed delivery, and abandons
+one that is older than `NOTICE_GIVE_UP_AFTER_SECONDS` or superseded by a later completed run.
+
 ## Important Notes
 
 - Never bypass the repository pattern for data mutations

--- a/packages/console-backend/console_backend/models/delivery_channel.py
+++ b/packages/console-backend/console_backend/models/delivery_channel.py
@@ -6,6 +6,8 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 MessageFormatting = Literal["markdown", "slack", "google-chat", "plain"]
+#: What a channel renders when it declares no formatting of its own.
+DEFAULT_MESSAGE_FORMATTING: MessageFormatting = "markdown"
 
 _FORMATTING_DESCRIPTION = (
     "How this channel renders delivered text. Nothing rewrites an agent's output on the "
@@ -70,7 +72,7 @@ class DeliveryChannelResponse(BaseModel):
     description: str | None = None
     webhook_url: str
     message_formatting: MessageFormatting = Field(
-        default="markdown",
+        default=DEFAULT_MESSAGE_FORMATTING,
         description=_FORMATTING_DESCRIPTION,
     )
     client_id: str = Field(description="Keycloak client ID of the A2A service that registered this channel.")

--- a/packages/console-backend/console_backend/models/scheduled_job.py
+++ b/packages/console-backend/console_backend/models/scheduled_job.py
@@ -36,6 +36,24 @@ class JobRunStatus(str, Enum):
     SUCCESS = "success"
     FAILED = "failed"
     CONDITION_NOT_MET = "condition_not_met"  # Watch check ran but the condition was false
+    #: The process executing the run died — the agent was killed mid-run, or this
+    #: scheduler restarted and dropped the run's stream. Distinct from FAILED
+    #: because a failure is evidence about the job while an interruption is
+    #: evidence about the runtime: it does not count toward ``max_failures``, and
+    #: it earns one fresh attempt. See
+    #: docs/adr/0007-interrupted-runs-get-one-fresh-attempt.md.
+    INTERRUPTED = "interrupted"
+
+
+class RunTrigger(str, Enum):
+    """Why a run was started. Decides what its interruption is worth: a SCHEDULED
+    run earns one RETRY, a RETRY earns the user a notice, a MANUAL run earns
+    neither — the user is present and can press again. See
+    docs/adr/0007-interrupted-runs-get-one-fresh-attempt.md."""
+
+    SCHEDULED = "scheduled"
+    RETRY = "retry"
+    MANUAL = "manual"
 
 
 class ConditionEvaluation(BaseModel):
@@ -85,6 +103,16 @@ class ScheduledJobRun(BaseModel):
     conversation_id: str | None = None
     delivered: bool
     condition_evaluation: ConditionEvaluation | None = None
+    #: Last heartbeat from the process dispatching this run. The healer sweeps on
+    #: staleness of this rather than on age, so a slow-but-healthy run is never
+    #: mistaken for an abandoned one. None on rows written before recovery existed.
+    last_seen_at: datetime | None = None
+    #: Why this run was started; see RunTrigger.
+    trigger: RunTrigger = RunTrigger.SCHEDULED
+    #: When the user is owed the notice that this run was lost for good. Set only on an
+    #: interrupted run that was already the retry; cleared once the notice is delivered
+    #: or abandoned.
+    notice_due_at: datetime | None = None
 
 
 class RunNowResponse(BaseModel):
@@ -112,6 +140,10 @@ class ScheduledJob(BaseModel):
     run_at: datetime | None = None
     next_run_at: datetime
     last_run_at: datetime | None = None
+    #: When a fresh attempt is owed after an interrupted run. A second wake-up
+    #: reason for the claim loop, kept out of next_run_at so the schedule users
+    #: read is never rewritten by a retry.
+    retry_at: datetime | None = None
     prompt: str | None = None
     notification_message: str | None = None
     # Watch fields

--- a/packages/console-backend/console_backend/repositories/scheduled_job_repository.py
+++ b/packages/console-backend/console_backend/repositories/scheduled_job_repository.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -14,6 +15,7 @@ from ..models.scheduled_job import (
     ConditionEvaluation,
     JobRunStatus,
     JobType,
+    RunTrigger,
     ScheduledJob,
     ScheduledJobRun,
     ScheduleKind,
@@ -40,6 +42,7 @@ def _row_to_scheduled_job(row: Any) -> ScheduledJob:
         run_at=row["run_at"],
         next_run_at=row["next_run_at"],
         last_run_at=row["last_run_at"],
+        retry_at=row.get("retry_at"),
         prompt=row.get("prompt"),
         notification_message=row.get("notification_message"),
         check_tool=row["check_tool"],
@@ -74,7 +77,22 @@ def _row_to_run(row: Any) -> ScheduledJobRun:
         conversation_id=row.get("conversation_id"),
         delivered=row["delivered"],
         condition_evaluation=row.get("condition_evaluation"),
+        last_seen_at=row.get("last_seen_at"),
+        trigger=RunTrigger(row.get("trigger", RunTrigger.SCHEDULED.value)),
+        notice_due_at=row.get("notice_due_at"),
     )
+
+
+@dataclass(frozen=True)
+class ClaimedJob:
+    """A job handed to a scheduler by ``claim_due_jobs`` and why it was due.
+
+    The trigger is decided by the claim itself rather than inferred afterwards, so the
+    caller never depends on what the row looked like before the marker was consumed.
+    """
+
+    job: ScheduledJob
+    trigger: RunTrigger
 
 
 def compute_next_run(
@@ -155,23 +173,56 @@ class ScheduledJobRepository(AuditedRepository):
         )
         return [_row_to_scheduled_job(r) for r in result.mappings().all()]
 
-    async def claim_due_jobs(self, db: AsyncSession, limit: int = 10) -> list[ScheduledJob]:
+    async def claim_due_jobs(self, db: AsyncSession, limit: int = 10) -> list[ClaimedJob]:
         """Claim up to *limit* due jobs using SELECT … FOR UPDATE SKIP LOCKED.
 
         Marks each claimed job as claimed by setting last_run_at = NOW() to prevent
         double-processing in a multi-instance deployment.  The caller is responsible
         for updating next_run_at once execution completes.
+
+        Two wake-up reasons, and the returned trigger says which one fired. The
+        schedule (``next_run_at``) is the ordinary one. A due ``retry_at`` is the
+        second: the fresh attempt an interrupted run earns, put in the database
+        rather than in the noticing process because the process best placed to
+        notice an interruption is often the one dying. Whichever scheduler ticks
+        next picks it up.
+
+        The retry branch does not require ``enabled``: a ``once`` job is retired by
+        ``complete_job`` the moment its occurrence is recorded, so requiring
+        ``enabled`` would discard the very attempt the interruption earned.
+        ``paused_reason IS NULL`` is what keeps that from resurrecting a job somebody
+        stopped on purpose — every deliberate stop writes a reason, one-shot
+        retirement does not.
+
+        A job with a run still ``running`` is not claimable on either branch. The
+        schedule does not advance until a run completes, so without this a process
+        restart would re-claim a job through a stale ``next_run_at`` while its
+        stranded run waits for the healer, and the interruption would then earn a
+        retry on top — two extra attempts for one loss. A stranded run is released
+        by the healer within about a minute; a healthy one keeps the job for as long
+        as it runs, so runs of the same job never overlap.
+
+        ``retry_at`` is cleared on claim, so an attempt is handed out once even if
+        several schedulers tick together.
         """
         now = datetime.now(timezone.utc)
         result = await db.execute(
             text("""
-                SELECT * FROM scheduled_jobs
-                WHERE deleted_at IS NULL
-                  AND enabled = TRUE
-                  AND next_run_at <= :now
-                ORDER BY next_run_at ASC
+                SELECT j.*,
+                       (j.retry_at IS NOT NULL AND j.retry_at <= :now) AS via_retry
+                FROM scheduled_jobs j
+                WHERE j.deleted_at IS NULL
+                  AND (
+                        (j.enabled = TRUE AND j.next_run_at <= :now)
+                     OR (j.retry_at IS NOT NULL AND j.retry_at <= :now AND j.paused_reason IS NULL)
+                  )
+                  AND NOT EXISTS (
+                        SELECT 1 FROM scheduled_job_runs r
+                        WHERE r.job_id = j.id AND r.status = 'running'
+                  )
+                ORDER BY COALESCE(j.retry_at, j.next_run_at) ASC
                 LIMIT :limit
-                FOR UPDATE SKIP LOCKED
+                FOR UPDATE OF j SKIP LOCKED
             """),
             {"now": now, "limit": limit},
         )
@@ -179,72 +230,68 @@ class ScheduledJobRepository(AuditedRepository):
         if not rows:
             return []
 
-        # Stamp last_run_at so other workers skip these rows during execution
+        # Stamp last_run_at so other workers skip these rows during execution, and
+        # consume the retry marker in the same statement — the attempt is now this
+        # process's to make, and leaving it set would hand it out again next tick.
         ids = [r["id"] for r in rows]
         await db.execute(
-            text("UPDATE scheduled_jobs SET last_run_at = :now WHERE id = ANY(:ids)"),
+            text("UPDATE scheduled_jobs SET last_run_at = :now, retry_at = NULL WHERE id = ANY(:ids)"),
             {"now": now, "ids": ids},
         )
-        return [_row_to_scheduled_job(r) for r in rows]
+        return [
+            ClaimedJob(
+                job=_row_to_scheduled_job(r),
+                trigger=RunTrigger.RETRY if r["via_retry"] else RunTrigger.SCHEDULED,
+            )
+            for r in rows
+        ]
 
     async def complete_job(
         self,
         db: AsyncSession,
         job_id: int,
-        success: bool,
+        status: JobRunStatus,
         next_run_at: datetime | None,
         last_check_result: dict[str, Any] | None = None,
         paused_reason: str | None = None,
+        retry_at: datetime | None = None,
     ) -> None:
-        """Update a job after execution: advance schedule, track failures, auto-pause on threshold."""
+        """Update a job after execution: advance schedule, track failures, auto-pause on threshold.
+
+        Takes the run's status rather than a success flag because there are three
+        outcomes, not two. Only a FAILED run moves ``consecutive_failures`` up and
+        only a successful one resets it; an INTERRUPTED run leaves it alone in both
+        directions. See docs/adr/0007-interrupted-runs-get-one-fresh-attempt.md.
+
+        *retry_at* schedules the one fresh attempt an interruption earns. It is
+        only ever written, never cleared here: runs of one job can complete out of
+        order — a manual run finishing after the healer marked a scheduled one lost —
+        and a completion that wiped the marker would silently cancel an attempt that
+        was earned. The claim consumes it; pause and resume clear it.
+        """
         now = datetime.now(timezone.utc)
+        failed = status == JobRunStatus.FAILED
+        success = status in (JobRunStatus.SUCCESS, JobRunStatus.CONDITION_NOT_MET)
 
-        if success:
-            fields: dict[str, Any] = {
-                "consecutive_failures": 0,
-                "last_run_at": now,
-                "updated_at": now,
-            }
-        else:
-            fields = {
-                "consecutive_failures": text("consecutive_failures + 1"),
-                "last_run_at": now,
-                "updated_at": now,
-            }
-
-        if last_check_result is not None:
-            fields["last_check_result"] = json.dumps(last_check_result)
-
-        if next_run_at is not None:
-            fields["next_run_at"] = next_run_at
-            fields["enabled"] = True
-        else:
-            # schedule_kind='once' or max failures reached — disable
-            fields["enabled"] = False
-
-        if paused_reason is not None:
-            fields["paused_reason"] = paused_reason
-            fields["enabled"] = False
-
-        # Check if max_failures threshold is crossed (done via raw SQL to avoid a
-        # round-trip fetch)
         await db.execute(
             text("""
                 UPDATE scheduled_jobs
                 SET
                     consecutive_failures = CASE
+                        WHEN :failed  THEN consecutive_failures + 1
                         WHEN :success THEN 0
-                        ELSE consecutive_failures + 1
+                        ELSE consecutive_failures
                     END,
                     last_run_at          = :last_run_at,
                     next_run_at          = COALESCE(:next_run_at, next_run_at),
+                    retry_at             = COALESCE(CAST(:retry_at AS timestamptz), retry_at),
                     enabled              = CASE
-                        WHEN :next_run_at IS NULL          THEN FALSE
-                        WHEN NOT :success AND (consecutive_failures + 1) >= max_failures THEN FALSE
+                        WHEN :next_run_at IS NULL                                        THEN FALSE
+                        WHEN :failed AND (consecutive_failures + 1) >= max_failures      THEN FALSE
                         ELSE enabled
                     END,
                     paused_reason        = CASE
-                        WHEN NOT :success AND (consecutive_failures + 1) >= max_failures
+                        WHEN :failed AND (consecutive_failures + 1) >= max_failures
                             THEN 'Auto-paused after ' || max_failures || ' consecutive failures'
                         WHEN CAST(:paused_reason AS text) IS NOT NULL THEN CAST(:paused_reason AS text)
                         ELSE paused_reason
@@ -255,9 +302,11 @@ class ScheduledJobRepository(AuditedRepository):
             """),
             {
                 "job_id": job_id,
+                "failed": failed,
                 "success": success,
                 "last_run_at": now,
                 "next_run_at": next_run_at,
+                "retry_at": retry_at,
                 "paused_reason": paused_reason,
                 # `is not None`, not truthiness: `{}` is a real response (a tool with no
                 # content returns one), and mapping it to NULL makes the COALESCE above
@@ -293,19 +342,189 @@ class ScheduledJobRepository(AuditedRepository):
         self,
         db: AsyncSession,
         job_id: int,
+        trigger: RunTrigger = RunTrigger.SCHEDULED,
     ) -> int:
-        """Insert a new 'running' run record. Returns run ID."""
+        """Insert a new 'running' run record. Returns run ID.
+
+        *trigger* is recorded on the row because the healer, which may run in a
+        process that never saw this dispatch, decides from it what the run's
+        interruption is worth. ``last_seen_at`` starts at insert time so a run is
+        never stale before its first heartbeat.
+        """
         result = await db.execute(
             text("""
-                INSERT INTO scheduled_job_runs (job_id, started_at, status)
-                VALUES (:job_id, NOW(), 'running')
+                INSERT INTO scheduled_job_runs (job_id, started_at, status, last_seen_at, trigger)
+                VALUES (:job_id, NOW(), 'running', NOW(), :trigger)
                 RETURNING id
             """),
-            {"job_id": job_id},
+            {"job_id": job_id, "trigger": trigger.value},
         )
         row = result.mappings().first()
         assert row is not None
         return row["id"]
+
+    async def touch_run(self, db: AsyncSession, run_id: int) -> None:
+        """Record that the process dispatching *run_id* is still alive.
+
+        The healer sweeps on staleness of this timestamp rather than on the run's
+        age, which is what lets a legitimately slow run take as long as it needs
+        while an abandoned one is caught in about a minute.
+        """
+        await db.execute(
+            text("UPDATE scheduled_job_runs SET last_seen_at = NOW() WHERE id = :run_id"),
+            {"run_id": run_id},
+        )
+
+    async def claim_due_notices(
+        self,
+        db: AsyncSession,
+        next_attempt_at: datetime,
+        give_up_before: datetime,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        """Claim owed notices that are due; return ``{run_id, job_id}`` for each.
+
+        Claiming pushes ``notice_due_at`` to *next_attempt_at* in the same statement, so
+        a notice is attempted once per round even with several schedulers ticking, and a
+        failed attempt is naturally retried later without any attempt counter. The caller
+        clears the marker on success.
+
+        Two kinds of notice are abandoned rather than claimed, in the same statement.
+
+        One whose run completed before *give_up_before*: past some age the news has
+        stopped being useful, and a notifier still trying through a long outage is how one
+        unhealthy process becomes a stampede.
+
+        One the job has already moved past — any later run of the same job has completed.
+        Delivering it then would contradict newer news the user already has, arriving
+        after a fresh result to say the job could not run. Supersession is keyed on a
+        later run having *completed*, not on the schedule having come round: if the next
+        run is lost too, nothing has superseded anything and the notice is still owed.
+        Ordering by ``(completed_at, id)`` also means that when an outage costs a job
+        several runs, only the newest owed notice survives — one message, not a burst.
+        """
+        # Data-modifying CTEs all see the snapshot from before the statement, so `due`
+        # excludes `abandoned` explicitly rather than relying on the NULL it just wrote.
+        result = await db.execute(
+            text("""
+                WITH abandoned AS (
+                    UPDATE scheduled_job_runs r
+                    SET notice_due_at = NULL
+                    WHERE r.notice_due_at IS NOT NULL
+                      AND (
+                            r.completed_at <= :give_up_before
+                         OR EXISTS (
+                                SELECT 1 FROM scheduled_job_runs newer
+                                WHERE newer.job_id = r.job_id
+                                  AND newer.completed_at IS NOT NULL
+                                  AND (newer.completed_at, newer.id) > (r.completed_at, r.id)
+                            )
+                      )
+                    RETURNING r.id, r.completed_at <= :give_up_before AS too_old
+                ), due AS (
+                    SELECT id
+                    FROM scheduled_job_runs
+                    WHERE notice_due_at IS NOT NULL
+                      AND notice_due_at <= NOW()
+                      AND id NOT IN (SELECT id FROM abandoned)
+                    ORDER BY notice_due_at
+                    LIMIT :limit
+                    FOR UPDATE SKIP LOCKED
+                ), claimed AS (
+                    UPDATE scheduled_job_runs r
+                    SET notice_due_at = :next_attempt_at
+                    FROM due
+                    WHERE r.id = due.id
+                    RETURNING r.id, r.job_id
+                )
+                SELECT 'abandoned' AS outcome, id, NULL::bigint AS job_id, too_old FROM abandoned
+                UNION ALL
+                SELECT 'claimed', id, job_id, NULL FROM claimed
+            """),
+            {"give_up_before": give_up_before, "limit": limit, "next_attempt_at": next_attempt_at},
+        )
+        claimed: list[dict[str, Any]] = []
+        for row in result.mappings().all():
+            if row["outcome"] == "claimed":
+                claimed.append({"run_id": row["id"], "job_id": row["job_id"]})
+            else:
+                logger.warning(
+                    "Run %s: dropped the recovery notice (%s)",
+                    row["id"],
+                    "too old to be useful" if row["too_old"] else "superseded by a later run",
+                )
+        return claimed
+
+    async def clear_notice(self, db: AsyncSession, run_id: int) -> None:
+        """Mark the notice for *run_id* as no longer owed."""
+        await db.execute(
+            text("UPDATE scheduled_job_runs SET notice_due_at = NULL WHERE id = :run_id"),
+            {"run_id": run_id},
+        )
+
+    async def interrupt_stale_runs(
+        self,
+        db: AsyncSession,
+        stale_after_seconds: int,
+        exclude_run_ids: list[int],
+        retry_at: datetime,
+        notice_due_at: datetime,
+        heartbeatless_after_seconds: int,
+    ) -> list[int]:
+        """Mark runs whose dispatcher stopped reporting as interrupted; return their ids.
+
+        A run is stale when its heartbeat (``last_seen_at``) is older than
+        *stale_after_seconds*. A run with no heartbeat at all was written by a process
+        on a release without one and may still be executing there, so it is judged by
+        age against the far longer *heartbeatless_after_seconds* instead — the
+        pre-heartbeat bound this replaced. Runs in *exclude_run_ids* are this
+        process's own and are never touched.
+
+        Each interrupted ``scheduled`` run earns its job one fresh attempt at
+        *retry_at*, unless the job carries a ``paused_reason`` — those were stopped on
+        purpose and are not quietly resumed. A stale ``retry`` run has exhausted
+        recovery, so it is marked as owing the user a notice at *notice_due_at*
+        instead. A ``manual`` run earns neither: the user was present.
+        """
+        result = await db.execute(
+            text("""
+                WITH stale AS (
+                    UPDATE scheduled_job_runs
+                    SET status        = 'interrupted',
+                        completed_at  = NOW(),
+                        error_message = 'The process running this job stopped before it finished',
+                        notice_due_at = CASE WHEN trigger = 'retry' THEN :notice_due_at ELSE notice_due_at END
+                    WHERE status = 'running'
+                      AND (
+                            (last_seen_at IS NOT NULL
+                             AND last_seen_at < NOW() - make_interval(secs => :stale_after))
+                         OR (last_seen_at IS NULL
+                             AND started_at < NOW() - make_interval(secs => :heartbeatless_after))
+                      )
+                      AND NOT (id = ANY(:exclude))
+                    RETURNING id, job_id, trigger
+                ), retried AS (
+                    UPDATE scheduled_jobs j
+                    SET retry_at   = :retry_at,
+                        updated_at = NOW()
+                    FROM stale
+                    WHERE j.id = stale.job_id
+                      AND stale.trigger = 'scheduled'
+                      AND j.deleted_at IS NULL
+                      AND j.paused_reason IS NULL
+                    RETURNING j.id
+                )
+                SELECT id FROM stale
+            """),
+            {
+                "stale_after": stale_after_seconds,
+                "heartbeatless_after": heartbeatless_after_seconds,
+                "exclude": exclude_run_ids,
+                "retry_at": retry_at,
+                "notice_due_at": notice_due_at,
+            },
+        )
+        return [r["id"] for r in result.mappings().all()]
 
     async def complete_run(
         self,
@@ -317,9 +536,21 @@ class ScheduledJobRepository(AuditedRepository):
         conversation_id: str | None = None,
         delivered: bool = False,
         condition_evaluation: ConditionEvaluation | None = None,
-    ) -> None:
-        """Finalise a run record with execution outcome."""
-        await db.execute(
+        notice_due_at: datetime | None = None,
+    ) -> bool:
+        """Finalise a run record with execution outcome. Returns whether a row changed.
+
+        Only a run still ``running`` is finalised. A run the healer has already called
+        interrupted stays interrupted even if its dispatcher turns out to be alive and
+        finishes: the retry it earned is already on its way, and a row flipping back to
+        success would hide that the job ran twice.
+
+        *notice_due_at* records, in the same write, that the user is owed the notice
+        that this run was lost for good. Same statement on purpose: the process
+        recording an interruption may be the one dying, and a run that is interrupted
+        but owes nothing would leave the user untold.
+        """
+        result = await db.execute(
             text("""
                 UPDATE scheduled_job_runs
                 SET
@@ -329,8 +560,10 @@ class ScheduledJobRepository(AuditedRepository):
                     error_message    = :error_message,
                     conversation_id  = :conversation_id,
                     delivered        = :delivered,
-                    condition_evaluation = :condition_evaluation
+                    condition_evaluation = :condition_evaluation,
+                    notice_due_at    = COALESCE(CAST(:notice_due_at AS timestamptz), notice_due_at)
                 WHERE id = :run_id
+                  AND status = 'running'
             """),
             {
                 "run_id": run_id,
@@ -346,7 +579,33 @@ class ScheduledJobRepository(AuditedRepository):
                     if condition_evaluation is not None
                     else None
                 ),
+                "notice_due_at": notice_due_at,
             },
+        )
+        return result.rowcount > 0
+
+    async def close_run_minimally(
+        self,
+        db: AsyncSession,
+        run_id: int,
+        status: JobRunStatus,
+        error_message: str | None,
+    ) -> None:
+        """Record only that *run_id* ended, touching no column added since the run table was created.
+
+        The fallback for when ``complete_run`` fails. The outage that shaped ``_finalize``
+        was exactly that — a write failing on a column the deployed schema did not have —
+        and a run left ``running`` after it has finished is no longer harmless: the
+        healer sweeps it, calls it interrupted, and re-executes a job whose result the
+        user already has.
+        """
+        await db.execute(
+            text("""
+                UPDATE scheduled_job_runs
+                SET completed_at = NOW(), status = :status, error_message = :error_message
+                WHERE id = :run_id AND status = 'running'
+            """),
+            {"run_id": run_id, "status": status.value, "error_message": error_message},
         )
 
     async def get_run(

--- a/packages/console-backend/console_backend/routers/scheduler_router.py
+++ b/packages/console-backend/console_backend/routers/scheduler_router.py
@@ -25,6 +25,7 @@ from ..models.scheduled_job import (
     ValidateArgsExprRequest,
     ValidateArgsExprResponse,
     RunNowResponse,
+    RunTrigger,
     ScheduledJob,
     ScheduledJobCreate,
     ScheduledJobDraft,
@@ -1023,7 +1024,9 @@ async def run_job_now(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
 
     engine: SchedulerEngine = request.app.state.scheduler_engine
-    run_id: int = await engine._repo.create_run(db, job_id)
+    # Recorded as MANUAL so that, should it be interrupted, neither _finalize nor the
+    # healer treats a test press as a scheduled occurrence owed a retry.
+    run_id: int = await engine._repo.create_run(db, job_id, trigger=RunTrigger.MANUAL)
     await db.commit()
     background_tasks.add_task(engine.run_job_now, job, run_id)
     return RunNowResponse(job_id=job_id, run_id=run_id)

--- a/packages/console-backend/console_backend/services/scheduler_engine.py
+++ b/packages/console-backend/console_backend/services/scheduler_engine.py
@@ -12,7 +12,7 @@ It owns:
 import asyncio
 import json
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import httpx
@@ -24,23 +24,62 @@ from ..repositories.model_defaults_repository import ModelDefaultsRepository
 from .llm_gateway import gateway_chat
 from .spend_attribution import SERVICE_SCHEDULER, billing_subject
 from .watch_evaluator import WatchEvaluator, WatchOutcome
-from ..models.scheduled_job import ConditionEvaluation, JobRunStatus, JobType, ScheduledJob
+from ..models.delivery_channel import DEFAULT_MESSAGE_FORMATTING
+from ..models.scheduled_job import ConditionEvaluation, JobRunStatus, JobType, RunTrigger, ScheduledJob
 from ..repositories.delivery_channel_repository import DeliveryChannelRepository
 from ..repositories.scheduled_job_repository import ScheduledJobRepository, compute_next_run
 from ..services.scheduler_token_service import SchedulerTokenService
 from ..services.socket_notification_manager import SocketNotificationManager
-from ..utils.a2a_dispatch import dispatch_streaming
+from ..utils.a2a_dispatch import AgentUnreachable, dispatch_streaming
 
 logger = logging.getLogger(__name__)
 
-# How long a run may sit in 'running' before the healer calls it interrupted.
+# How long a run may go without a heartbeat before the healer calls it interrupted.
 #
-# Generous on purpose. The healer now sweeps on every tick, so this bound is the only
-# thing standing between a legitimately slow dispatch and a run record that says it
-# failed while the agent is still working. Runs this process started are excluded
-# outright (_in_flight), so the window only has to cover dispatches this process cannot
-# see: another instance's, or a crashed predecessor's.
-STUCK_RUN_THRESHOLD = "30 minutes"
+# The dispatching process refreshes last_seen_at every HEARTBEAT_INTERVAL_SECONDS for as
+# long as it holds the run's stream, so this is a miss count, not a guess about how long
+# a job should take: a legitimately slow run keeps reporting and is never swept, however
+# many hours it takes. Three missed beats is the tolerance for a GC pause, a slow query
+# or a brief database blip.
+#
+# This replaced an age-based bound of 30 minutes, which could only ever be a compromise
+# between catching a strand quickly and not shooting a healthy long run. Staleness has no
+# such tension, which is also what makes the healer correct with more than one scheduler
+# process: _in_flight is only the local view, so age alone cannot tell another process's
+# healthy run from an abandoned one.
+HEARTBEAT_INTERVAL_SECONDS = 20
+STALE_RUN_AFTER_SECONDS = 3 * HEARTBEAT_INTERVAL_SECONDS
+
+# The bound for runs that carry no heartbeat at all: rows written by a process on the
+# release before heartbeats existed, which may still be executing them during a rolling
+# deploy. Judging those by the heartbeat window would sweep a healthy run and fire a
+# duplicate, so they keep the age-based bound they were written under.
+HEARTBEATLESS_RUN_AFTER_SECONDS = 30 * 60
+
+# How long after an interruption the fresh attempt becomes claimable. Long enough that a
+# runner still restarting is not immediately handed the same work, short enough that a
+# scheduled result is not meaningfully late.
+RETRY_DELAY_SECONDS = 60
+
+# Read timeout for the ephemeral notification-only dispatch. Nothing is computed on the
+# other side, so the long inter-event timeout that covers a working agent would only make
+# an unreachable runner take five minutes to say so.
+NOTIFY_TIMEOUT_SECONDS = 20.0
+
+# When the notice that a run was lost becomes deliverable, and how often it is retried.
+#
+# Not immediately: the loss is detected exactly when the agent is least able to answer.
+# If the runner is what died it is restarting right now, and delivery would fail at
+# connect — no read timeout helps when there is nothing listening. The first attempt waits
+# long enough for it to come back.
+#
+# Retries are cheap here in a way the job's own retry is not: this is a POST of one
+# sentence, not an agent turn, so attempting it again costs nothing worth counting. It is
+# still bounded — past NOTICE_GIVE_UP_AFTER_SECONDS the news has stopped being useful, and
+# a notifier still trying through a long outage is its own small stampede.
+NOTICE_FIRST_ATTEMPT_SECONDS = 90
+NOTICE_RETRY_INTERVAL_SECONDS = 300
+NOTICE_GIVE_UP_AFTER_SECONDS = 3600
 
 
 class SchedulerEngine:
@@ -86,39 +125,150 @@ class SchedulerEngine:
         )
 
     async def _heal_stuck_runs(self) -> None:
-        """Fail runs left in 'running' longer than STUCK_RUN_THRESHOLD.
+        """Interrupt runs whose dispatcher stopped reporting, and owe each one a retry.
 
         A run gets stranded when the process is killed mid-dispatch, or when recording
         its outcome fails. Nothing else ever revisits the row: it reads as work in
         progress forever, with no duration and no error.
 
-        This used to run only at startup, which meant a stranded run cleared on the next
-        restart or never. It now runs on every tick, so a strand self-clears within the
-        threshold wherever it came from. Runs this process is still dispatching are
-        excluded — see _in_flight.
+        Runs this process is still dispatching are excluded outright (_in_flight) so a
+        local run is never swept on the strength of a heartbeat that merely lost a race
+        with the sweep. For everyone else's, the heartbeat is the evidence.
         """
         try:
+            now = datetime.now(timezone.utc)
             async with self._db_session_factory() as db:
-                result = await db.execute(
-                    text(f"""
-                        UPDATE scheduled_job_runs
-                        SET
-                            status       = 'failed',
-                            completed_at = NOW(),
-                            error_message = 'Run was interrupted before completing (process restart or unhandled error)'
-                        WHERE status = 'running'
-                          AND started_at < NOW() - INTERVAL '{STUCK_RUN_THRESHOLD}'
-                          AND NOT (id = ANY(:in_flight))
-                        RETURNING id
-                    """),
-                    {"in_flight": list(self._in_flight)},
+                healed = await self._repo.interrupt_stale_runs(
+                    db,
+                    stale_after_seconds=STALE_RUN_AFTER_SECONDS,
+                    heartbeatless_after_seconds=HEARTBEATLESS_RUN_AFTER_SECONDS,
+                    exclude_run_ids=list(self._in_flight),
+                    retry_at=now + timedelta(seconds=RETRY_DELAY_SECONDS),
+                    notice_due_at=now + timedelta(seconds=NOTICE_FIRST_ATTEMPT_SECONDS),
                 )
-                healed = [r["id"] for r in result.mappings().all()]
                 await db.commit()
             if healed:
-                logger.warning("Healed %d stuck 'running' run(s): %s", len(healed), healed)
+                logger.warning(
+                    "Interrupted %d run(s) whose dispatcher stopped reporting: %s",
+                    len(healed),
+                    healed,
+                )
         except Exception:
-            logger.exception("Failed to heal stuck runs")
+            logger.exception("Failed to sweep stale runs")
+
+    async def _notify_recovery_exhausted(self, job: ScheduledJob) -> bool:
+        """Tell the user a run was lost, after the retry was interrupted too.
+
+        Returns whether the debt is settled — delivered, or owed to nobody. False means
+        the attempt failed and the notice stays owed for a later round.
+
+        Dispatched as an ephemeral notification-only job: an A2A message carrying the
+        text and the job's push config but no ``sub_agent_id``, which agent-runner
+        delivers without running an agent (see its ``if sub_agent_id:`` branch). This is
+        the same path a notification-only watch already takes, and using it keeps the
+        number of processes that post to a delivery channel at three — posting from here
+        would duplicate the A2A envelope and its token contract across every receiver.
+
+        That it needs the runner is deliberate and survivable: the runner restarts in
+        seconds, the notice carries no tools, no context and no sandbox, so it lives
+        where the job that died did not.
+
+        Deliberately outside the run machinery it reports on. It records no run, and it
+        is never retried. A notify dispatch that created a run row would go stale, be
+        swept by the healer, and earn the job another retry — a loop built out of the
+        recovery mechanism. Every failure here is logged and dropped: the run row already
+        carries the truth, and a notifier that retries during an incident is how one
+        unhealthy process becomes a stampede.
+        """
+        if job.delivery_channel_id is None:
+            logger.info("Job %d has no delivery channel; recovery notice not sent", job.id)
+            return True
+
+        try:
+            async with self._db_session_factory() as db:
+                channel = await self._delivery_channel_repo.get_channel_for_dispatch(db, job.delivery_channel_id)
+                if not channel:
+                    logger.warning("Job %d: delivery channel %d is gone", job.id, job.delivery_channel_id)
+                    return True
+                access_token = await self._token_service.get_access_token(db, job.user_id)
+
+            # Plain text, like every other notification the scheduler writes itself: it
+            # goes out verbatim on whichever channel the job notifies, and Slack renders
+            # Markdown literally.
+            text_body = (
+                f"'{job.name}' could not run. The process handling it stopped before it finished, "
+                f"twice in a row, so there is no result for this run. The schedule is unchanged and "
+                f"the next run will go ahead as normal."
+            )
+
+            # No sub_agent_id: the runner delivers and runs nothing. No
+            # scheduled_job_run_id either — this notice is not a run.
+            metadata = self._base_metadata(job)
+            metadata["messageFormatting"] = self._message_formatting(channel)
+            await dispatch_streaming(
+                agent_url=self._agent_runner_url,
+                access_token=access_token,
+                parts=[{"kind": "text", "text": text_body}],
+                metadata=metadata,
+                push_config=self._push_config(channel),
+                # Nothing is being computed, so the long inter-event timeout that covers a
+                # working agent would only make a dead runner take five minutes to admit it.
+                timeout_read=NOTIFY_TIMEOUT_SECONDS,
+            )
+            logger.info("Job %d: told the user the run was lost", job.id)
+            return True
+        except Exception:
+            logger.warning("Job %d: could not deliver the recovery notice", job.id, exc_info=True)
+            return False
+
+    async def _deliver_due_notices(self) -> None:
+        """Deliver the notices owed to users whose runs were lost for good.
+
+        Claiming pushes each notice's due time forward, so an attempt happens once per
+        round across every scheduler, and a failed one is simply tried again later.
+        Whoever ticks next does the work — which is the point: the process that recorded
+        the debt may be the one that went away.
+        """
+        try:
+            now = datetime.now(timezone.utc)
+            async with self._db_session_factory() as db:
+                due = await self._repo.claim_due_notices(
+                    db,
+                    next_attempt_at=now + timedelta(seconds=NOTICE_RETRY_INTERVAL_SECONDS),
+                    give_up_before=now - timedelta(seconds=NOTICE_GIVE_UP_AFTER_SECONDS),
+                    limit=self._claim_limit,
+                )
+                await db.commit()
+
+            for item in due:
+                async with self._db_session_factory() as db:
+                    job = await self._repo.get_job(db, item["job_id"])
+                    # A deleted job settles the debt too: there is nobody left to tell,
+                    # and the obligation should not outlive its subject.
+                    settled = job is None or await self._notify_recovery_exhausted(job)
+                    if settled:
+                        await self._repo.clear_notice(db, item["run_id"])
+                        await db.commit()
+        except Exception:
+            logger.exception("Failed to deliver recovery notices")
+
+    async def _heartbeat(self, run_id: int) -> None:
+        """Report this process alive for *run_id* until cancelled.
+
+        Runs for as long as the dispatch holds the agent's stream. Losing a beat is
+        survivable — the healer tolerates several — so a failed write is logged at debug
+        and the loop continues rather than taking the dispatch down with it.
+        """
+        while True:
+            await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
+            try:
+                async with self._db_session_factory() as db:
+                    await self._repo.touch_run(db, run_id)
+                    await db.commit()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.debug("Heartbeat failed for run %s", run_id, exc_info=True)
 
     async def stop(self) -> None:
         """Stop the background tick loop gracefully."""
@@ -137,13 +287,15 @@ class SchedulerEngine:
         Bypasses the claim mechanism — use only for on-demand test runs triggered
         by a user.  The execution is identical to a regular scheduled dispatch:
         offline-token resolution, A2A call to agent-runner, webhook delivery, and
-        run-record creation.
+        run-record creation — except that an interrupted manual run earns no retry.
+        The user is present and can press again, and reviving a test press through
+        the claim path would turn it into a scheduled execution of the job.
 
-        If run_id is provided (pre-created by the caller) the engine will skip
-        creating a new run record and use the supplied ID instead.
+        If run_id is provided (pre-created by the caller, with RunTrigger.MANUAL) the
+        engine will skip creating a new run record and use the supplied ID instead.
         """
         logger.info("Manual run-now triggered for job %d by user request", job.id)
-        await self._dispatch_job(job, run_id=run_id)
+        await self._dispatch_job(job, run_id=run_id, trigger=RunTrigger.MANUAL)
 
     async def _loop(self) -> None:
         while self._running:
@@ -155,32 +307,46 @@ class SchedulerEngine:
 
     async def _tick(self) -> None:
         await self._heal_stuck_runs()
+        await self._deliver_due_notices()
 
         async with self._db_session_factory() as db:
-            jobs = await self._repo.claim_due_jobs(db, limit=self._claim_limit)
+            claimed = await self._repo.claim_due_jobs(db, limit=self._claim_limit)
             await db.commit()
 
-        if not jobs:
+        if not claimed:
             return
 
-        logger.info("Scheduler claiming %d due job(s)", len(jobs))
-        tasks = [asyncio.create_task(self._dispatch_job(job)) for job in jobs]
+        logger.info("Scheduler claiming %d due job(s)", len(claimed))
+        tasks = [asyncio.create_task(self._dispatch_job(c.job, trigger=c.trigger)) for c in claimed]
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        for job, result in zip(jobs, results):
+        for c, result in zip(claimed, results):
             if isinstance(result, Exception):
-                logger.error("Job %d dispatch raised an unhandled exception: %s", job.id, result)
+                logger.error("Job %d dispatch raised an unhandled exception: %s", c.job.id, result)
 
-    async def _dispatch_job(self, job: ScheduledJob, run_id: int | None = None) -> None:
-        """Resolve user token, build A2A payload, call agent-runner, record result."""
+    async def _dispatch_job(
+        self,
+        job: ScheduledJob,
+        run_id: int | None = None,
+        trigger: RunTrigger = RunTrigger.SCHEDULED,
+    ) -> None:
+        """Resolve user token, build A2A payload, call agent-runner, record result.
+
+        *trigger* is why this run exists, and decides what its interruption is worth:
+        a SCHEDULED run earns one RETRY, a RETRY earns the user a notice, a MANUAL run
+        earns neither.
+        """
         if run_id is None:
             async with self._db_session_factory() as db:
-                run_id = await self._repo.create_run(db, job.id)
+                run_id = await self._repo.create_run(db, job.id, trigger=trigger)
                 await db.commit()
 
-        logger.info("Dispatching job %d (run %d) to agent-runner", job.id, run_id)
+        logger.info("Dispatching job %d (run %d, %s) to agent-runner", job.id, run_id, trigger.value)
 
         self._in_flight.add(run_id)
+        # Report liveness for as long as this dispatch holds the stream, so another
+        # scheduler's healer can tell a slow run from an abandoned one.
+        heartbeat = asyncio.create_task(self._heartbeat(run_id), name=f"scheduler-heartbeat-{run_id}")
         try:
             # Resolve user access token and build payload in a single DB session
             async with self._db_session_factory() as db:
@@ -283,31 +449,42 @@ class SchedulerEngine:
                 condition_evaluation=watch_outcome.evaluation if watch_outcome else None,
             )
 
-        except httpx.HTTPStatusError as e:
-            logger.error("agent-runner HTTP error for job %d: %s", job.id, e)
-            try:
-                await self._finalize(
-                    run_id=run_id,
-                    job=job,
-                    status=JobRunStatus.FAILED,
-                    error_message=f"agent-runner HTTP {e.response.status_code}: {e.response.text[:500]}",
-                    delivered=False,
-                )
-            except Exception:
-                logger.exception("Failed to finalize run %s for job %d after HTTP error", run_id, job.id)
         except Exception as e:
-            logger.exception("Unexpected error dispatching job %d", job.id)
+            # Only the dispatch itself can say the agent died: dispatch_streaming raises
+            # AgentUnreachable for that and nothing else does, so a Keycloak or database
+            # error on the way there is a failure of this run, not an interruption.
+            if isinstance(e, AgentUnreachable):
+                logger.warning("agent-runner unreachable for job %d: %s", job.id, e)
+                status = JobRunStatus.INTERRUPTED
+                error_message = str(e)
+            elif isinstance(e, httpx.HTTPStatusError):
+                logger.error("agent-runner HTTP error for job %d: %s", job.id, e)
+                status = JobRunStatus.FAILED
+                error_message = f"agent-runner HTTP {e.response.status_code}: {e.response.text[:500]}"
+            else:
+                logger.exception("Unexpected error dispatching job %d", job.id)
+                status = JobRunStatus.FAILED
+                error_message = str(e)
             try:
                 await self._finalize(
                     run_id=run_id,
                     job=job,
-                    status=JobRunStatus.FAILED,
-                    error_message=str(e),
+                    status=status,
+                    error_message=error_message,
                     delivered=False,
+                    trigger=trigger,
                 )
             except Exception:
                 logger.exception("Failed to finalize run %s for job %d after dispatch error", run_id, job.id)
         finally:
+            # Await the cancellation: the heartbeat may be inside a session commit, and
+            # letting it unwind after this dispatch has reported completion makes
+            # shutdown non-deterministic.
+            heartbeat.cancel()
+            try:
+                await heartbeat
+            except asyncio.CancelledError:
+                pass
             self._in_flight.discard(run_id)
 
     async def _build_message_args(
@@ -324,14 +501,8 @@ class SchedulerEngine:
         normal path for a watch job. It is passed on so agent-runner does not call the
         tool a second time or reach a different verdict than the one that got us here.
         """
-        metadata: dict[str, Any] = {
-            "scheduled_job_id": job.id,
-            "scheduled_job_run_id": run_id,
-            "job_type": job.job_type.value,
-            # The job's IANA timezone, so the runner's tool-less LLM calls
-            # (condition eval, notification generation) can be told "now".
-            "timezone": job.timezone or None,
-        }
+        metadata = self._base_metadata(job)
+        metadata["scheduled_job_run_id"] = run_id
 
         # The channel this job notifies, needed twice below: for how it renders text, and
         # as the push target. Fetched once.
@@ -421,9 +592,7 @@ class SchedulerEngine:
         # notification and runs no agent: delivery is the push sender's job, and the
         # payload is an A2A Task envelope that the delivery channels normalise. Posting
         # it from here would duplicate that contract across three receivers.
-        push_config: dict[str, str] | None = None
-        if channel:
-            push_config = {"url": channel["webhook_url"], "token": channel["secret"]}
+        push_config = self._push_config(channel) if channel else None
 
         # How the channel this job notifies renders text, sent under the key an interactive
         # client uses (`messageFormatting`) so agent-runner and the orchestrator apply the
@@ -436,9 +605,30 @@ class SchedulerEngine:
         # asked for one and found no voice agent falls back to a text dispatch, and that
         # text still lands on the channel and still has to be written for it.
         if not is_voice_dispatch:
-            metadata["messageFormatting"] = (channel or {}).get("message_formatting") or "markdown"
+            metadata["messageFormatting"] = self._message_formatting(channel)
 
         return parts, metadata, push_config
+
+    @staticmethod
+    def _base_metadata(job: ScheduledJob) -> dict[str, Any]:
+        """The A2A message metadata every dispatch on behalf of *job* carries."""
+        return {
+            "scheduled_job_id": job.id,
+            "job_type": job.job_type.value,
+            # The job's IANA timezone, so the runner's tool-less LLM calls
+            # (condition eval, notification generation) can be told "now".
+            "timezone": job.timezone or None,
+        }
+
+    @staticmethod
+    def _push_config(channel: dict[str, Any]) -> dict[str, str]:
+        """The push-notification target for a delivery channel, as the A2A task registers it."""
+        return {"url": channel["webhook_url"], "token": channel["secret"]}
+
+    @staticmethod
+    def _message_formatting(channel: dict[str, Any] | None) -> str:
+        """How the channel renders text, under the key an interactive client uses."""
+        return (channel or {}).get("message_formatting") or DEFAULT_MESSAGE_FORMATTING
 
     async def _write_notification(self, job: ScheduledJob, outcome: WatchOutcome | None) -> str:
         """Write the notification for a triggered watch whose author left it empty.
@@ -585,9 +775,37 @@ class SchedulerEngine:
         last_check_result: dict | None = None,
         paused_reason: str | None = None,
         condition_evaluation: ConditionEvaluation | None = None,
+        trigger: RunTrigger = RunTrigger.SCHEDULED,
     ) -> None:
-        """Persist run outcome and advance job state."""
-        success = status in (JobRunStatus.SUCCESS, JobRunStatus.CONDITION_NOT_MET)
+        """Persist run outcome and advance job state.
+
+        An interrupted SCHEDULED run earns the job one fresh attempt. The marker goes
+        in the database rather than being retried here: the process that noticed the
+        interruption is often the one dying, and a retry that dies with it is no
+        retry at all. An interrupted RETRY has exhausted recovery and owes the user a
+        notice instead. An interrupted MANUAL run earns neither — the user is present.
+        """
+        interrupted = status == JobRunStatus.INTERRUPTED
+        now = datetime.now(timezone.utc)
+        retry_at = now + timedelta(seconds=RETRY_DELAY_SECONDS) if interrupted and trigger == RunTrigger.SCHEDULED else None
+        # Recovery is exhausted: an interrupted run that was already the retry. Only this
+        # terminal case is worth a message — an interruption the system absorbed is not
+        # news, and a notice per interruption would be loudest exactly during an incident.
+        #
+        # Recorded as owed, not delivered here. Sending it now would aim at an agent that
+        # is, by construction, in the middle of dying or restarting; and if this process
+        # is the one going away, an in-process attempt goes with it. The tick loop
+        # delivers it once the dust has settled.
+        notice_due_at = (
+            now + timedelta(seconds=NOTICE_FIRST_ATTEMPT_SECONDS) if interrupted and trigger == RunTrigger.RETRY else None
+        )
+        if interrupted:
+            consequence = {
+                RunTrigger.SCHEDULED: f"retrying at {retry_at.isoformat()}" if retry_at else "",
+                RunTrigger.RETRY: "already the retry, giving up and owing the user a notice",
+                RunTrigger.MANUAL: "a manual run, not retried",
+            }[trigger]
+            logger.warning("Run %s of job %d was interrupted (%s); %s", run_id, job.id, error_message, consequence)
 
         try:
             next_run_at = compute_next_run(
@@ -645,8 +863,9 @@ class SchedulerEngine:
             await self._repo.complete_job(
                 db=db,
                 job_id=job.id,
-                success=success,
+                status=status,
                 next_run_at=next_run_at,
+                retry_at=retry_at,
                 last_check_result=last_check_result,
                 paused_reason=paused_reason,
             )
@@ -663,12 +882,21 @@ class SchedulerEngine:
                     conversation_id=conversation_id,
                     delivered=delivered,
                     condition_evaluation=condition_evaluation,
+                    notice_due_at=notice_due_at,
                 )
                 await db.commit()
         except Exception:
-            # The schedule is already advanced, so this cannot loop. The run is left for
-            # the healer, and the job keeps working while somebody reads this.
+            # The schedule is already advanced, so this cannot loop. But a run left
+            # 'running' is no longer harmless: the healer would call it interrupted and
+            # re-execute a job whose result was delivered. Close it with the columns the
+            # table has always had, which is what the write that shaped this code lacked.
             logger.exception("Job %d: failed to record run %d; the job itself advanced", job.id, run_id)
+            try:
+                async with self._db_session_factory() as db:
+                    await self._repo.close_run_minimally(db, run_id, status, error_message)
+                    await db.commit()
+            except Exception:
+                logger.exception("Job %d: could not close run %d at all; the healer will sweep it", job.id, run_id)
 
         logger.info(
             "Job %d run %d finished: status=%s delivered=%s",

--- a/packages/console-backend/console_backend/services/scheduler_service.py
+++ b/packages/console-backend/console_backend/services/scheduler_service.py
@@ -279,6 +279,20 @@ class SchedulerService:
             if val is not None:
                 fields[attr] = val
 
+        # Toggling `enabled` here is a deliberate stop or start, and the scheduler
+        # tells those apart from one-shot retirement by `paused_reason`: the retry
+        # branch of claim_due_jobs ignores `enabled` (a retired once-job is disabled
+        # too) and trusts the reason instead. A disable that wrote none would leave
+        # the job claimable by a retry; an enable that kept one would look paused.
+        # Either direction also drops a pending retry — the user has made a decision
+        # about the job, and a fresh attempt for an earlier interruption is not it.
+        if fields.get("enabled") is False:
+            fields["paused_reason"] = "Disabled by user"
+            fields["retry_at"] = None
+        elif fields.get("enabled") is True:
+            fields["paused_reason"] = None
+            fields["retry_at"] = None
+
         # A watch must keep at least one condition. Create rejects a watch with neither,
         # and WatchEvaluator treats that combination as unreachable — but a PATCH clearing
         # both produces exactly it, leaving a job that calls its check tool on every poll
@@ -362,7 +376,14 @@ class SchedulerService:
             db=db,
             actor=actor,
             job_id=job_id,
-            fields={"enabled": False, "paused_reason": reason, "updated_at": datetime.now(timezone.utc)},
+            # A pending retry dies with the pause: a job somebody stopped is not resumed
+            # by a fresh attempt for an interruption that happened before they did.
+            fields={
+                "enabled": False,
+                "paused_reason": reason,
+                "retry_at": None,
+                "updated_at": datetime.now(timezone.utc),
+            },
         )
         await db.commit()
         return True
@@ -388,6 +409,10 @@ class SchedulerService:
             "enabled": True,
             "consecutive_failures": 0,
             "paused_reason": None,
+            # A retry earned while the job was paused must not fire the moment it is
+            # resumed: the resume computes the next occurrence, and that is the run
+            # the user asked for.
+            "retry_at": None,
             "updated_at": datetime.now(timezone.utc),
         }
         if next_run_at:

--- a/packages/console-backend/console_backend/utils/a2a_dispatch.py
+++ b/packages/console-backend/console_backend/utils/a2a_dispatch.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import httpx
 from a2a.client import A2ACardResolver
+from a2a.client.errors import A2AClientError
 from a2a.client.client import ClientConfig
 from a2a.client.client_factory import ClientFactory
 from a2a.types import (
@@ -45,6 +46,37 @@ _TERMINAL_STATES: dict[int, str] = {
 
 # Agent cards are static per URL; cache them so we don't refetch on every dispatch.
 _card_cache: dict[str, AgentCard] = {}
+
+# Gateway statuses that mean nothing was there to answer, as opposed to an agent that
+# answered with an error of its own.
+_UNREACHABLE_STATUSES = frozenset({502, 503, 504})
+
+
+class AgentUnreachable(Exception):
+    """The agent could not be reached, or stopped answering mid-stream.
+
+    Raised by :func:`dispatch_streaming` in place of the transport's own errors so a
+    caller can tell "the agent died" from "the agent failed" without knowing how the
+    a2a SDK wraps httpx. The scheduler records the former as an interruption of the
+    run and the latter as a failure of the job; the distinction decides whether the
+    run counts against the job (see docs/adr/0007-interrupted-runs-get-one-fresh-attempt.md).
+    """
+
+
+def _is_unreachable(exc: BaseException) -> bool:
+    """Whether *exc*, or the httpx error the SDK wrapped in it, means nobody answered.
+
+    The SDK wraps every httpx error: the card resolver in AgentCardResolutionError, the
+    transports in A2AClientError / A2AClientTimeoutError, all ``from e``. The wrapped
+    cause is where the evidence is, so this looks through one level of wrapping.
+    A 500 from a running agent is a genuine failure and stays one.
+    """
+    for candidate in (exc, exc.__cause__):
+        if isinstance(candidate, httpx.TransportError):
+            return True
+        if isinstance(candidate, httpx.HTTPStatusError):
+            return candidate.response.status_code in _UNREACHABLE_STATUSES
+    return False
 
 
 async def _resolve_card(agent_url: str, http_client: httpx.AsyncClient) -> AgentCard:
@@ -109,8 +141,36 @@ async def dispatch_streaming(
         ``contextId``, ``status.state``, and a single text artifact carrying the final output.
 
     Raises:
-        Transport/HTTP/JSON-RPC errors propagate to the caller (which marks the run FAILED).
+        AgentUnreachable: nothing answered — connect refused, the stream dropped or timed
+            out, or a 502/503/504 from a gateway — whether the SDK wrapped it or not.
+        Other transport/HTTP/JSON-RPC errors propagate as raised.
     """
+    try:
+        return await _dispatch_streaming(
+            agent_url=agent_url,
+            access_token=access_token,
+            parts=parts,
+            metadata=metadata,
+            context_id=context_id,
+            push_config=push_config,
+            timeout_read=timeout_read,
+        )
+    except (httpx.HTTPError, A2AClientError) as e:
+        if _is_unreachable(e):
+            raise AgentUnreachable(f"{agent_url}: {e}") from e
+        raise
+
+
+async def _dispatch_streaming(
+    *,
+    agent_url: str,
+    access_token: str,
+    parts: list[dict[str, Any]],
+    metadata: dict[str, Any],
+    context_id: str | None,
+    push_config: dict[str, str] | None,
+    timeout_read: float,
+) -> dict[str, Any]:
     last_text: str | None = None
     result_context_id: str | None = context_id
     final_state = "completed"

--- a/packages/console-backend/sqlmigrations/ddl/092_job_run_status_interrupted.sql
+++ b/packages/console-backend/sqlmigrations/ddl/092_job_run_status_interrupted.sql
@@ -1,0 +1,15 @@
+-- rambler up
+-- Add 'interrupted' to job_run_status: a run that ended because the process
+-- executing it died, rather than because the job failed. Recorded as 'failed'
+-- until now, which let process churn write itself into user state — enough
+-- restarts landing on the same job cross max_failures and auto-pause it with a
+-- paused_reason blaming the job — and left the run history unable to answer
+-- "did my job fail, or did the process die?" without reading pod logs.
+--
+-- Kept in its own file so the forward-only enum change is isolated from the
+-- reversible column work in 092: this file's down-block is a no-op, 092's is not.
+ALTER TYPE job_run_status
+ADD VALUE IF NOT EXISTS 'interrupted';
+-- rambler down
+-- Note: PostgreSQL does not support removing enum values
+-- This is a forward-only migration

--- a/packages/console-backend/sqlmigrations/ddl/093_scheduled_run_recovery.sql
+++ b/packages/console-backend/sqlmigrations/ddl/093_scheduled_run_recovery.sql
@@ -1,0 +1,56 @@
+-- rambler up
+
+-- Recovery for runs interrupted by a process death. See
+-- docs/adr/0007-interrupted-runs-get-one-fresh-attempt.md for the reasoning; this
+-- header only states what each column means.
+
+-- Last heartbeat from the dispatching process. The healer sweeps on staleness of
+-- this, so a slow-but-healthy run is never mistaken for an abandoned one. NULL on
+-- rows written before recovery existed; the healer gives those a much longer
+-- age-based window, since a process on the previous release may still be running
+-- them.
+ALTER TABLE scheduled_job_runs
+    ADD COLUMN last_seen_at TIMESTAMPTZ;
+
+-- Why this run was started. 'scheduled' is an ordinary occurrence; 'retry' is the
+-- one fresh attempt an interrupted scheduled run earns; 'manual' is a user's
+-- run-now. Only a 'scheduled' run earns a retry, only a 'retry' run owes the user
+-- a notice when it is lost, and a 'manual' run does neither.
+ALTER TABLE scheduled_job_runs
+    ADD COLUMN trigger TEXT NOT NULL DEFAULT 'scheduled'
+        CONSTRAINT scheduled_job_runs_trigger_check
+        CHECK (trigger IN ('scheduled', 'retry', 'manual'));
+
+-- When the user is owed the notice that this run was lost for good. NULL means
+-- nothing is owed, which is nearly every row, hence the partial index.
+ALTER TABLE scheduled_job_runs
+    ADD COLUMN notice_due_at TIMESTAMPTZ;
+
+CREATE INDEX idx_scheduled_job_runs_notice_due
+    ON scheduled_job_runs (notice_due_at)
+    WHERE notice_due_at IS NOT NULL;
+
+-- When a fresh attempt is owed. A second wake-up reason for claim_due_jobs, kept
+-- out of next_run_at so the schedule users read is never rewritten by a retry.
+ALTER TABLE scheduled_jobs
+    ADD COLUMN retry_at TIMESTAMPTZ;
+
+CREATE INDEX idx_scheduled_jobs_retry_at
+    ON scheduled_jobs (retry_at)
+    WHERE retry_at IS NOT NULL;
+
+-- The set the healer and the claim guard scan: runs still in progress. Keyed on a
+-- column the heartbeat never touches, so touch_run stays a HOT update.
+CREATE INDEX idx_scheduled_job_runs_running
+    ON scheduled_job_runs (job_id, started_at)
+    WHERE status = 'running';
+
+-- rambler down
+
+DROP INDEX IF EXISTS idx_scheduled_job_runs_running;
+DROP INDEX IF EXISTS idx_scheduled_jobs_retry_at;
+ALTER TABLE scheduled_jobs DROP COLUMN IF EXISTS retry_at;
+DROP INDEX IF EXISTS idx_scheduled_job_runs_notice_due;
+ALTER TABLE scheduled_job_runs DROP COLUMN IF EXISTS notice_due_at;
+ALTER TABLE scheduled_job_runs DROP COLUMN IF EXISTS trigger;
+ALTER TABLE scheduled_job_runs DROP COLUMN IF EXISTS last_seen_at;

--- a/packages/console-backend/tests/scheduler_helpers.py
+++ b/packages/console-backend/tests/scheduler_helpers.py
@@ -1,0 +1,135 @@
+"""Shared fixtures-as-functions for the scheduler test modules.
+
+Two things every scheduler test needs and none should hand-write: a ScheduledJob model
+with sane defaults, and a user plus job row in a real database.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from console_backend.models.scheduled_job import JobType, ScheduledJob, ScheduleKind
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def make_job(
+    job_id: int = 1,
+    user_id: str = "user-abc",
+    job_type: JobType = JobType.TASK,
+    sub_agent_id: int | None = 42,
+    schedule_kind: ScheduleKind = ScheduleKind.INTERVAL,
+    interval_seconds: int | None = 3600,
+    cel_expr: str | None = None,
+    llm_condition: str | None = None,
+    destroy_after_trigger: bool = True,
+    max_failures: int = 3,
+    consecutive_failures: int = 0,
+    delivery_channel_id: int | None = None,
+    name: str = "Test Job",
+) -> ScheduledJob:
+    """An enabled interval task job due in an hour, unless told otherwise."""
+    now = datetime.now(timezone.utc)
+    return ScheduledJob(
+        id=job_id,
+        user_id=user_id,
+        sub_agent_id=sub_agent_id,
+        name=name,
+        job_type=job_type,
+        schedule_kind=schedule_kind,
+        interval_seconds=interval_seconds,
+        cel_expr=cel_expr,
+        llm_condition=llm_condition,
+        next_run_at=now + timedelta(hours=1),
+        prompt="Do something",
+        destroy_after_trigger=destroy_after_trigger,
+        enabled=True,
+        max_failures=max_failures,
+        consecutive_failures=consecutive_failures,
+        delivery_channel_id=delivery_channel_id,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+async def seed_job(
+    pg_session: AsyncSession,
+    suffix: str,
+    *,
+    schedule_kind: str = "interval",
+    next_run_at: str = "NOW() + INTERVAL '1 hour'",
+    enabled: str = "true",
+    consecutive_failures: int = 0,
+    paused_reason: str | None = None,
+    retry_at: str | None = None,
+) -> int:
+    """Insert a user and one scheduled job; return the job id.
+
+    SQL-expression arguments (*next_run_at*, *retry_at*, *enabled*) are spliced in
+    verbatim so tests can say ``NOW() - INTERVAL '1 minute'``. *suffix* keeps the
+    user unique across tests sharing a database.
+    """
+    user_id = f"sched-user-{suffix}"
+    await pg_session.execute(
+        text(
+            "INSERT INTO users (id, sub, email, first_name, last_name, is_administrator, role, status) "
+            "VALUES (:id, :sub, :email, 'S', 'T', false, 'member', 'active')"
+        ),
+        {"id": user_id, "sub": f"sched-sub-{suffix}", "email": f"sched-{suffix}@test.com"},
+    )
+    # A watch job: 'task' carries a check constraint requiring a sub-agent, and the job
+    # type is irrelevant to what these tests exercise. scheduled_jobs_schedule_config
+    # requires exactly the fields its schedule_kind uses, hence the split below.
+    if schedule_kind == "once":
+        interval_seconds, run_at = "NULL", "NOW() - INTERVAL '1 hour'"
+    else:
+        interval_seconds, run_at = "3600", "NULL"
+    result = await pg_session.execute(
+        text(f"""
+            INSERT INTO scheduled_jobs
+                (user_id, name, job_type, schedule_kind, interval_seconds, run_at, next_run_at,
+                 enabled, max_failures, consecutive_failures, destroy_after_trigger,
+                 paused_reason, retry_at, check_tool, cel_expr)
+            VALUES
+                (:uid, 'Seeded Job', 'watch', '{schedule_kind}', {interval_seconds}, {run_at},
+                 {next_run_at}, {enabled}, 3, :cf, true, :paused_reason, {retry_at or "NULL"},
+                 'ping_tool', 'result != null')
+            RETURNING id
+        """),
+        {"uid": user_id, "cf": consecutive_failures, "paused_reason": paused_reason},
+    )
+    return result.mappings().first()["id"]
+
+
+async def seed_run(
+    pg_session: AsyncSession,
+    job_id: int,
+    *,
+    status: str = "running",
+    started_at: str = "NOW()",
+    last_seen_at: str | None = "NOW()",
+    completed_at: str | None = None,
+    trigger: str = "scheduled",
+    notice_due_at: str | None = None,
+) -> int:
+    """Insert one run row for *job_id*; return the run id. Time arguments are SQL expressions."""
+    result = await pg_session.execute(
+        text(f"""
+            INSERT INTO scheduled_job_runs
+                (job_id, status, started_at, last_seen_at, completed_at, trigger, notice_due_at)
+            VALUES
+                (:job_id, :status, {started_at}, {last_seen_at or "NULL"}, {completed_at or "NULL"},
+                 :trigger, {notice_due_at or "NULL"})
+            RETURNING id
+        """),
+        {"job_id": job_id, "status": status, "trigger": trigger},
+    )
+    return result.mappings().first()["id"]
+
+
+async def run_status(pg_session: AsyncSession, run_id: int) -> str:
+    r = await pg_session.execute(text("SELECT status FROM scheduled_job_runs WHERE id = :id"), {"id": run_id})
+    return r.scalar_one()
+
+
+async def job_retry_at(pg_session: AsyncSession, job_id: int) -> datetime | None:
+    r = await pg_session.execute(text("SELECT retry_at FROM scheduled_jobs WHERE id = :id"), {"id": job_id})
+    return r.scalar_one()

--- a/packages/console-backend/tests/test_a2a_dispatch_unreachable.py
+++ b/packages/console-backend/tests/test_a2a_dispatch_unreachable.py
@@ -1,0 +1,76 @@
+"""dispatch_streaming tells "nobody answered" from every other error.
+
+The a2a SDK wraps httpx errors (``from e``) before they reach a caller, so the scheduler
+cannot classify by httpx type itself — the case this exists for is a runner still
+restarting when the card cache is empty, which arrives as AgentCardResolutionError.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from a2a.client.errors import A2AClientError, AgentCardResolutionError
+from console_backend.utils.a2a_dispatch import AgentUnreachable, _is_unreachable, dispatch_streaming
+
+
+def _request() -> httpx.Request:
+    return httpx.Request("GET", "http://agent-runner:8000/.well-known/agent-card.json")
+
+
+def _wrapped(cause: BaseException) -> BaseException:
+    try:
+        raise AgentCardResolutionError("card fetch failed") from cause
+    except AgentCardResolutionError as e:
+        return e
+
+
+class TestClassification:
+    def test_a_bare_transport_error_is_unreachable(self):
+        assert _is_unreachable(httpx.ConnectError("refused", request=_request()))
+
+    def test_a_read_timeout_is_unreachable(self):
+        """The 300s inter-event timeout is how a black-holed runner surfaces."""
+        assert _is_unreachable(httpx.ReadTimeout("silent", request=_request()))
+
+    def test_a_wrapped_connect_error_is_unreachable(self):
+        assert _is_unreachable(_wrapped(httpx.ConnectError("refused", request=_request())))
+
+    @pytest.mark.parametrize("code", [502, 503, 504])
+    def test_a_gateway_status_is_unreachable_wrapped_or_not(self, code: int):
+        err = httpx.HTTPStatusError("gw", request=_request(), response=httpx.Response(code))
+        assert _is_unreachable(err)
+        assert _is_unreachable(_wrapped(err))
+
+    @pytest.mark.parametrize("code", [400, 404, 500])
+    def test_an_answer_from_a_running_agent_is_not(self, code: int):
+        err = httpx.HTTPStatusError("agent", request=_request(), response=httpx.Response(code))
+        assert not _is_unreachable(err)
+        assert not _is_unreachable(_wrapped(err))
+
+    def test_an_sdk_error_with_no_transport_cause_is_not(self):
+        assert not _is_unreachable(A2AClientError("SSE stream error event received"))
+
+
+class TestDispatchStreamingRaises:
+    @pytest.mark.asyncio
+    async def test_unreachable_runner_raises_agent_unreachable(self):
+        with patch(
+            "console_backend.utils.a2a_dispatch._resolve_card",
+            new=AsyncMock(side_effect=_wrapped(httpx.ConnectError("refused", request=_request()))),
+        ):
+            with pytest.raises(AgentUnreachable) as excinfo:
+                await dispatch_streaming(
+                    agent_url="http://agent-runner:8000", access_token="t", parts=[], metadata={}
+                )
+        assert isinstance(excinfo.value.__cause__, AgentCardResolutionError)
+
+    @pytest.mark.asyncio
+    async def test_other_errors_propagate_as_raised(self):
+        with patch(
+            "console_backend.utils.a2a_dispatch._resolve_card",
+            new=AsyncMock(side_effect=A2AClientError("bad card")),
+        ):
+            with pytest.raises(A2AClientError):
+                await dispatch_streaming(
+                    agent_url="http://agent-runner:8000", access_token="t", parts=[], metadata={}
+                )

--- a/packages/console-backend/tests/test_scheduler_engine.py
+++ b/packages/console-backend/tests/test_scheduler_engine.py
@@ -17,6 +17,7 @@ import pytest
 from console_backend.models.scheduled_job import (
     JobRunStatus,
     JobType,
+    RunTrigger,
     ScheduledJob,
     ScheduleKind,
 )
@@ -27,41 +28,10 @@ from ringier_a2a_sdk.cost_tracking.attribution import current_attribution
 from console_backend.services.watch_evaluator import WatchOutcome
 from console_backend.services.scheduler_engine import SchedulerEngine
 from console_backend.services.scheduler_token_service import SchedulerTokenService
+from console_backend.utils.a2a_dispatch import AgentUnreachable
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
-
-
-def _make_job(
-    job_id: int = 1,
-    user_id: str = "user-abc",
-    job_type: JobType = JobType.TASK,
-    sub_agent_id: int | None = 42,
-    schedule_kind: ScheduleKind = ScheduleKind.INTERVAL,
-    interval_seconds: int | None = 3600,
-    destroy_after_trigger: bool = True,
-    max_failures: int = 3,
-    consecutive_failures: int = 0,
-    delivery_channel_id: int | None = None,
-) -> ScheduledJob:
-    now = datetime.now(timezone.utc)
-    return ScheduledJob(
-        id=job_id,
-        user_id=user_id,
-        sub_agent_id=sub_agent_id,
-        name="Test Job",
-        job_type=job_type,
-        schedule_kind=schedule_kind,
-        interval_seconds=interval_seconds,
-        next_run_at=now + timedelta(hours=1),
-        prompt="Do something",
-        destroy_after_trigger=destroy_after_trigger,
-        enabled=True,
-        max_failures=max_failures,
-        consecutive_failures=consecutive_failures,
-        delivery_channel_id=delivery_channel_id,
-        created_at=now,
-        updated_at=now,
-    )
+from tests.scheduler_helpers import job_retry_at, make_job, run_status, seed_job, seed_run
 
 
 def _make_engine(
@@ -216,160 +186,144 @@ class TestParseResult:
         assert status == JobRunStatus.FAILED
 
 
+def _pg_engine(pg_session: AsyncSession) -> SchedulerEngine:
+    """An engine on a real repository: the sweep is SQL, and a mocked repo would assert nothing."""
+    return _make_engine(repo=ScheduledJobRepository(), db_session_factory=make_pg_session_factory(pg_session))
+
+
 class TestHealStuckRuns:
     """Tests for SchedulerEngine._heal_stuck_runs() using pg_session."""
 
     @pytest.mark.asyncio
-    async def test_marks_old_running_runs_as_failed(self, pg_session: AsyncSession):
-        """Runs stuck in 'running' past STUCK_RUN_THRESHOLD are marked 'failed'."""
-        # Insert prerequisite: user + job
-        user_id = "heal-user-1"
-        await pg_session.execute(
-            text(
-                "INSERT INTO users (id, sub, email, first_name, last_name, is_administrator, role, status) VALUES (:id, :sub, :email, :fn, :ln, false, 'member', 'active')"
-            ),
-            {"id": user_id, "sub": "heal-sub-1", "email": "heal1@test.com", "fn": "Heal", "ln": "Test"},
+    async def test_sweeps_on_staleness_not_age(self, pg_session: AsyncSession):
+        """A run is swept when its heartbeat goes stale — not merely because it is old."""
+        job_id = await seed_job(pg_session, "heal-stale")
+        # Dispatcher stopped reporting an hour ago.
+        stale_run_id = await seed_run(
+            pg_session, job_id, started_at="NOW() - INTERVAL '2 hours'", last_seen_at="NOW() - INTERVAL '1 hour'"
         )
-        result = await pg_session.execute(
-            text("""
-                INSERT INTO scheduled_jobs
-                    (user_id, name, job_type, schedule_kind, interval_seconds, next_run_at, enabled, max_failures, consecutive_failures, destroy_after_trigger, check_tool, cel_expr)
-                VALUES
-                    (:uid, 'Heal Job', 'watch', 'interval', 3600, NOW() + INTERVAL '1 hour', true, 3, 0, true, 'ping_tool', 'result != null')
-                RETURNING id
-            """),
-            {"uid": user_id},
+        # Running for two hours and still reporting: a slow job, not an abandoned one.
+        # Under the old age-based bound this run was swept while the agent worked.
+        long_lived_run_id = await seed_run(
+            pg_session, job_id, started_at="NOW() - INTERVAL '2 hours'", last_seen_at="NOW() - INTERVAL '5 seconds'"
         )
-        job_id = result.mappings().first()["id"]
-
-        # Insert a run that started well past the threshold (stuck)
-        stale_started = datetime.now(timezone.utc) - timedelta(minutes=45)
-        result = await pg_session.execute(
-            text("""
-                INSERT INTO scheduled_job_runs (job_id, started_at, status)
-                VALUES (:job_id, :started_at, 'running')
-                RETURNING id
-            """),
-            {"job_id": job_id, "started_at": stale_started},
-        )
-        stale_run_id = result.mappings().first()["id"]
-
-        # Insert a fresh run (only 1 minute ago — should not be healed)
-        fresh_started = datetime.now(timezone.utc) - timedelta(minutes=1)
-        result = await pg_session.execute(
-            text("""
-                INSERT INTO scheduled_job_runs (job_id, started_at, status)
-                VALUES (:job_id, :started_at, 'running')
-                RETURNING id
-            """),
-            {"job_id": job_id, "started_at": fresh_started},
-        )
-        fresh_run_id = result.mappings().first()["id"]
         await pg_session.commit()
 
-        engine = _make_engine(db_session_factory=make_pg_session_factory(pg_session))
+        await _pg_engine(pg_session)._heal_stuck_runs()
 
+        assert await run_status(pg_session, stale_run_id) == "interrupted"
+        assert await run_status(pg_session, long_lived_run_id) == "running"
+        # The interruption owes the job a fresh attempt.
+        assert await job_retry_at(pg_session, job_id) is not None
+
+    @pytest.mark.asyncio
+    async def test_a_heartbeatless_run_keeps_the_old_age_bound(self, pg_session: AsyncSession):
+        """A row with no heartbeat was written by the previous release, whose process may
+        still be executing it during a rolling deploy. It is judged by age, generously."""
+        job_id = await seed_job(pg_session, "heal-legacy")
+        recent_legacy = await seed_run(pg_session, job_id, started_at="NOW() - INTERVAL '5 minutes'", last_seen_at=None)
+        old_legacy = await seed_run(pg_session, job_id, started_at="NOW() - INTERVAL '2 hours'", last_seen_at=None)
+        await pg_session.commit()
+
+        await _pg_engine(pg_session)._heal_stuck_runs()
+
+        assert await run_status(pg_session, recent_legacy) == "running", "60s stale would have swept a live run"
+        assert await run_status(pg_session, old_legacy) == "interrupted"
+
+    @pytest.mark.asyncio
+    async def test_in_flight_runs_are_never_swept(self, pg_session: AsyncSession):
+        """A run this process is dispatching is excluded regardless of its heartbeat."""
+        job_id = await seed_job(pg_session, "heal-inflight")
+        run_id = await seed_run(
+            pg_session, job_id, started_at="NOW() - INTERVAL '2 hours'", last_seen_at="NOW() - INTERVAL '1 hour'"
+        )
+        await pg_session.commit()
+
+        engine = _pg_engine(pg_session)
+        engine._in_flight.add(run_id)
         await engine._heal_stuck_runs()
 
-        # Stale run should now be 'failed'
-        r = await pg_session.execute(text("SELECT status FROM scheduled_job_runs WHERE id = :id"), {"id": stale_run_id})
-        assert r.scalar_one() == "failed"
+        assert await run_status(pg_session, run_id) == "running"
 
-        # Fresh run should remain 'running'
-        r = await pg_session.execute(text("SELECT status FROM scheduled_job_runs WHERE id = :id"), {"id": fresh_run_id})
-        assert r.scalar_one() == "running"
+    @pytest.mark.asyncio
+    async def test_interrupted_retry_earns_no_second_retry(self, pg_session: AsyncSession):
+        """An interruption buys one fresh attempt; a retry that is interrupted buys none,
+        and owes the user a notice instead."""
+        job_id = await seed_job(pg_session, "heal-retry")
+        retry_run_id = await seed_run(
+            pg_session,
+            job_id,
+            started_at="NOW() - INTERVAL '2 hours'",
+            last_seen_at="NOW() - INTERVAL '1 hour'",
+            trigger="retry",
+        )
+        await pg_session.commit()
+
+        await _pg_engine(pg_session)._heal_stuck_runs()
+
+        assert await run_status(pg_session, retry_run_id) == "interrupted"
+        assert await job_retry_at(pg_session, job_id) is None
+        r = await pg_session.execute(
+            text("SELECT notice_due_at FROM scheduled_job_runs WHERE id = :id"), {"id": retry_run_id}
+        )
+        assert r.scalar_one() is not None
+
+    @pytest.mark.asyncio
+    async def test_interrupted_manual_run_earns_nothing(self, pg_session: AsyncSession):
+        """The user was present for a run-now and can press again; reviving it through the
+        claim path would turn a test press into a scheduled execution."""
+        job_id = await seed_job(pg_session, "heal-manual")
+        manual_run_id = await seed_run(
+            pg_session,
+            job_id,
+            started_at="NOW() - INTERVAL '2 hours'",
+            last_seen_at="NOW() - INTERVAL '1 hour'",
+            trigger="manual",
+        )
+        await pg_session.commit()
+
+        await _pg_engine(pg_session)._heal_stuck_runs()
+
+        assert await run_status(pg_session, manual_run_id) == "interrupted"
+        assert await job_retry_at(pg_session, job_id) is None
+        r = await pg_session.execute(
+            text("SELECT notice_due_at FROM scheduled_job_runs WHERE id = :id"), {"id": manual_run_id}
+        )
+        assert r.scalar_one() is None
 
     @pytest.mark.asyncio
     async def test_heal_does_not_touch_completed_runs(self, pg_session: AsyncSession):
         """Completed runs are not affected by healing."""
-        user_id = "heal-user-2"
-        await pg_session.execute(
-            text(
-                "INSERT INTO users (id, sub, email, first_name, last_name, is_administrator, role, status) VALUES (:id, :sub, :email, :fn, :ln, false, 'member', 'active')"
-            ),
-            {"id": user_id, "sub": "heal-sub-2", "email": "heal2@test.com", "fn": "Heal", "ln": "Two"},
+        job_id = await seed_job(pg_session, "heal-done")
+        old_success_run_id = await seed_run(
+            pg_session, job_id, status="success", started_at="NOW() - INTERVAL '45 minutes'", completed_at="NOW()"
         )
-        result = await pg_session.execute(
-            text("""
-                INSERT INTO scheduled_jobs
-                    (user_id, name, job_type, schedule_kind, interval_seconds, next_run_at, enabled, max_failures, consecutive_failures, destroy_after_trigger, check_tool, cel_expr)
-                VALUES
-                    (:uid, 'Heal Job 2', 'watch', 'interval', 3600, NOW() + INTERVAL '1 hour', true, 3, 0, true, 'ping_tool', 'result != null')
-                RETURNING id
-            """),
-            {"uid": user_id},
-        )
-        job_id = result.mappings().first()["id"]
-
-        stale_started = datetime.now(timezone.utc) - timedelta(minutes=45)
-        result = await pg_session.execute(
-            text("""
-                INSERT INTO scheduled_job_runs (job_id, started_at, completed_at, status)
-                VALUES (:job_id, :started_at, NOW(), 'success')
-                RETURNING id
-            """),
-            {"job_id": job_id, "started_at": stale_started},
-        )
-        old_success_run_id = result.mappings().first()["id"]
         await pg_session.commit()
 
-        engine = _make_engine(db_session_factory=make_pg_session_factory(pg_session))
-        await engine._heal_stuck_runs()
+        await _pg_engine(pg_session)._heal_stuck_runs()
 
-        # Old success run should remain 'success'
-        r = await pg_session.execute(
-            text("SELECT status FROM scheduled_job_runs WHERE id = :id"), {"id": old_success_run_id}
-        )
-        assert r.scalar_one() == "success"
+        assert await run_status(pg_session, old_success_run_id) == "success"
 
     @pytest.mark.asyncio
-    async def test_in_flight_run_is_never_healed(self, pg_session: AsyncSession):
-        """A dispatch this process is still running is not stuck, however long it takes.
-
-        The healer runs on every tick now, so without this exclusion a slow agent would
-        have its own run marked failed underneath it — and then overwrite that verdict
-        when it finished.
-        """
-        user_id = "heal-user-3"
-        await pg_session.execute(
-            text(
-                "INSERT INTO users (id, sub, email, first_name, last_name, is_administrator, role, status) VALUES (:id, :sub, :email, :fn, :ln, false, 'member', 'active')"
-            ),
-            {"id": user_id, "sub": "heal-sub-3", "email": "heal3@test.com", "fn": "Heal", "ln": "Three"},
+    async def test_a_swept_run_stays_swept_when_its_dispatcher_finishes(self, pg_session: AsyncSession):
+        """If the healer was wrong and the dispatcher was merely slow to report, its late
+        completion must not flip the row back: the retry is already on its way, and a
+        row reading 'success' would hide that the job ran twice."""
+        repo = ScheduledJobRepository()
+        job_id = await seed_job(pg_session, "heal-late")
+        run_id = await seed_run(
+            pg_session, job_id, started_at="NOW() - INTERVAL '10 minutes'", last_seen_at="NOW() - INTERVAL '5 minutes'"
         )
-        result = await pg_session.execute(
-            text("""
-                INSERT INTO scheduled_jobs
-                    (user_id, name, job_type, schedule_kind, interval_seconds, next_run_at, enabled, max_failures, consecutive_failures, destroy_after_trigger, check_tool, cel_expr)
-                VALUES
-                    (:uid, 'Heal Job 3', 'watch', 'interval', 3600, NOW() + INTERVAL '1 hour', true, 3, 0, true, 'ping_tool', 'result != null')
-                RETURNING id
-            """),
-            {"uid": user_id},
-        )
-        job_id = result.mappings().first()["id"]
-
-        long_started = datetime.now(timezone.utc) - timedelta(hours=3)
-        result = await pg_session.execute(
-            text("""
-                INSERT INTO scheduled_job_runs (job_id, started_at, status)
-                VALUES (:job_id, :started_at, 'running')
-                RETURNING id
-            """),
-            {"job_id": job_id, "started_at": long_started},
-        )
-        live_run_id = result.mappings().first()["id"]
         await pg_session.commit()
 
-        engine = _make_engine(db_session_factory=make_pg_session_factory(pg_session))
-        engine._in_flight.add(live_run_id)
+        await _pg_engine(pg_session)._heal_stuck_runs()
+        assert await run_status(pg_session, run_id) == "interrupted"
 
-        await engine._heal_stuck_runs()
+        changed = await repo.complete_run(pg_session, run_id, JobRunStatus.SUCCESS, delivered=True)
+        await pg_session.commit()
 
-        r = await pg_session.execute(
-            text("SELECT status FROM scheduled_job_runs WHERE id = :id"), {"id": live_run_id}
-        )
-        assert r.scalar_one() == "running"
+        assert changed is False
+        assert await run_status(pg_session, run_id) == "interrupted"
 
 
 class TestFinalizeAdvancesDespiteRunWriteFailure:
@@ -388,7 +342,7 @@ class TestFinalizeAdvancesDespiteRunWriteFailure:
         repo.complete_run = AsyncMock(side_effect=RuntimeError("column does not exist"))
 
         engine = _make_engine(repo=repo)
-        job = _make_job(job_id=77, schedule_kind=ScheduleKind.INTERVAL, interval_seconds=3600)
+        job = make_job(job_id=77, schedule_kind=ScheduleKind.INTERVAL, interval_seconds=3600)
 
         # Must not raise: the caller has nothing useful to do with a bookkeeping failure.
         await engine._finalize(run_id=99, job=job, status=JobRunStatus.SUCCESS)
@@ -399,6 +353,22 @@ class TestFinalizeAdvancesDespiteRunWriteFailure:
         assert kwargs["next_run_at"] > datetime.now(timezone.utc)
 
     @pytest.mark.asyncio
+    async def test_a_run_that_cannot_be_recorded_is_still_closed(self):
+        """Left 'running', the healer would call it interrupted and re-execute a job whose
+        result the user already has. The fallback touches only columns the table has
+        always had — the write that shaped this code failed on a column it did not."""
+        repo = AsyncMock(spec=ScheduledJobRepository)
+        repo.complete_job = AsyncMock()
+        repo.complete_run = AsyncMock(side_effect=RuntimeError("column does not exist"))
+        repo.close_run_minimally = AsyncMock()
+
+        engine = _make_engine(repo=repo)
+        await engine._finalize(run_id=99, job=make_job(), status=JobRunStatus.SUCCESS)
+
+        repo.close_run_minimally.assert_awaited_once()
+        assert repo.close_run_minimally.call_args[0][1:3] == (99, JobRunStatus.SUCCESS)
+
+    @pytest.mark.asyncio
     async def test_schedule_advances_before_the_run_is_recorded(self):
         """Ordering, not just independence — the advance cannot be the write's hostage."""
         calls: list[str] = []
@@ -407,7 +377,7 @@ class TestFinalizeAdvancesDespiteRunWriteFailure:
         repo.complete_run = AsyncMock(side_effect=lambda **_: calls.append("run"))
 
         engine = _make_engine(repo=repo)
-        await engine._finalize(run_id=1, job=_make_job(), status=JobRunStatus.SUCCESS)
+        await engine._finalize(run_id=1, job=make_job(), status=JobRunStatus.SUCCESS)
 
         assert calls == ["job", "run"]
 
@@ -427,7 +397,7 @@ class TestDispatchJobNoToken:
         token_service.get_access_token.side_effect = ValueError("No offline token stored")
 
         engine = _make_engine(repo=repo, token_service=token_service)
-        job = _make_job()
+        job = make_job()
 
         await engine._dispatch_job(job)
 
@@ -480,22 +450,24 @@ class TestFinalizeJobState:
         kwargs = repo.complete_job.call_args[1]
         # Once job: compute_next_run returns None → next_run_at=None → disabled
         assert kwargs["next_run_at"] is None
-        assert kwargs["success"] is True
+        assert kwargs["status"] is JobRunStatus.SUCCESS
 
     @pytest.mark.asyncio
     async def test_failure_increments_passed_to_repo(self):
-        """On failure, success=False is passed so the repo can increment consecutive_failures."""
+        """On failure the status reaches the repo, which is what increments consecutive_failures."""
         repo = AsyncMock(spec=ScheduledJobRepository)
         repo.complete_run = AsyncMock()
         repo.complete_job = AsyncMock()
 
         engine = _make_engine(repo=repo)
-        interval_job = _make_job(schedule_kind=ScheduleKind.INTERVAL, interval_seconds=300)
+        interval_job = make_job(schedule_kind=ScheduleKind.INTERVAL, interval_seconds=300)
 
         await engine._finalize(run_id=5, job=interval_job, status=JobRunStatus.FAILED, error_message="Oops")
 
         kwargs = repo.complete_job.call_args[1]
-        assert kwargs["success"] is False
+        assert kwargs["status"] is JobRunStatus.FAILED
+        # A failure is not an interruption: no fresh attempt is owed.
+        assert kwargs["retry_at"] is None
 
     @pytest.mark.asyncio
     async def test_condition_not_met_counts_as_success(self):
@@ -505,12 +477,12 @@ class TestFinalizeJobState:
         repo.complete_job = AsyncMock()
 
         engine = _make_engine(repo=repo)
-        watch_job = _make_job(job_type=JobType.WATCH, schedule_kind=ScheduleKind.INTERVAL, interval_seconds=60)
+        watch_job = make_job(job_type=JobType.WATCH, schedule_kind=ScheduleKind.INTERVAL, interval_seconds=60)
 
         await engine._finalize(run_id=2, job=watch_job, status=JobRunStatus.CONDITION_NOT_MET)
 
         kwargs = repo.complete_job.call_args[1]
-        assert kwargs["success"] is True
+        assert kwargs["status"] is JobRunStatus.CONDITION_NOT_MET
 
     @pytest.mark.asyncio
     async def test_destroy_after_trigger_disables_watch_job(self):
@@ -529,7 +501,7 @@ class TestFinalizeJobState:
 
         engine = _make_engine(repo=repo, db_session_factory=factory)
 
-        watch_job = _make_job(
+        watch_job = make_job(
             job_type=JobType.WATCH,
             schedule_kind=ScheduleKind.INTERVAL,
             interval_seconds=60,
@@ -561,7 +533,7 @@ class TestFinalizeJobState:
 
         engine = _make_engine(repo=repo, db_session_factory=factory)
 
-        watch_job = _make_job(
+        watch_job = make_job(
             job_type=JobType.WATCH,
             schedule_kind=ScheduleKind.INTERVAL,
             interval_seconds=60,
@@ -583,7 +555,7 @@ class TestFinalizeJobState:
         repo.complete_job = AsyncMock()
 
         engine = _make_engine(repo=repo)
-        interval_job = _make_job()
+        interval_job = make_job()
 
         reason = "No offline token stored. User must re-grant scheduler consent."
         await engine._finalize(
@@ -607,7 +579,7 @@ class TestFinalizeJobState:
         socket_manager.send_notification = AsyncMock(return_value=True)
 
         engine = _make_engine(repo=repo, socket_manager=socket_manager)
-        job = _make_job(user_id="notify-user")
+        job = make_job(user_id="notify-user")
 
         await engine._finalize(run_id=8, job=job, status=JobRunStatus.SUCCESS)
 
@@ -645,7 +617,7 @@ class TestDispatchErrorHandling:
             "console_backend.services.scheduler_engine.dispatch_streaming",
             new=AsyncMock(side_effect=http_error),
         ):
-            await engine._dispatch_job(_make_job(), run_id=99)
+            await engine._dispatch_job(make_job(), run_id=99)
 
         repo.complete_run.assert_awaited_once()
         kwargs = repo.complete_run.await_args.kwargs
@@ -669,12 +641,83 @@ class TestDispatchErrorHandling:
             "console_backend.services.scheduler_engine.dispatch_streaming",
             new=AsyncMock(side_effect=RuntimeError("assessor exploded")),
         ):
-            await engine._dispatch_job(_make_job(), run_id=99)
+            await engine._dispatch_job(make_job(), run_id=99)
 
         repo.complete_run.assert_awaited_once()
         kwargs = repo.complete_run.await_args.kwargs
         assert kwargs["status"] == JobRunStatus.FAILED
         assert "assessor exploded" in (kwargs["error_message"] or "")
+
+
+class TestInterruptionIsDecidedByTheDispatch:
+    """Only dispatch_streaming can say the agent died. It says so with AgentUnreachable;
+    everything else that goes wrong on the way to it is a failure of the run."""
+
+    @staticmethod
+    def _engine(token_error: Exception | None = None) -> tuple[SchedulerEngine, AsyncMock]:
+        repo = AsyncMock(spec=ScheduledJobRepository)
+        repo.create_run = AsyncMock(return_value=99)
+        token_service = AsyncMock(spec=SchedulerTokenService)
+        if token_error is None:
+            token_service.get_access_token = AsyncMock(return_value="token-xyz")
+        else:
+            token_service.get_access_token = AsyncMock(side_effect=token_error)
+        return _make_engine(repo=repo, token_service=token_service), repo
+
+    @pytest.mark.asyncio
+    async def test_an_unreachable_runner_interrupts_a_scheduled_run_and_earns_a_retry(self):
+        engine, repo = self._engine()
+        with patch(
+            "console_backend.services.scheduler_engine.dispatch_streaming",
+            new=AsyncMock(side_effect=AgentUnreachable("connection refused")),
+        ):
+            await engine._dispatch_job(make_job(), run_id=99)
+
+        assert repo.complete_run.await_args.kwargs["status"] == JobRunStatus.INTERRUPTED
+        assert repo.complete_run.await_args.kwargs["notice_due_at"] is None, "the first loss is not news"
+        assert repo.complete_job.await_args.kwargs["retry_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_an_interrupted_retry_owes_a_notice_and_no_further_retry(self):
+        engine, repo = self._engine()
+        with patch(
+            "console_backend.services.scheduler_engine.dispatch_streaming",
+            new=AsyncMock(side_effect=AgentUnreachable("connection refused")),
+        ):
+            await engine._dispatch_job(make_job(), run_id=99, trigger=RunTrigger.RETRY)
+
+        assert repo.complete_run.await_args.kwargs["status"] == JobRunStatus.INTERRUPTED
+        assert repo.complete_run.await_args.kwargs["notice_due_at"] is not None
+        assert repo.complete_job.await_args.kwargs["retry_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_an_interrupted_manual_run_earns_neither(self):
+        """The user pressed Run Now and is present; a retry would turn a test press into a
+        scheduled execution, and a notice would tell them what they watched happen."""
+        engine, repo = self._engine()
+        with patch(
+            "console_backend.services.scheduler_engine.dispatch_streaming",
+            new=AsyncMock(side_effect=AgentUnreachable("connection refused")),
+        ):
+            await engine.run_job_now(make_job(), run_id=99)
+
+        assert repo.complete_run.await_args.kwargs["status"] == JobRunStatus.INTERRUPTED
+        assert repo.complete_run.await_args.kwargs["notice_due_at"] is None
+        assert repo.complete_job.await_args.kwargs["retry_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_a_transport_error_before_the_dispatch_is_a_failure(self):
+        """Keycloak refusing the token refresh is not the agent dying: nothing was
+        running, so it counts against the job like any other failure."""
+        engine, repo = self._engine(
+            token_error=httpx.ConnectError("keycloak down", request=httpx.Request("POST", "http://keycloak/"))
+        )
+        with patch("console_backend.services.scheduler_engine.dispatch_streaming") as dispatch:
+            await engine._dispatch_job(make_job(), run_id=99)
+
+        dispatch.assert_not_called()
+        assert repo.complete_run.await_args.kwargs["status"] == JobRunStatus.FAILED
+        assert repo.complete_job.await_args.kwargs["retry_at"] is None
 
 
 class TestFinalizeInvalidTimezone:
@@ -691,7 +734,7 @@ class TestFinalizeInvalidTimezone:
         repo.complete_job = AsyncMock()
 
         engine = _make_engine(repo=repo)
-        job = _make_job(schedule_kind=ScheduleKind.CRON, interval_seconds=None)
+        job = make_job(schedule_kind=ScheduleKind.CRON, interval_seconds=None)
         job.cron_expr = "0 8 * * *"
         job.timezone = "Zurich"  # migrated verbatim from unvalidated user settings
 
@@ -718,7 +761,7 @@ class TestBuildMessageArgs:
     @pytest.mark.asyncio
     async def test_a_triggered_watch_with_an_agent_carries_instruction_and_result(self):
         engine = _make_engine()
-        job = _make_job(job_type=JobType.WATCH)
+        job = make_job(job_type=JobType.WATCH)
         job.check_tool = "ping_tool"
         job.cel_expr = "result.status != ''"
         job.timezone = "Europe/Zurich"
@@ -742,7 +785,7 @@ class TestBuildMessageArgs:
     @pytest.mark.asyncio
     async def test_an_agent_without_an_instruction_gets_a_default(self):
         engine = _make_engine()
-        job = _make_job(job_type=JobType.WATCH)
+        job = make_job(job_type=JobType.WATCH)
         job.prompt = ""
         job.check_tool = "ping_tool"
 
@@ -758,7 +801,7 @@ class TestBuildMessageArgs:
     @pytest.mark.asyncio
     async def test_a_notification_only_watch_carries_the_written_message(self):
         engine = _make_engine()
-        job = _make_job(job_type=JobType.WATCH, sub_agent_id=None)
+        job = make_job(job_type=JobType.WATCH, sub_agent_id=None)
         job.check_tool = "ping_tool"
         job.notification_message = "Sync broke again."
 
@@ -777,7 +820,7 @@ class TestBuildMessageArgs:
         # It used to be written inside the agent run, which is why a watch that only
         # notifies needed an agent at all.
         engine = _make_engine()
-        job = _make_job(job_type=JobType.WATCH, sub_agent_id=None)
+        job = make_job(job_type=JobType.WATCH, sub_agent_id=None)
         job.check_tool = "ping_tool"
         job.notification_message = ""
 
@@ -806,7 +849,7 @@ class TestBuildMessageArgs:
             "secret": "s3cret",
             "message_formatting": "slack",
         }
-        job = _make_job(delivery_channel_id=3)
+        job = make_job(delivery_channel_id=3)
 
         _, metadata, push_config = await engine._build_message_args(
             job, run_id=7, access_token="tok", db=AsyncMock()
@@ -820,7 +863,7 @@ class TestBuildMessageArgs:
     @pytest.mark.asyncio
     async def test_a_job_without_a_channel_writes_markdown(self):
         engine = _make_engine()
-        job = _make_job(delivery_channel_id=None)
+        job = make_job(delivery_channel_id=None)
 
         _, metadata, push_config = await engine._build_message_args(
             job, run_id=7, access_token="tok", db=AsyncMock()
@@ -838,7 +881,7 @@ class TestBuildMessageArgs:
             "secret": "s3cret",
             "message_formatting": "slack",
         }
-        job = _make_job(delivery_channel_id=3).model_copy(update={"voice_call": True})
+        job = make_job(delivery_channel_id=3).model_copy(update={"voice_call": True})
 
         with patch.object(engine, "_resolve_voice_agent_id", AsyncMock(return_value=77)):
             _, metadata, _ = await engine._build_message_args(
@@ -856,7 +899,7 @@ class TestBuildMessageArgs:
             "secret": "s3cret",
             "message_formatting": "slack",
         }
-        job = _make_job(delivery_channel_id=3).model_copy(update={"voice_call": True})
+        job = make_job(delivery_channel_id=3).model_copy(update={"voice_call": True})
 
         with patch.object(engine, "_resolve_voice_agent_id", AsyncMock(return_value=None)):
             _, metadata, _ = await engine._build_message_args(
@@ -875,7 +918,7 @@ class TestWatchEvaluatedBeforeDispatch:
 
     @staticmethod
     def _watch_job(**overrides) -> ScheduledJob:
-        job = _make_job(job_type=JobType.WATCH, sub_agent_id=None, **overrides)
+        job = make_job(job_type=JobType.WATCH, sub_agent_id=None, **overrides)
         return job.model_copy(
             update={
                 "check_tool": "naonous_get_campaign",
@@ -1003,7 +1046,7 @@ class TestVoiceCallDispatch:
 
     @staticmethod
     def _watch_job(**overrides) -> ScheduledJob:
-        job = _make_job(job_type=JobType.WATCH, sub_agent_id=None, **overrides)
+        job = make_job(job_type=JobType.WATCH, sub_agent_id=None, **overrides)
         return job.model_copy(
             update={"check_tool": "naonous_get_campaign", "cel_expr": "result.status", "voice_call": True}
         )
@@ -1064,7 +1107,7 @@ class TestVoiceCallDispatch:
         repo = AsyncMock(spec=ScheduledJobRepository)
         repo.create_run.return_value = 22
         engine = _make_engine(repo=repo)
-        job = _make_job(job_type=JobType.TASK, sub_agent_id=42).model_copy(update={"voice_call": True})
+        job = make_job(job_type=JobType.TASK, sub_agent_id=42).model_copy(update={"voice_call": True})
         call = await self._dispatch(engine, job, None)
 
         assert call["metadata"]["sub_agent_id"] == 99
@@ -1185,7 +1228,7 @@ class TestWriteNotification:
     @pytest.mark.asyncio
     async def test_the_model_writes_it(self):
         engine = _make_engine()
-        job = _make_job(job_type=JobType.WATCH, sub_agent_id=None)
+        job = make_job(job_type=JobType.WATCH, sub_agent_id=None)
         chat = AsyncMock(return_value='  "Campaign 4821 stopped syncing."  ')
         with patch("console_backend.services.scheduler_engine.gateway_chat", chat):
             with patch(
@@ -1206,7 +1249,7 @@ class TestWriteNotification:
         # A watch that triggered has something to report; silence would be the worst
         # possible outcome, so the raw result is reported instead.
         engine = _make_engine()
-        job = _make_job(job_type=JobType.WATCH, sub_agent_id=None)
+        job = make_job(job_type=JobType.WATCH, sub_agent_id=None)
         with patch(
             "console_backend.services.scheduler_engine.gateway_chat",
             AsyncMock(side_effect=RuntimeError("gateway down")),
@@ -1224,7 +1267,7 @@ class TestWriteNotification:
     @pytest.mark.asyncio
     async def test_no_configured_model_still_says_something(self):
         engine = _make_engine()
-        job = _make_job(job_type=JobType.WATCH, sub_agent_id=None)
+        job = make_job(job_type=JobType.WATCH, sub_agent_id=None)
         with patch(
             "console_backend.services.scheduler_engine.ModelDefaultsRepository.get_all",
             AsyncMock(return_value={}),
@@ -1237,7 +1280,7 @@ class TestWriteNotification:
     @pytest.mark.asyncio
     async def test_an_empty_result_needs_no_model(self):
         engine = _make_engine()
-        job = _make_job(job_type=JobType.WATCH, sub_agent_id=None)
+        job = make_job(job_type=JobType.WATCH, sub_agent_id=None)
         with patch(
             "console_backend.services.scheduler_engine.gateway_chat", AsyncMock()
         ) as chat:
@@ -1251,7 +1294,7 @@ class TestConditionEvaluationIsPersisted:
 
     @staticmethod
     def _watch_job() -> ScheduledJob:
-        job = _make_job(job_type=JobType.WATCH, sub_agent_id=None)
+        job = make_job(job_type=JobType.WATCH, sub_agent_id=None)
         return job.model_copy(update={"check_tool": "t", "cel_expr": "result.status"})
 
     @pytest.mark.asyncio
@@ -1326,6 +1369,6 @@ class TestConditionEvaluationIsPersisted:
             "console_backend.services.scheduler_engine.dispatch_streaming",
             AsyncMock(return_value={"result": {"kind": "task", "artifacts": []}}),
         ):
-            await engine._dispatch_job(_make_job(job_type=JobType.TASK, sub_agent_id=42))
+            await engine._dispatch_job(make_job(job_type=JobType.TASK, sub_agent_id=42))
 
         assert repo.complete_run.call_args[1]["condition_evaluation"] is None

--- a/packages/console-backend/tests/test_scheduler_recovery.py
+++ b/packages/console-backend/tests/test_scheduler_recovery.py
@@ -1,0 +1,492 @@
+"""Recovery for runs interrupted by a process death.
+
+Real-database tests: the behaviour under test is almost entirely SQL — a CASE that
+must not move a counter, and a claim predicate with a second wake-up reason — so a
+mocked repository would assert nothing. See
+docs/adr/0007-interrupted-runs-get-one-fresh-attempt.md.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from console_backend.models.scheduled_job import JobRunStatus, RunTrigger
+from console_backend.repositories.scheduled_job_repository import ScheduledJobRepository
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from tests.scheduler_helpers import job_retry_at, run_status, seed_job, seed_run
+
+
+class TestFailureAccounting:
+    """An interruption is evidence about the runtime, not about the job."""
+
+    @pytest.mark.asyncio
+    async def test_interruption_does_not_move_the_failure_counter(self, pg_session: AsyncSession):
+        """Neither incremented (churn would auto-pause a healthy job) nor reset (it would
+        launder a real failure streak)."""
+        repo = ScheduledJobRepository()
+        job_id = await seed_job(pg_session, "counter", consecutive_failures=2)
+        await pg_session.commit()
+
+        async def _failures() -> int:
+            r = await pg_session.execute(
+                text("SELECT consecutive_failures FROM scheduled_jobs WHERE id = :id"), {"id": job_id}
+            )
+            return r.scalar_one()
+
+        await repo.complete_job(
+            db=pg_session,
+            job_id=job_id,
+            status=JobRunStatus.INTERRUPTED,
+            next_run_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            retry_at=datetime.now(timezone.utc),
+        )
+        await pg_session.commit()
+        assert await _failures() == 2
+
+        await repo.complete_job(
+            db=pg_session,
+            job_id=job_id,
+            status=JobRunStatus.FAILED,
+            next_run_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+        await pg_session.commit()
+        assert await _failures() == 3, "a genuine failure still counts"
+
+    @pytest.mark.asyncio
+    async def test_interruption_never_auto_pauses(self, pg_session: AsyncSession):
+        """A job one failure short of max_failures survives any number of interruptions."""
+        repo = ScheduledJobRepository()
+        job_id = await seed_job(pg_session, "nopause", consecutive_failures=2)  # max_failures = 3
+        await pg_session.commit()
+
+        for _ in range(3):
+            await repo.complete_job(
+                db=pg_session,
+                job_id=job_id,
+                status=JobRunStatus.INTERRUPTED,
+                next_run_at=datetime.now(timezone.utc) + timedelta(hours=1),
+                retry_at=datetime.now(timezone.utc),
+            )
+        await pg_session.commit()
+
+        r = await pg_session.execute(
+            text("SELECT enabled, paused_reason FROM scheduled_jobs WHERE id = :id"), {"id": job_id}
+        )
+        row = r.mappings().first()
+        assert row["enabled"] is True
+        assert row["paused_reason"] is None
+
+
+class TestRetryMarkerSurvivesOtherCompletions:
+    """complete_job only ever writes retry_at, never clears it."""
+
+    @pytest.mark.asyncio
+    async def test_a_normal_completion_keeps_an_earned_retry(self, pg_session: AsyncSession):
+        """Runs of one job complete out of order — a manual run finishing after the healer
+        marked a scheduled one lost. A completion that wiped the marker would silently
+        cancel an attempt that was earned."""
+        repo = ScheduledJobRepository()
+        job_id = await seed_job(pg_session, "keep", retry_at="NOW() + INTERVAL '1 minute'")
+        await pg_session.commit()
+
+        await repo.complete_job(
+            db=pg_session,
+            job_id=job_id,
+            status=JobRunStatus.SUCCESS,
+            next_run_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+        await pg_session.commit()
+
+        assert await job_retry_at(pg_session, job_id) is not None
+
+
+class TestRetryClaiming:
+    """retry_at is the claim loop's second wake-up reason."""
+
+    @pytest.mark.asyncio
+    async def test_due_retry_is_claimed_and_the_marker_consumed(self, pg_session: AsyncSession):
+        """Claimed even though next_run_at is an hour away, and handed out only once."""
+        repo = ScheduledJobRepository()
+        job_id = await seed_job(pg_session, "claim", retry_at="NOW() - INTERVAL '1 minute'")
+        await pg_session.commit()
+
+        claimed = await repo.claim_due_jobs(pg_session, limit=10)
+        await pg_session.commit()
+
+        mine = next(c for c in claimed if c.job.id == job_id)
+        # The claim says why the job was due, so the engine never infers it from a
+        # marker the same statement has just consumed.
+        assert mine.trigger is RunTrigger.RETRY
+        assert await job_retry_at(pg_session, job_id) is None
+
+    @pytest.mark.asyncio
+    async def test_a_job_due_on_its_schedule_is_a_scheduled_claim(self, pg_session: AsyncSession):
+        repo = ScheduledJobRepository()
+        job_id = await seed_job(pg_session, "sched", next_run_at="NOW() - INTERVAL '1 minute'")
+        await pg_session.commit()
+
+        claimed = await repo.claim_due_jobs(pg_session, limit=10)
+        await pg_session.commit()
+
+        assert next(c for c in claimed if c.job.id == job_id).trigger is RunTrigger.SCHEDULED
+
+    @pytest.mark.asyncio
+    async def test_a_job_with_a_run_still_running_is_not_claimed(self, pg_session: AsyncSession):
+        """The schedule does not advance until a run completes, so after a restart a
+        stranded run would let its job be re-claimed through the stale next_run_at —
+        and then earn a retry on top when the healer sweeps it. One loss, one attempt."""
+        repo = ScheduledJobRepository()
+        job_id = await seed_job(pg_session, "running", next_run_at="NOW() - INTERVAL '1 minute'")
+        run_id = await seed_run(pg_session, job_id, started_at="NOW() - INTERVAL '30 seconds'")
+        await pg_session.commit()
+
+        claimed = await repo.claim_due_jobs(pg_session, limit=10)
+        await pg_session.commit()
+        assert job_id not in [c.job.id for c in claimed]
+
+        # Once the healer (or the dispatcher) has closed the run, the job is claimable again.
+        await pg_session.execute(
+            text("UPDATE scheduled_job_runs SET status = 'interrupted', completed_at = NOW() WHERE id = :id"),
+            {"id": run_id},
+        )
+        await pg_session.commit()
+        claimed = await repo.claim_due_jobs(pg_session, limit=10)
+        await pg_session.commit()
+        assert job_id in [c.job.id for c in claimed]
+
+    @pytest.mark.asyncio
+    async def test_future_retry_is_not_claimed(self, pg_session: AsyncSession):
+        """The delay before a fresh attempt is real: a runner still restarting is not
+        immediately handed the same work."""
+        repo = ScheduledJobRepository()
+        job_id = await seed_job(pg_session, "future", retry_at="NOW() + INTERVAL '5 minutes'")
+        await pg_session.commit()
+
+        claimed = await repo.claim_due_jobs(pg_session, limit=10)
+        await pg_session.commit()
+
+        assert job_id not in [c.job.id for c in claimed]
+
+    @pytest.mark.asyncio
+    async def test_retry_survives_a_retired_once_job(self, pg_session: AsyncSession):
+        """A 'once' job is retired the moment its occurrence is recorded, so the retry
+        branch cannot require `enabled` — that is the case it exists for."""
+        repo = ScheduledJobRepository()
+        job_id = await seed_job(
+            pg_session,
+            "once",
+            schedule_kind="once",
+            enabled="false",  # compute_next_run returns None for 'once', so complete_job disables it
+            retry_at="NOW() - INTERVAL '1 minute'",
+        )
+        await pg_session.commit()
+
+        claimed = await repo.claim_due_jobs(pg_session, limit=10)
+        await pg_session.commit()
+
+        assert job_id in [c.job.id for c in claimed]
+
+    @pytest.mark.asyncio
+    async def test_retry_does_not_resurrect_a_deliberately_stopped_job(self, pg_session: AsyncSession):
+        """paused_reason separates one-shot retirement from somebody stopping the job."""
+        repo = ScheduledJobRepository()
+        job_id = await seed_job(
+            pg_session,
+            "paused",
+            enabled="false",
+            paused_reason="Manually paused",
+            retry_at="NOW() - INTERVAL '1 minute'",
+        )
+        await pg_session.commit()
+
+        claimed = await repo.claim_due_jobs(pg_session, limit=10)
+        await pg_session.commit()
+
+        assert job_id not in [c.job.id for c in claimed]
+
+
+class TestHeartbeat:
+    """touch_run is what lets the healer sweep on staleness rather than age."""
+
+    @pytest.mark.asyncio
+    async def test_touch_run_refreshes_liveness(self, pg_session: AsyncSession):
+        repo = ScheduledJobRepository()
+        job_id = await seed_job(pg_session, "beat")
+        run_id = await repo.create_run(pg_session, job_id)
+        await pg_session.execute(
+            text("UPDATE scheduled_job_runs SET last_seen_at = NOW() - INTERVAL '1 hour' WHERE id = :id"),
+            {"id": run_id},
+        )
+        await pg_session.commit()
+
+        await repo.touch_run(pg_session, run_id)
+        await pg_session.commit()
+
+        r = await pg_session.execute(
+            text("SELECT NOW() - last_seen_at < INTERVAL '5 seconds' FROM scheduled_job_runs WHERE id = :id"),
+            {"id": run_id},
+        )
+        assert r.scalar_one() is True
+
+    @pytest.mark.asyncio
+    async def test_create_run_starts_alive_and_scheduled(self, pg_session: AsyncSession):
+        """A run must never be stale before its first heartbeat."""
+        repo = ScheduledJobRepository()
+        job_id = await seed_job(pg_session, "fresh")
+        run_id = await repo.create_run(pg_session, job_id)
+        manual_id = await repo.create_run(pg_session, job_id, trigger=RunTrigger.MANUAL)
+        await pg_session.commit()
+
+        r = await pg_session.execute(
+            text("SELECT last_seen_at IS NOT NULL AS alive, trigger FROM scheduled_job_runs WHERE id = :id"),
+            {"id": run_id},
+        )
+        row = r.mappings().first()
+        assert row["alive"] is True
+        assert row["trigger"] == "scheduled"
+        r = await pg_session.execute(text("SELECT trigger FROM scheduled_job_runs WHERE id = :id"), {"id": manual_id})
+        assert r.scalar_one() == "manual"
+
+    @pytest.mark.asyncio
+    async def test_complete_run_records_the_notice_in_the_same_write(self, pg_session: AsyncSession):
+        repo = ScheduledJobRepository()
+        job_id = await seed_job(pg_session, "notice")
+        run_id = await repo.create_run(pg_session, job_id, trigger=RunTrigger.RETRY)
+        await pg_session.commit()
+
+        due = datetime.now(timezone.utc) + timedelta(seconds=90)
+        changed = await repo.complete_run(pg_session, run_id, JobRunStatus.INTERRUPTED, notice_due_at=due)
+        await pg_session.commit()
+
+        assert changed is True
+        assert await run_status(pg_session, run_id) == "interrupted"
+        r = await pg_session.execute(
+            text("SELECT notice_due_at FROM scheduled_job_runs WHERE id = :id"), {"id": run_id}
+        )
+        assert r.scalar_one() == due
+
+
+class TestNoticeDebt:
+    """The notice owed when recovery is exhausted, claimed and cleared in SQL."""
+
+    @staticmethod
+    async def _owed_run(pg_session: AsyncSession, suffix: str, *, due: str, completed: str) -> tuple[int, int]:
+        job_id = await seed_job(pg_session, suffix)
+        run_id = await seed_run(
+            pg_session,
+            job_id,
+            status="interrupted",
+            started_at="NOW() - INTERVAL '3 hours'",
+            completed_at=completed,
+            trigger="retry",
+            notice_due_at=due,
+        )
+        return job_id, run_id
+
+    @pytest.mark.asyncio
+    async def test_due_notice_is_claimed_and_pushed_out(self, pg_session: AsyncSession):
+        """Claiming defers the next attempt, so one round makes one attempt and a
+        failure is retried later without an attempt counter."""
+        repo = ScheduledJobRepository()
+        now = datetime.now(timezone.utc)
+        _, run_id = await self._owed_run(
+            pg_session, "due", due="NOW() - INTERVAL '1 minute'", completed="NOW() - INTERVAL '2 minutes'"
+        )
+        await pg_session.commit()
+
+        claimed = await repo.claim_due_notices(
+            pg_session,
+            next_attempt_at=now + timedelta(minutes=5),
+            give_up_before=now - timedelta(hours=1),
+        )
+        await pg_session.commit()
+
+        assert [c["run_id"] for c in claimed] == [run_id]
+        r = await pg_session.execute(
+            text("SELECT notice_due_at > NOW() FROM scheduled_job_runs WHERE id = :id"), {"id": run_id}
+        )
+        assert r.scalar_one() is True
+
+        await repo.clear_notice(pg_session, run_id)
+        await pg_session.commit()
+        r = await pg_session.execute(
+            text("SELECT notice_due_at FROM scheduled_job_runs WHERE id = :id"), {"id": run_id}
+        )
+        assert r.scalar_one() is None
+
+    @pytest.mark.asyncio
+    async def test_a_future_notice_is_not_claimed(self, pg_session: AsyncSession):
+        """The delay before the first attempt is the point: it lets the agent come back."""
+        repo = ScheduledJobRepository()
+        now = datetime.now(timezone.utc)
+        _, run_id = await self._owed_run(
+            pg_session, "later", due="NOW() + INTERVAL '2 minutes'", completed="NOW()"
+        )
+        await pg_session.commit()
+
+        claimed = await repo.claim_due_notices(
+            pg_session,
+            next_attempt_at=now + timedelta(minutes=5),
+            give_up_before=now - timedelta(hours=1),
+        )
+        await pg_session.commit()
+
+        assert run_id not in [c["run_id"] for c in claimed]
+
+    @pytest.mark.asyncio
+    async def test_an_old_notice_is_abandoned(self, pg_session: AsyncSession):
+        """Past some age the news has stopped being useful, and a notifier still trying
+        through a long outage is its own small stampede."""
+        repo = ScheduledJobRepository()
+        now = datetime.now(timezone.utc)
+        _, run_id = await self._owed_run(
+            pg_session, "stale", due="NOW() - INTERVAL '1 minute'", completed="NOW() - INTERVAL '3 hours'"
+        )
+        await pg_session.commit()
+
+        claimed = await repo.claim_due_notices(
+            pg_session,
+            next_attempt_at=now + timedelta(minutes=5),
+            give_up_before=now - timedelta(hours=1),
+        )
+        await pg_session.commit()
+
+        assert run_id not in [c["run_id"] for c in claimed]
+        r = await pg_session.execute(
+            text("SELECT notice_due_at FROM scheduled_job_runs WHERE id = :id"), {"id": run_id}
+        )
+        assert r.scalar_one() is None, "an abandoned debt must not be reclaimed forever"
+
+    @pytest.mark.asyncio
+    async def test_a_later_completed_run_supersedes_the_notice(self, pg_session: AsyncSession):
+        """Delivering it now would contradict newer news the user already has: a fresh
+        result, followed by a message saying the job could not run."""
+        repo = ScheduledJobRepository()
+        now = datetime.now(timezone.utc)
+        job_id, run_id = await self._owed_run(
+            pg_session, "superseded", due="NOW() - INTERVAL '1 minute'", completed="NOW() - INTERVAL '10 minutes'"
+        )
+        # The next occurrence ran and delivered.
+        await pg_session.execute(
+            text("""
+                INSERT INTO scheduled_job_runs (job_id, started_at, completed_at, status, delivered)
+                VALUES (:job_id, NOW() - INTERVAL '5 minutes', NOW() - INTERVAL '4 minutes', 'success', TRUE)
+            """),
+            {"job_id": job_id},
+        )
+        await pg_session.commit()
+
+        claimed = await repo.claim_due_notices(
+            pg_session,
+            next_attempt_at=now + timedelta(minutes=5),
+            give_up_before=now - timedelta(hours=1),
+        )
+        await pg_session.commit()
+
+        assert run_id not in [c["run_id"] for c in claimed]
+        r = await pg_session.execute(
+            text("SELECT notice_due_at FROM scheduled_job_runs WHERE id = :id"), {"id": run_id}
+        )
+        assert r.scalar_one() is None
+
+    @pytest.mark.asyncio
+    async def test_a_later_lost_run_supersedes_nothing(self, pg_session: AsyncSession):
+        """Keyed on a later run *completing*, not on the schedule coming round: if the
+        next run is lost too, nothing has superseded anything."""
+        repo = ScheduledJobRepository()
+        now = datetime.now(timezone.utc)
+        job_id, run_id = await self._owed_run(
+            pg_session, "stillrunning", due="NOW() - INTERVAL '1 minute'", completed="NOW() - INTERVAL '10 minutes'"
+        )
+        # The next occurrence started and is still in flight — nothing delivered.
+        await pg_session.execute(
+            text("""
+                INSERT INTO scheduled_job_runs (job_id, started_at, status, last_seen_at)
+                VALUES (:job_id, NOW() - INTERVAL '5 minutes', 'running', NOW())
+            """),
+            {"job_id": job_id},
+        )
+        await pg_session.commit()
+
+        claimed = await repo.claim_due_notices(
+            pg_session,
+            next_attempt_at=now + timedelta(minutes=5),
+            give_up_before=now - timedelta(hours=1),
+        )
+        await pg_session.commit()
+
+        assert run_id in [c["run_id"] for c in claimed]
+
+    @pytest.mark.asyncio
+    async def test_an_outage_costing_several_runs_sends_one_notice(self, pg_session: AsyncSession):
+        """Only the newest owed notice survives — one message, not a burst."""
+        repo = ScheduledJobRepository()
+        now = datetime.now(timezone.utc)
+        job_id = await seed_job(pg_session, "burst")
+
+        run_ids = []
+        for minutes_ago in (30, 20, 10):
+            run_ids.append(
+                await seed_run(
+                    pg_session,
+                    job_id,
+                    status="interrupted",
+                    started_at=f"NOW() - INTERVAL '{minutes_ago + 5} minutes'",
+                    completed_at=f"NOW() - INTERVAL '{minutes_ago} minutes'",
+                    trigger="retry",
+                    notice_due_at="NOW() - INTERVAL '1 minute'",
+                )
+            )
+        await pg_session.commit()
+
+        claimed = await repo.claim_due_notices(
+            pg_session,
+            next_attempt_at=now + timedelta(minutes=5),
+            give_up_before=now - timedelta(hours=1),
+        )
+        await pg_session.commit()
+
+        assert [c["run_id"] for c in claimed] == [run_ids[-1]], "the newest loss is the one worth telling"
+        r = await pg_session.execute(
+            text("SELECT COUNT(*) FROM scheduled_job_runs WHERE id = ANY(:ids) AND notice_due_at IS NULL"),
+            {"ids": run_ids[:-1]},
+        )
+        assert r.scalar_one() == 2
+
+    @pytest.mark.asyncio
+    async def test_healer_owes_a_notice_only_for_an_exhausted_retry(self, pg_session: AsyncSession):
+        """The healer is the only witness when the scheduler itself was what died."""
+        repo = ScheduledJobRepository()
+        now = datetime.now(timezone.utc)
+        job_id = await seed_job(pg_session, "healnotice")
+
+        async def _stale_run(trigger: str) -> int:
+            return await seed_run(
+                pg_session,
+                job_id,
+                started_at="NOW() - INTERVAL '2 hours'",
+                last_seen_at="NOW() - INTERVAL '1 hour'",
+                trigger=trigger,
+            )
+
+        retry_run = await _stale_run("retry")
+        first_run = await _stale_run("scheduled")
+        await pg_session.commit()
+
+        await repo.interrupt_stale_runs(
+            pg_session,
+            stale_after_seconds=60,
+            heartbeatless_after_seconds=1800,
+            exclude_run_ids=[],
+            retry_at=now + timedelta(seconds=60),
+            notice_due_at=now + timedelta(seconds=90),
+        )
+        await pg_session.commit()
+
+        r = await pg_session.execute(
+            text("SELECT id, notice_due_at IS NOT NULL AS owed FROM scheduled_job_runs WHERE id = ANY(:ids)"),
+            {"ids": [retry_run, first_run]},
+        )
+        owed = {row["id"]: row["owed"] for row in r.mappings().all()}
+        assert owed[retry_run] is True, "recovery is exhausted; nothing else will tell the user"
+        assert owed[first_run] is False, "this one earned a retry — silence is correct"

--- a/packages/console-backend/tests/test_scheduler_recovery_notice.py
+++ b/packages/console-backend/tests/test_scheduler_recovery_notice.py
@@ -1,0 +1,179 @@
+"""The notice sent when recovery is exhausted.
+
+Delivered by dispatching an ephemeral notification-only job to agent-runner rather
+than by posting to the delivery channel from here — see
+docs/adr/0007-interrupted-runs-get-one-fresh-attempt.md.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from console_backend.models.scheduled_job import JobRunStatus, RunTrigger, ScheduledJob
+from console_backend.repositories.delivery_channel_repository import DeliveryChannelRepository
+from console_backend.repositories.scheduled_job_repository import ScheduledJobRepository
+from console_backend.services.scheduler_engine import SchedulerEngine
+from console_backend.services.scheduler_token_service import SchedulerTokenService
+from tests.scheduler_helpers import make_job
+
+_DISPATCH = "console_backend.services.scheduler_engine.dispatch_streaming"
+
+
+def _make_job(delivery_channel_id: int | None = 7) -> ScheduledJob:
+    return make_job(job_id=11, name="Morning digest", delivery_channel_id=delivery_channel_id)
+
+
+def _make_engine(*, channel: dict | None) -> SchedulerEngine:
+    delivery_channel_repo = AsyncMock(spec=DeliveryChannelRepository)
+    delivery_channel_repo.get_channel_for_dispatch.return_value = channel
+    token_service = AsyncMock(spec=SchedulerTokenService)
+    token_service.get_access_token.return_value = "token-xyz"
+
+    session = AsyncMock()
+    session.__aenter__.return_value = session
+    session.__aexit__.return_value = False
+
+    return SchedulerEngine(
+        repo=AsyncMock(spec=ScheduledJobRepository),
+        delivery_channel_repo=delivery_channel_repo,
+        token_service=token_service,
+        agent_runner_url="http://agent-runner:8000",
+        db_session_factory=lambda: session,
+    )
+
+
+_CHANNEL = {
+    "webhook_url": "https://slack.example/hook",
+    "secret": "s3cret",
+    "message_formatting": "slack",
+}
+
+
+class TestRecoveryNotice:
+    @pytest.mark.asyncio
+    async def test_dispatches_a_notification_only_job(self):
+        """No sub_agent_id, so agent-runner delivers the text and runs no agent."""
+        engine = _make_engine(channel=_CHANNEL)
+
+        with patch(_DISPATCH, new=AsyncMock(return_value={})) as dispatch:
+            await engine._notify_recovery_exhausted(_make_job())
+
+        dispatch.assert_awaited_once()
+        kwargs = dispatch.call_args[1]
+        assert "sub_agent_id" not in kwargs["metadata"], (
+            "a sub_agent_id would make the runner execute an agent for a one-sentence notice"
+        )
+        assert "scheduled_job_run_id" not in kwargs["metadata"], (
+            "the notice is not a run: a run row would go stale, be swept by the healer, "
+            "and earn the job another retry"
+        )
+        assert kwargs["push_config"] == {"url": _CHANNEL["webhook_url"], "token": _CHANNEL["secret"]}
+        assert kwargs["metadata"]["messageFormatting"] == "slack"
+        assert kwargs["timeout_read"] < 300.0, "nothing is computed; do not wait like an agent is working"
+        assert "Morning digest" in kwargs["parts"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_an_unreachable_runner_is_logged_not_raised(self):
+        """The notice is best-effort: the run row already carries the truth."""
+        engine = _make_engine(channel=_CHANNEL)
+
+        with patch(_DISPATCH, new=AsyncMock(side_effect=RuntimeError("connection refused"))):
+            await engine._notify_recovery_exhausted(_make_job())  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_no_channel_means_no_dispatch(self):
+        engine = _make_engine(channel=None)
+
+        with patch(_DISPATCH, new=AsyncMock()) as dispatch:
+            await engine._notify_recovery_exhausted(_make_job(delivery_channel_id=None))
+
+        dispatch.assert_not_awaited()
+
+
+class TestWhenTheNoticeIsOwed:
+    """Only the terminal case speaks: an absorbed interruption is not news."""
+
+    @staticmethod
+    def _notice_due_at(engine: SchedulerEngine) -> object:
+        return engine._repo.complete_run.call_args.kwargs["notice_due_at"]
+
+    @pytest.mark.asyncio
+    async def test_interrupted_retry_records_the_debt(self):
+        """Recorded, not delivered: the agent is mid-restart and this process may be going
+        away. Recorded in the same write as the run's outcome, so a death between the two
+        cannot leave a lost run that owes nothing."""
+        engine = _make_engine(channel=_CHANNEL)
+        engine._notify_recovery_exhausted = AsyncMock()
+
+        await engine._finalize(run_id=5, job=_make_job(), status=JobRunStatus.INTERRUPTED, trigger=RunTrigger.RETRY)
+
+        assert engine._repo.complete_run.call_args.kwargs["run_id"] == 5
+        assert self._notice_due_at(engine) is not None
+        # Delivery belongs to the sweep.
+        engine._notify_recovery_exhausted.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_first_interruption_owes_nothing(self):
+        """It earned a retry; the user hears nothing unless that one is lost too."""
+        engine = _make_engine(channel=_CHANNEL)
+
+        await engine._finalize(run_id=5, job=_make_job(), status=JobRunStatus.INTERRUPTED, trigger=RunTrigger.SCHEDULED)
+
+        assert self._notice_due_at(engine) is None
+
+    @pytest.mark.asyncio
+    async def test_a_plain_failure_owes_nothing(self):
+        """A failed job already reports itself through the normal delivery path."""
+        engine = _make_engine(channel=_CHANNEL)
+
+        await engine._finalize(run_id=5, job=_make_job(), status=JobRunStatus.FAILED, trigger=RunTrigger.RETRY)
+
+        assert self._notice_due_at(engine) is None
+
+
+class TestNoticeSweep:
+    """Delivery is whoever ticks next — the process that recorded the debt may be gone."""
+
+    @pytest.mark.asyncio
+    async def test_delivered_notice_is_cleared(self):
+        engine = _make_engine(channel=_CHANNEL)
+        engine._repo.claim_due_notices.return_value = [{"run_id": 5, "job_id": 11}]
+        engine._repo.get_job.return_value = _make_job()
+        engine._notify_recovery_exhausted = AsyncMock(return_value=True)
+
+        await engine._deliver_due_notices()
+
+        engine._repo.clear_notice.assert_awaited_once()
+        assert engine._repo.clear_notice.call_args[0][1] == 5
+
+    @pytest.mark.asyncio
+    async def test_a_failed_attempt_leaves_the_debt_standing(self):
+        """Claiming already pushed the due time out, so it is simply tried again later."""
+        engine = _make_engine(channel=_CHANNEL)
+        engine._repo.claim_due_notices.return_value = [{"run_id": 5, "job_id": 11}]
+        engine._repo.get_job.return_value = _make_job()
+        engine._notify_recovery_exhausted = AsyncMock(return_value=False)
+
+        await engine._deliver_due_notices()
+
+        engine._repo.clear_notice.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_deleted_job_cancels_the_debt(self):
+        """Nobody left to tell; the obligation must not outlive its subject."""
+        engine = _make_engine(channel=_CHANNEL)
+        engine._repo.claim_due_notices.return_value = [{"run_id": 5, "job_id": 11}]
+        engine._repo.get_job.return_value = None
+        engine._notify_recovery_exhausted = AsyncMock()
+
+        await engine._deliver_due_notices()
+
+        engine._notify_recovery_exhausted.assert_not_awaited()
+        engine._repo.clear_notice.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_sweep_failure_does_not_escape(self):
+        """The tick must keep dispatching jobs even if notices cannot be delivered."""
+        engine = _make_engine(channel=_CHANNEL)
+        engine._repo.claim_due_notices.side_effect = RuntimeError("database is down")
+
+        await engine._deliver_due_notices()  # must not raise

--- a/packages/console-backend/tests/test_scheduler_service.py
+++ b/packages/console-backend/tests/test_scheduler_service.py
@@ -18,6 +18,7 @@ from console_backend.models.scheduled_job import (
 )
 from console_backend.models.user import User, UserRole, UserSettings, UserStatus
 from console_backend.services.scheduler_service import SchedulerService
+from tests.scheduler_helpers import make_job
 
 
 def _make_user(user_id: str = "user-123") -> User:
@@ -29,36 +30,6 @@ def _make_user(user_id: str = "user-123") -> User:
         last_name="User",
         role=UserRole.MEMBER,
         status=UserStatus.ACTIVE,
-    )
-
-
-def _make_job(
-    job_id: int = 1,
-    user_id: str = "user-123",
-    sub_agent_id: int | None = 42,
-    job_type: JobType = JobType.TASK,
-    schedule_kind: ScheduleKind = ScheduleKind.INTERVAL,
-    interval_seconds: int | None = 3600,
-    cel_expr: str | None = None,
-    llm_condition: str | None = None,
-) -> ScheduledJob:
-    now = datetime.now(timezone.utc)
-    return ScheduledJob(
-        id=job_id,
-        user_id=user_id,
-        sub_agent_id=sub_agent_id,
-        name="Test Job",
-        job_type=job_type,
-        schedule_kind=schedule_kind,
-        interval_seconds=interval_seconds,
-        cel_expr=cel_expr,
-        llm_condition=llm_condition,
-        next_run_at=now + timedelta(hours=1),
-        enabled=True,
-        max_failures=3,
-        consecutive_failures=0,
-        created_at=now,
-        updated_at=now,
     )
 
 
@@ -136,7 +107,7 @@ class TestCreateJobAutoSubAgent:
         mock_sub_agent_service.get_accessible_sub_agents.return_value = [created_agent]
 
         mock_repo.create_job.return_value = 1
-        expected_job = _make_job(job_id=1, sub_agent_id=99)
+        expected_job = make_job(job_id=1, sub_agent_id=99)
         mock_repo.get_job.return_value = expected_job
 
         create_data = ScheduledJobCreate(
@@ -178,7 +149,7 @@ class TestCreateJobAutoSubAgent:
         mock_sub_agent_service.create_sub_agent.return_value = created_agent
         mock_sub_agent_service.get_accessible_sub_agents.return_value = [created_agent]
         mock_repo.create_job.return_value = 1
-        mock_repo.get_job.return_value = _make_job(job_id=1, sub_agent_id=77)
+        mock_repo.get_job.return_value = make_job(job_id=1, sub_agent_id=77)
 
         create_data = ScheduledJobCreate(
             sub_agent_id=None,
@@ -214,7 +185,7 @@ class TestCreateJobAutoSubAgent:
         mock_sub_agent_service.create_sub_agent.return_value = created_agent
         mock_sub_agent_service.get_accessible_sub_agents.return_value = [created_agent]
         mock_repo.create_job.return_value = 1
-        mock_repo.get_job.return_value = _make_job(job_id=1, sub_agent_id=55)
+        mock_repo.get_job.return_value = make_job(job_id=1, sub_agent_id=55)
 
         create_data = ScheduledJobCreate(
             sub_agent_id=None,
@@ -267,7 +238,7 @@ class TestCreateJobAccessControl:
         accessible.id = 42
         mock_sub_agent_service.get_accessible_sub_agents.return_value = [accessible]
         mock_repo.create_job.return_value = 1
-        mock_repo.get_job.return_value = _make_job(job_id=1, sub_agent_id=42)
+        mock_repo.get_job.return_value = make_job(job_id=1, sub_agent_id=42)
 
         result = await service.create_job(
             db=db,
@@ -355,7 +326,7 @@ class TestCreateJobNextRunAt:
         mock_repo.create_job.return_value = 1
 
         before = datetime.now(timezone.utc)
-        returned_job = _make_job(job_id=1)
+        returned_job = make_job(job_id=1)
         mock_repo.get_job.return_value = returned_job
 
         await service.create_job(db=db, data=_make_interval_create(), actor=actor)
@@ -374,7 +345,7 @@ class TestCreateJobNextRunAt:
         accessible.id = 42
         mock_sub_agent_service.get_accessible_sub_agents.return_value = [accessible]
         mock_repo.create_job.return_value = 1
-        mock_repo.get_job.return_value = _make_job(job_id=1)
+        mock_repo.get_job.return_value = make_job(job_id=1)
 
         run_at = datetime(2027, 6, 15, 8, 0, 0, tzinfo=timezone.utc)
         once_data = ScheduledJobCreate(
@@ -400,10 +371,10 @@ class TestUpdateJobUnsetSentinel:
     ):
         """Fields not passed to update_job() are excluded from the update payload."""
         db = AsyncMock()
-        existing_job = _make_job(user_id=actor.id)
+        existing_job = make_job(user_id=actor.id)
         mock_repo.get_job.return_value = existing_job
         mock_repo.update_job.return_value = None
-        mock_repo.get_job.side_effect = [existing_job, _make_job(user_id=actor.id)]
+        mock_repo.get_job.side_effect = [existing_job, make_job(user_id=actor.id)]
 
         update_data = ScheduledJobUpdate()  # no fields set
         await service.update_job(db=db, job_id=1, data=update_data, actor=actor)
@@ -420,10 +391,10 @@ class TestUpdateJobUnsetSentinel:
     ):
         """Passing name=None explicitly sets the field to None in the update."""
         db = AsyncMock()
-        existing_job = _make_job(user_id=actor.id)
+        existing_job = make_job(user_id=actor.id)
         mock_repo.get_job.return_value = existing_job
         mock_repo.update_job.return_value = None
-        mock_repo.get_job.side_effect = [existing_job, _make_job(user_id=actor.id)]
+        mock_repo.get_job.side_effect = [existing_job, make_job(user_id=actor.id)]
 
         update_data = ScheduledJobUpdate()
         # We pass name=None explicitly — should be included in fields
@@ -443,7 +414,7 @@ class TestUpdateJobUnsetSentinel:
     ):
         """update_job() validates delivery_channel_id before the DB FK constraint."""
         db = AsyncMock()
-        mock_repo.get_job.return_value = _make_job(user_id=actor.id)
+        mock_repo.get_job.return_value = make_job(user_id=actor.id)
         mock_delivery_channel_repo.get_channel_by_id.return_value = None
 
         with pytest.raises(ValueError, match="Delivery channel 1 not found"):
@@ -462,7 +433,7 @@ class TestUpdateJobUnsetSentinel:
     ):
         """Setting delivery_channel_id=None (clearing) must not trigger an existence check."""
         db = AsyncMock()
-        existing_job = _make_job(user_id=actor.id)
+        existing_job = make_job(user_id=actor.id)
         mock_repo.get_job.side_effect = [existing_job, existing_job]
         mock_repo.update_job.return_value = None
 
@@ -484,7 +455,7 @@ class TestUpdateJobUnsetSentinel:
     ):
         """A watch job can be given a sub_agent_id, subject to the access check."""
         db = AsyncMock()
-        existing_job = _make_job(user_id=actor.id, job_type=JobType.WATCH, sub_agent_id=None)
+        existing_job = make_job(user_id=actor.id, job_type=JobType.WATCH, sub_agent_id=None)
         mock_repo.get_job.side_effect = [existing_job, existing_job]
         mock_repo.update_job.return_value = None
         accessible = MagicMock()
@@ -509,7 +480,7 @@ class TestUpdateJobUnsetSentinel:
     ):
         """Setting sub_agent_id=None on a watch clears it back to notify-only."""
         db = AsyncMock()
-        existing_job = _make_job(user_id=actor.id, job_type=JobType.WATCH)
+        existing_job = make_job(user_id=actor.id, job_type=JobType.WATCH)
         mock_repo.get_job.side_effect = [existing_job, existing_job]
         mock_repo.update_job.return_value = None
 
@@ -527,7 +498,7 @@ class TestUpdateJobUnsetSentinel:
     ):
         """Task jobs require a sub-agent, so clearing it must fail."""
         db = AsyncMock()
-        mock_repo.get_job.return_value = _make_job(user_id=actor.id, job_type=JobType.TASK)
+        mock_repo.get_job.return_value = make_job(user_id=actor.id, job_type=JobType.TASK)
 
         with pytest.raises(ValueError, match="cannot be cleared on a task job"):
             await service.update_job(
@@ -546,7 +517,7 @@ class TestUpdateJobUnsetSentinel:
         check tool on every poll and then fails until it auto-pauses.
         """
         db = AsyncMock()
-        mock_repo.get_job.return_value = _make_job(
+        mock_repo.get_job.return_value = make_job(
             user_id=actor.id, job_type=JobType.WATCH, cel_expr="result.items", llm_condition=None
         )
 
@@ -567,7 +538,7 @@ class TestUpdateJobUnsetSentinel:
     ):
         """The guard is about the effective pair, not about clearing as such."""
         db = AsyncMock()
-        existing_job = _make_job(
+        existing_job = make_job(
             user_id=actor.id,
             job_type=JobType.WATCH,
             cel_expr="result.items",
@@ -589,7 +560,7 @@ class TestUpdateJobUnsetSentinel:
     ):
         """A task has no condition to keep — the guard is watch-only."""
         db = AsyncMock()
-        existing_job = _make_job(user_id=actor.id, job_type=JobType.TASK)
+        existing_job = make_job(user_id=actor.id, job_type=JobType.TASK)
         mock_repo.get_job.side_effect = [existing_job, existing_job]
         mock_repo.update_job.return_value = None
 
@@ -610,7 +581,7 @@ class TestUpdateJobUnsetSentinel:
     ):
         """update_job() returns None when job belongs to a different user."""
         db = AsyncMock()
-        other_user_job = _make_job(user_id="other-user")
+        other_user_job = make_job(user_id="other-user")
         mock_repo.get_job.return_value = other_user_job  # different user
 
         result = await service.update_job(db=db, job_id=1, data=ScheduledJobUpdate(), actor=actor)
@@ -630,7 +601,7 @@ class TestUpdateJobScheduleSwitch:
         self, service: SchedulerService, mock_repo: AsyncMock, actor: User
     ):
         db = AsyncMock()
-        existing_job = _make_job(
+        existing_job = make_job(
             user_id=actor.id, schedule_kind=ScheduleKind.CRON, interval_seconds=None
         )
         existing_job.cron_expr = "0 8 * * *"
@@ -654,7 +625,7 @@ class TestUpdateJobScheduleSwitch:
         self, service: SchedulerService, mock_repo: AsyncMock, actor: User
     ):
         db = AsyncMock()
-        existing_job = _make_job(user_id=actor.id)  # interval job
+        existing_job = make_job(user_id=actor.id)  # interval job
         mock_repo.get_job.side_effect = [existing_job, existing_job]
         mock_repo.update_job.return_value = None
 
@@ -673,7 +644,7 @@ class TestUpdateJobScheduleSwitch:
         self, service: SchedulerService, mock_repo: AsyncMock, actor: User
     ):
         db = AsyncMock()
-        existing_job = _make_job(user_id=actor.id)  # interval job, run_at unset
+        existing_job = make_job(user_id=actor.id)  # interval job, run_at unset
         mock_repo.get_job.return_value = existing_job
 
         with pytest.raises(ValueError, match="'once' requires run_at"):
@@ -687,7 +658,7 @@ class TestUpdateJobScheduleSwitch:
         self, service: SchedulerService, mock_repo: AsyncMock, actor: User
     ):
         db = AsyncMock()
-        existing_job = _make_job(user_id=actor.id)  # interval job, cron_expr unset
+        existing_job = make_job(user_id=actor.id)  # interval job, cron_expr unset
         mock_repo.get_job.return_value = existing_job
 
         with pytest.raises(ValueError, match="'cron' requires cron_expr"):
@@ -703,7 +674,7 @@ class TestUpdateJobScheduleSwitch:
         """Regression: the old code checked for schedule fields in the update payload
         BEFORE adding them, so next_run_at was never recomputed on a schedule change."""
         db = AsyncMock()
-        existing_job = _make_job(user_id=actor.id)  # interval 3600s
+        existing_job = make_job(user_id=actor.id)  # interval 3600s
         mock_repo.get_job.side_effect = [existing_job, existing_job]
         mock_repo.update_job.return_value = None
 
@@ -722,7 +693,7 @@ class TestUpdateJobScheduleSwitch:
         self, service: SchedulerService, mock_repo: AsyncMock, actor: User
     ):
         db = AsyncMock()
-        existing_job = _make_job(user_id=actor.id)
+        existing_job = make_job(user_id=actor.id)
         mock_repo.get_job.side_effect = [existing_job, existing_job]
         mock_repo.update_job.return_value = None
 
@@ -764,7 +735,7 @@ class TestJobTimezone:
         accessible.id = 42
         mock_sub_agent_service.get_accessible_sub_agents.return_value = [accessible]
         mock_repo.create_job.return_value = 1
-        mock_repo.get_job.return_value = _make_job(job_id=1)
+        mock_repo.get_job.return_value = make_job(job_id=1)
 
         await service.create_job(db=db, data=self._cron_create(), actor=actor)
 
@@ -786,7 +757,7 @@ class TestJobTimezone:
         accessible.id = 42
         mock_sub_agent_service.get_accessible_sub_agents.return_value = [accessible]
         mock_repo.create_job.return_value = 1
-        mock_repo.get_job.return_value = _make_job(job_id=1)
+        mock_repo.get_job.return_value = make_job(job_id=1)
 
         await service.create_job(db=db, data=self._cron_create("America/New_York"), actor=actor)
 
@@ -806,7 +777,7 @@ class TestJobTimezone:
         accessible.id = 42
         mock_sub_agent_service.get_accessible_sub_agents.return_value = [accessible]
         mock_repo.create_job.return_value = 1
-        mock_repo.get_job.return_value = _make_job(job_id=1)
+        mock_repo.get_job.return_value = make_job(job_id=1)
 
         await service.create_job(db=db, data=self._cron_create(), actor=actor)
 
@@ -826,7 +797,7 @@ class TestJobTimezone:
         accessible.id = 42
         mock_sub_agent_service.get_accessible_sub_agents.return_value = [accessible]
         mock_repo.create_job.return_value = 1
-        mock_repo.get_job.return_value = _make_job(job_id=1)
+        mock_repo.get_job.return_value = make_job(job_id=1)
 
         once_data = ScheduledJobCreate(
             sub_agent_id=42,
@@ -849,7 +820,7 @@ class TestJobTimezone:
         from zoneinfo import ZoneInfo
 
         db = AsyncMock()
-        existing_job = _make_job(
+        existing_job = make_job(
             user_id=actor.id, schedule_kind=ScheduleKind.CRON, interval_seconds=None
         )
         existing_job.cron_expr = "0 8 * * *"
@@ -874,7 +845,7 @@ class TestResumeJob:
         self, service: SchedulerService, mock_repo: AsyncMock, actor: User
     ):
         now = datetime.now(timezone.utc)
-        job = _make_job(user_id=actor.id, schedule_kind=ScheduleKind.ONCE, interval_seconds=None)
+        job = make_job(user_id=actor.id, schedule_kind=ScheduleKind.ONCE, interval_seconds=None)
         job.run_at = now - timedelta(hours=1)
         job.next_run_at = job.run_at
         job.enabled = False
@@ -889,7 +860,7 @@ class TestResumeJob:
         self, service: SchedulerService, mock_repo: AsyncMock, actor: User
     ):
         now = datetime.now(timezone.utc)
-        job = _make_job(user_id=actor.id, schedule_kind=ScheduleKind.ONCE, interval_seconds=None)
+        job = make_job(user_id=actor.id, schedule_kind=ScheduleKind.ONCE, interval_seconds=None)
         job.run_at = now + timedelta(days=1)
         job.next_run_at = job.run_at
         job.enabled = False
@@ -904,7 +875,7 @@ class TestResumeJob:
         self, service: SchedulerService, mock_repo: AsyncMock, actor: User
     ):
         """An unresolvable stored timezone surfaces as ValueError (→ 400), not KeyError (→ 500)."""
-        job = _make_job(user_id=actor.id, schedule_kind=ScheduleKind.CRON, interval_seconds=None)
+        job = make_job(user_id=actor.id, schedule_kind=ScheduleKind.CRON, interval_seconds=None)
         job.cron_expr = "0 8 * * *"
         job.timezone = "Zurich"  # migrated verbatim from unvalidated user settings
         job.enabled = False
@@ -934,7 +905,7 @@ class TestSettingsTimezoneFallback:
         accessible.id = 42
         mock_sub_agent_service.get_accessible_sub_agents.return_value = [accessible]
         mock_repo.create_job.return_value = 1
-        mock_repo.get_job.return_value = _make_job(job_id=1)
+        mock_repo.get_job.return_value = make_job(job_id=1)
 
         data = ScheduledJobCreate(
             sub_agent_id=42,
@@ -984,7 +955,7 @@ class TestGetRun:
         self, service: SchedulerService, mock_repo: AsyncMock, actor: User
     ):
         db = AsyncMock()
-        mock_repo.get_job.return_value = _make_job(user_id=actor.id)
+        mock_repo.get_job.return_value = make_job(user_id=actor.id)
         sentinel_run = object()
         mock_repo.get_run.return_value = sentinel_run
 
@@ -998,9 +969,83 @@ class TestGetRun:
         self, service: SchedulerService, mock_repo: AsyncMock, actor: User
     ):
         db = AsyncMock()
-        mock_repo.get_job.return_value = _make_job(user_id="other-user")
+        mock_repo.get_job.return_value = make_job(user_id="other-user")
 
         result = await service.get_run(db=db, job_id=1, run_id=42, user_id=actor.id)
 
         assert result is None
         mock_repo.get_run.assert_not_awaited()
+
+
+class TestEnabledToggleIsADeliberateStop:
+    """The scheduler tells a deliberate stop from one-shot retirement by paused_reason,
+    and the retry branch of claim_due_jobs trusts that rather than `enabled`. So a
+    PATCH that flips `enabled` must write the reason — and drop any pending retry."""
+
+    @pytest.mark.asyncio
+    async def test_disabling_writes_a_reason_and_drops_the_retry(
+        self, service: SchedulerService, mock_repo: AsyncMock, actor: User
+    ):
+        mock_repo.get_job.return_value = make_job(user_id=actor.id)
+
+        await service.update_job(db=AsyncMock(), job_id=1, data=ScheduledJobUpdate(enabled=False), actor=actor)
+
+        fields = mock_repo.update_job.call_args[1]["fields"]
+        assert fields["enabled"] is False
+        assert fields["paused_reason"], "without a reason a retry would resurrect the disabled job"
+        assert fields["retry_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_enabling_clears_the_reason_and_the_retry(
+        self, service: SchedulerService, mock_repo: AsyncMock, actor: User
+    ):
+        job = make_job(user_id=actor.id)
+        job.enabled = False
+        job.paused_reason = "Disabled by user"
+        mock_repo.get_job.return_value = job
+
+        await service.update_job(db=AsyncMock(), job_id=1, data=ScheduledJobUpdate(enabled=True), actor=actor)
+
+        fields = mock_repo.update_job.call_args[1]["fields"]
+        assert fields["enabled"] is True
+        assert fields["paused_reason"] is None
+        assert fields["retry_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_an_unrelated_patch_leaves_both_alone(
+        self, service: SchedulerService, mock_repo: AsyncMock, actor: User
+    ):
+        mock_repo.get_job.return_value = make_job(user_id=actor.id)
+
+        await service.update_job(db=AsyncMock(), job_id=1, data=ScheduledJobUpdate(), actor=actor, name="Renamed")
+
+        fields = mock_repo.update_job.call_args[1]["fields"]
+        assert "paused_reason" not in fields
+        assert "retry_at" not in fields
+
+
+class TestPauseAndResumeDropThePendingRetry:
+    """A retry earned while the job was paused must not fire the moment it is resumed."""
+
+    @pytest.mark.asyncio
+    async def test_pause_clears_retry_at(self, service: SchedulerService, mock_repo: AsyncMock, actor: User):
+        mock_repo.get_job.return_value = make_job(user_id=actor.id)
+
+        assert await service.pause_job(db=AsyncMock(), job_id=1, actor=actor) is True
+
+        fields = mock_repo.update_job.call_args[1]["fields"]
+        assert fields["retry_at"] is None
+        assert fields["paused_reason"]
+
+    @pytest.mark.asyncio
+    async def test_resume_clears_retry_at(self, service: SchedulerService, mock_repo: AsyncMock, actor: User):
+        job = make_job(user_id=actor.id)
+        job.enabled = False
+        job.paused_reason = "Manually paused"
+        mock_repo.get_job.return_value = job
+
+        assert await service.resume_job(db=AsyncMock(), job_id=1, actor=actor) is True
+
+        fields = mock_repo.update_job.call_args[1]["fields"]
+        assert fields["retry_at"] is None
+        assert fields["enabled"] is True

--- a/packages/console-frontend/src/api/generated/types.gen.ts
+++ b/packages/console-frontend/src/api/generated/types.gen.ts
@@ -2137,7 +2137,7 @@ export type ImpersonateStartRequest = {
  *
  * Terminal status of a single job execution attempt.
  */
-export type JobRunStatus = 'running' | 'success' | 'failed' | 'condition_not_met';
+export type JobRunStatus = 'running' | 'success' | 'failed' | 'condition_not_met' | 'interrupted';
 
 /**
  * JobType
@@ -3915,6 +3915,16 @@ export type RunNowResponse = {
 };
 
 /**
+ * RunTrigger
+ *
+ * Why a run was started. Decides what its interruption is worth: a SCHEDULED
+ * run earns one RETRY, a RETRY earns the user a notice, a MANUAL run earns
+ * neither — the user is present and can press again. See
+ * docs/adr/0007-interrupted-runs-get-one-fresh-attempt.md.
+ */
+export type RunTrigger = 'scheduled' | 'retry' | 'manual';
+
+/**
  * ScheduleKind
  *
  * How the job is scheduled.
@@ -3969,6 +3979,10 @@ export type ScheduledJob = {
      * Last Run At
      */
     last_run_at?: string | null;
+    /**
+     * Retry At
+     */
+    retry_at?: string | null;
     /**
      * Prompt
      */
@@ -4321,6 +4335,15 @@ export type ScheduledJobRun = {
      */
     delivered: boolean;
     condition_evaluation?: ConditionEvaluation | null;
+    /**
+     * Last Seen At
+     */
+    last_seen_at?: string | null;
+    trigger?: RunTrigger;
+    /**
+     * Notice Due At
+     */
+    notice_due_at?: string | null;
 };
 
 /**

--- a/packages/console-frontend/src/pages/SchedulerJobDetailPage.tsx
+++ b/packages/console-frontend/src/pages/SchedulerJobDetailPage.tsx
@@ -174,6 +174,20 @@ function RunStatusBadge({ status }: { status: ScheduledJobRun['status'] }) {
           <AlertCircle className="h-3 w-3" /> Condition not met
         </Badge>
       );
+    case 'interrupted':
+      // The process running it died; it does not count against the job.
+      return (
+        <Badge variant="outline" className="gap-1 text-muted-foreground">
+          <AlertCircle className="h-3 w-3" /> Interrupted
+        </Badge>
+      );
+    default:
+      // A status this build does not know yet must still show *something*.
+      return (
+        <Badge variant="outline" className="gap-1">
+          {status}
+        </Badge>
+      );
   }
 }
 


### PR DESCRIPTION
## What

A scheduled run whose **process** died was recorded `failed` with `delivered=False`. Three consequences, all silent:

- the job's `consecutive_failures` advanced, so enough restarts crossed `max_failures` and auto-paused a healthy job with a `paused_reason` blaming the job;
- nothing ever told the user their scheduled result was lost;
- the run history could not answer *"did my job fail, or did the process die?"* without reading pod logs.

This PR makes an interruption a distinct outcome that is **evidence about the runtime, not the job**, gives it exactly one fresh attempt, and tells the user when that attempt is lost too.

Design and rejected alternatives: [`docs/adr/0007-interrupted-runs-get-one-fresh-attempt.md`](docs/adr/0007-interrupted-runs-get-one-fresh-attempt.md).

## How

**`INTERRUPTED` is not a failure.** It leaves `consecutive_failures` untouched in *either* direction — incrementing lets churn auto-pause a healthy job, resetting would launder a real failure streak.

**Recovery is a fresh attempt, never a resumption.** The LangGraph checkpoint of an interrupted run stays forensic. Because no half-executed run is ever continued, no already-sent email or already-written record can be replayed, so replay safety never becomes a permanent design obligation.

**Recovery markers are durable, not in-process** — the process best placed to notice an interruption is often the one dying:
- `scheduled_jobs.retry_at` is a second wake-up reason for the existing `FOR UPDATE SKIP LOCKED` claim, so whichever scheduler ticks next makes the attempt;
- `scheduled_job_runs.notice_due_at` records the notice owed when a retry is lost too, delivered by a later tick.

**Liveness is a heartbeat swept on staleness, not age.** `last_seen_at` is refreshed while a dispatch holds the agent's stream, so a legitimately slow run is never swept however long it takes. This is also what makes the healer correct with **more than one scheduler process**: `_in_flight` is only ever the local view, so age alone cannot tell another process's healthy run from an abandoned one. Adding a replica before this would have been a live race.

**The notice reuses the path a notification-only watch already takes**: an ephemeral A2A message with no `sub_agent_id`, which agent-runner delivers while running no agent. No new outbound capability in console-backend and no new case in the three delivery-channel receivers — the notice arrives in the envelope they already normalise.

It is bounded and quiet: only the terminal case speaks, a notice is abandoned once stale, and also as soon as **a later run of the same job has completed** — delivering it then would contradict newer news the user already has. Ordering that by `(completed_at, id)` also collapses an outage's several lost runs into one message.

## Bugs found while building it

- **The a2a SDK wraps httpx errors** (`A2AClientError`, `AgentCardResolutionError`, … all `from e`), so classifying on the raw exception type never matched and *every* interruption would have been recorded as a plain failure. Classification now lives in the dispatch layer as `AgentUnreachable`, looking through `__cause__`.
- **A job with a still-running run could be re-claimed** through its stale `next_run_at` after a restart, and then earn a retry on top when the healer swept the strand — two attempts for one loss.
- **`complete_job` must never clear `retry_at`.** Runs of one job complete out of order (a manual run finishing after the healer marked a scheduled one lost); a completion that wiped the marker would silently cancel an earned attempt.
- The notice is written in the **same** statement as the run's outcome, so a death between the two cannot leave a lost run that owes nothing.

## Testing

`1767 passed`. New coverage is mostly against real Postgres, because the behaviour is largely SQL — a `CASE` that must not move a counter, a claim predicate with a second wake-up reason, a supersession clause — where a mocked repository would assert nothing.

Notable cases: a two-hour run with a live heartbeat is **not** swept (the property the old age-based bound could not express); a `once` job retired by its own completion still gets its retry; a job stopped on purpose is not resurrected by one; an outage costing several runs sends one notice; a *lost* next run supersedes nothing.

## Migrations

`091` (enum value, forward-only) and `092` (columns + partial indexes), split because Postgres will not let a new enum value be **used** in the transaction that adds it.

## Not in this PR

Nothing here changes the memory limits that caused the incident — those are already applied in the GitOps repo.

## Checklist
- [x] I have performed a self-review of my code
- [x] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨
