### PR TITLE
fix(console): ask before saving an edit into a paused job

### DIFF
--- a/packages/console-frontend/src/pages/SchedulerJobDetailPage.tsx
+++ b/packages/console-frontend/src/pages/SchedulerJobDetailPage.tsx
@@ -439,11 +439,28 @@ function EditForm({ job }: { job: ScheduledJob }) {
 
   // ── Save ──────────────────────────────────────────────────────────────────
   const mutation = useMutation({
-    mutationFn: (body: Record<string, unknown>) => updateScheduledJob(job.id, body),
+    mutationFn: async ({ body, resume }: { body: Record<string, unknown>; resume: boolean }) => {
+      await updateScheduledJob(job.id, body);
+      if (!resume) return;
+      try {
+        // After the update, never before: resuming recomputes next_run_at, and it has
+        // to compute it from the schedule that was just saved.
+        await resumeJob(job.id);
+      } catch (e) {
+        // The edit is already persisted; only the resume failed — a one-time job that
+        // has already run refuses to resume. Reporting this as a failed save would be
+        // a lie, and the user would try again on changes that are already stored.
+        throw new Error(
+          `Changes saved, but the job could not be resumed: ${e instanceof Error ? e.message : String(e)}`
+        );
+      }
+    },
     onSuccess: () => {
       qc.invalidateQueries({
         queryKey: ['scheduler-job', job.id],
       });
+      // Resuming changes the job's status, which the list renders too.
+      qc.invalidateQueries({ queryKey: ['scheduler-jobs'] });
       setDirty(false);
       setEditing(false);
     },
@@ -451,6 +468,10 @@ function EditForm({ job }: { job: ScheduledJob }) {
       setError(e instanceof Error ? e.message : String(e));
     },
   });
+
+  // Set while a paused job's save waits for the user to say whether to resume it.
+  // Holds the built body so the answer costs one click rather than a re-submit.
+  const [pendingSave, setPendingSave] = useState<Record<string, unknown> | null>(null);
 
   function handleSave() {
     if (job.schedule_kind === 'cron' && cronExpr.trim() && !describeCron(cronExpr).ok) {
@@ -542,7 +563,15 @@ function EditForm({ job }: { job: ScheduledJob }) {
       voice_call: voiceCall,
     };
 
-    mutation.mutate(body);
+    // A paused job does not run whatever you save, and nothing on the way out says so:
+    // the fix you just made looks applied while the scheduler keeps skipping the job.
+    // Ask, rather than saving into a job that will not act on it.
+    if (!job.enabled) {
+      setPendingSave(body);
+      return;
+    }
+
+    mutation.mutate({ body, resume: false });
   }
 
   return (
@@ -808,12 +837,54 @@ function EditForm({ job }: { job: ScheduledJob }) {
             <span className="font-medium text-foreground">Last updated:</span> {formatDate(job.updated_at)}
           </div>
           <div>
-            <span className="font-medium text-foreground">Next run:</span> {formatDate(job.next_run_at)}
+            <span className="font-medium text-foreground">Next run:</span>{' '}
+            {/* A paused job's stored next_run_at is a leftover: resuming recomputes it.
+                Printing it anyway is how a paused job reads as one that is about to run. */}
+            {job.enabled ? formatDate(job.next_run_at) : '— paused'}
           </div>
           <div>
             <span className="font-medium text-foreground">Consecutive failures:</span> {job.consecutive_failures}
           </div>
         </div>
+
+        {/* Saving a paused job stores an edit the scheduler will not act on, and nothing
+            downstream says so. Ask instead of letting the fix look applied. */}
+        <AlertDialog open={pendingSave !== null} onOpenChange={(open) => !open && setPendingSave(null)}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>This job is paused</AlertDialogTitle>
+              <AlertDialogDescription>
+                <strong>{job.name}</strong> is paused{job.paused_reason ? ` (${job.paused_reason})` : ''}, so it
+                will not run on its schedule whatever you save. Resume it now, or keep it paused and resume it
+                later.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={mutation.isPending}>Cancel</AlertDialogCancel>
+              <Button
+                variant="outline"
+                disabled={mutation.isPending}
+                onClick={() => {
+                  const body = pendingSave;
+                  setPendingSave(null);
+                  if (body) mutation.mutate({ body, resume: false });
+                }}
+              >
+                Save, keep paused
+              </Button>
+              <Button
+                disabled={mutation.isPending}
+                onClick={() => {
+                  const body = pendingSave;
+                  setPendingSave(null);
+                  if (body) mutation.mutate({ body, resume: true });
+                }}
+              >
+                Save and resume
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## What

A paused job does not run whatever you save, and nothing on the way out says so. Edit one — fix the cron, correct a prompt — and the save succeeds, the card returns to read-only, and the change looks applied while the scheduler goes on skipping the job.

The card made it worse by printing **`Next run: <date>`** for a job that will never reach it. Found the hard way: a job showed `Next run 21:10`, `Consecutive failures: 0`, and simply never fired, which reads as a broken scheduler rather than a paused job.

## How

Saving a paused job now asks, with the pause reason in the prompt: **Save and resume** / **Save, keep paused** / **Cancel**. The built request is held while the dialog is open, so answering costs one click rather than a re-submit.

Two details worth reviewing:

- **The resume runs after the update, never before**, so it recomputes `next_run_at` from the schedule that was just saved rather than the one being replaced.
- **A failed resume does not report a failed save.** A one-time job that has already run refuses to resume ([`scheduler_service.resume_job`](packages/console-backend/console_backend/services/scheduler_service.py)); the edit is already persisted by then, so the message says the changes were saved and only the resume did not happen. Reporting it as a save failure would send the user to retry changes that are already stored.

The footer no longer prints a next run for a paused job — that stored value is a leftover, recomputed on resume, so showing it is precisely how a paused job reads as one about to run.

## Not in this PR

`paused_reason` outliving its cause: a successful manual run resets `consecutive_failures` to 0 while the stored reason still says *"Auto-paused after 3 consecutive failures"*, so the card can show both at once. That is a backend coherence question — the reason is also the audit trail of why a job stopped — and it belongs in its own change.

## Testing

`tsc -b` and `eslint` clean. Behaviour verified by reading against the paused/enabled paths; no automated coverage exists for this page.

## Checklist
- [x] I have performed a self-review of my code
- [ ] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨
