### PR TITLE
perf(agent-common): run fast-model utility calls with thinking off

### DIFF
--- a/packages/agent-common/agent_common/core/__init__.py
+++ b/packages/agent-common/agent_common/core/__init__.py
@@ -11,6 +11,7 @@ from .message_formatting import (
 from .model_factory import (
     _has_aws_credentials as has_aws_credentials,
     NoDefaultModelError,
+    create_fast_model,
     create_model,
     get_available_models,
     get_default_model,
@@ -31,6 +32,7 @@ from object_storage import (
 
 __all__ = [
     # Model factory
+    "create_fast_model",
     "create_model",
     "get_available_models",
     "has_aws_credentials",

--- a/packages/agent-common/agent_common/core/model_factory.py
+++ b/packages/agent-common/agent_common/core/model_factory.py
@@ -244,6 +244,12 @@ def assert_gateway_configured() -> None:
 # this runtime mapping never disagree.
 _NON_PORTABLE_EFFORT: dict[str, str] = {"minimal": "low", "xhigh": "high"}
 
+# LiteLLM's explicit "no extended thinking" value, portable across providers (the gateway
+# drops it for models with no reasoning to disable). NOT a `ThinkingLevel` member: the app
+# models thinking-off as a toggle rather than a tier, so it can only be requested through
+# `create_model(reasoning_effort=...)` — which is what `create_fast_model` does.
+REASONING_OFF = "none"
+
 
 def get_reasoning_effort(
     thinking_level: ThinkingLevel | None, model_type: ModelType | None = None
@@ -293,8 +299,11 @@ def max_tokens_for_effort(effort: str | None) -> int | None:
     Returns ``None`` when no effort is active (reasoning off) — callers should leave
     ``max_tokens`` unset so the gateway default applies and we don't lower a non-reasoning
     model's own output cap. See ``_MAX_TOKENS_BY_EFFORT`` for the rationale.
+
+    ``REASONING_OFF`` counts as no effort: it is the explicit off switch, so it must not
+    raise the ceiling the way a real tier does (it has no thinking budget to make room for).
     """
-    if not effort:
+    if not effort or effort == REASONING_OFF:
         return None
     return _MAX_TOKENS_BY_EFFORT.get(effort, _DEFAULT_REASONING_MAX_TOKENS)
 
@@ -304,12 +313,23 @@ def create_model(
     thinking_level: ThinkingLevel | None = None,
     callbacks: list | None = None,
     streaming: bool = True,
+    *,
+    reasoning_effort: str | None = None,
+    max_tokens: int | None = None,
 ) -> BaseChatModel:
     """Create a gateway-backed chat model for the given alias.
 
     `thinking_level` becomes `reasoning_effort` and is always forwarded; the gateway
     drops it for models that don't support reasoning (`drop_params`), so no per-model
     capability check is needed here.
+
+    `reasoning_effort` overrides that mapping with a raw LiteLLM value. It exists for
+    ``REASONING_OFF`` — `ThinkingLevel` has no `none` member (the app models thinking-off as
+    a toggle, not a tier), so without this there was no way to say "off" and the call
+    inherited the PROVIDER default instead. See `create_fast_model`.
+
+    `max_tokens` overrides the effort-derived output ceiling for callers that know their
+    answer is short.
     """
     # Gateway-aware subclass: preserves reasoning_content that base ChatOpenAI (>=1.2) drops.
     ChatOpenAI = _gateway_chat_openai_cls()
@@ -325,7 +345,7 @@ def create_model(
         callbacks = [cb for cb in callbacks if type(cb).__name__ != "CostTrackingCallback"] or None
 
     model_kwargs: dict = {}
-    effort = get_reasoning_effort(thinking_level, model_type)
+    effort = reasoning_effort if reasoning_effort is not None else get_reasoning_effort(thinking_level, model_type)
     if effort:
         model_kwargs["reasoning_effort"] = effort
 
@@ -333,7 +353,7 @@ def create_model(
     # whole (low) gateway-default max_tokens and truncate the answer. Unset for reasoning-off
     # turns (leave the gateway default). ContinueOnTruncationMiddleware raises this further
     # per-retry when a turn still gets cut off. See max_tokens_for_effort.
-    max_tokens = max_tokens_for_effort(effort)
+    max_tokens = max_tokens if max_tokens is not None else max_tokens_for_effort(effort)
 
     # NOTE: Native Gemini server-side web search (googleSearch) is NOT enabled here.
     # Enabling it for a tool-using deep agent requires `include_server_side_tool_invocations`
@@ -736,6 +756,45 @@ def get_default_fast_model() -> ModelType | None:
     Returns ``None`` only when no chat default is configured at all; runtime callers that must
     actually run a model pair this with require_default_model()."""
     return _default_alias_for("chat:low") or get_default_model()
+
+
+# One sentence per tool call, one risk score, one condition verdict — generous for a batch
+# of a few summaries, low enough that a model ignoring "ONE short sentence" cannot stretch
+# the call. Utility work must never inherit the reasoning tiers' 8k-32k ceiling.
+_FAST_MODEL_MAX_TOKENS = 1024
+
+
+def create_fast_model(
+    model_type: ModelType,
+    *,
+    max_tokens: int = _FAST_MODEL_MAX_TOKENS,
+    callbacks: list | None = None,
+) -> BaseChatModel:
+    """A cheap-tier model configured for LOW LATENCY: thinking off, no streaming, short cap.
+
+    For the utility calls that ride `get_default_fast_model()` — tool-call summaries, risk
+    scoring, watch-condition checks, chunk descriptions. They want the cheap tier's speed,
+    not its reasoning, and several of them sit on a user-visible critical path.
+
+    Thinking off is the whole point. `create_model` sends `reasoning_effort` only when a
+    caller passes a `thinking_level`, so these calls sent nothing and inherited the PROVIDER
+    default — dynamic thinking on Gemini 3.x flash, the current `chat:low`. Measured on
+    tool-call summaries (LangSmith, 2026-09-09): 2.7-25.5 s, median ~8 s, to produce one
+    sentence about one `ls` call — all of it in front of the HITL approval card. Same failure
+    as the `gateway_chat` fix in #209, which is why console-backend's `llm_gateway` already
+    defaults to `reasoning_effort="none"`; agent-common had no way to express it.
+
+    Streaming is off because every one of these callers awaits the whole answer before doing
+    anything with it (structured output, a score, a verdict) — a token stream buys nothing
+    and costs a per-chunk callback trip.
+    """
+    return create_model(
+        model_type,
+        callbacks=callbacks,
+        streaming=False,
+        reasoning_effort=REASONING_OFF,
+        max_tokens=max_tokens,
+    )
 
 
 def get_default_indexing_model() -> ModelType | None:

--- a/packages/agent-common/agent_common/core/model_factory.py
+++ b/packages/agent-common/agent_common/core/model_factory.py
@@ -257,9 +257,7 @@ _NON_PORTABLE_EFFORT: dict[str, str] = {"minimal": "low", "xhigh": "high"}
 REASONING_OFF = "none"
 
 
-def get_reasoning_effort(
-    thinking_level: ThinkingLevel | None, model_type: ModelType | None = None
-) -> str | None:
+def get_reasoning_effort(thinking_level: ThinkingLevel | None, model_type: ModelType | None = None) -> str | None:
     """Map the app `thinking_level` to LiteLLM's `reasoning_effort`.
 
     low/medium/high are accepted by every reasoning provider and pass through. The
@@ -336,7 +334,20 @@ def create_model(
 
     `max_tokens` overrides the effort-derived output ceiling for callers that know their
     answer is short.
+
+    Both overrides are validated rather than normalized: an empty `reasoning_effort` would
+    take the override branch and then fail the `if effort:` test below, sending nothing and
+    silently inheriting the provider default — the exact regression `REASONING_OFF` exists to
+    prevent, with no error to notice. A non-positive `max_tokens` would reach the gateway as
+    a 400 or an empty completion. ValueError, not assert: asserts vanish under `-O`.
     """
+    if reasoning_effort is not None and not reasoning_effort:
+        raise ValueError(
+            f"reasoning_effort must be a LiteLLM effort value or None, not {reasoning_effort!r} — "
+            f"pass REASONING_OFF ({REASONING_OFF!r}) to turn thinking off."
+        )
+    if max_tokens is not None and max_tokens <= 0:
+        raise ValueError(f"max_tokens must be positive when given, not {max_tokens!r}")
     # Gateway-aware subclass: preserves reasoning_content that base ChatOpenAI (>=1.2) drops.
     ChatOpenAI = _gateway_chat_openai_cls()
 
@@ -764,26 +775,40 @@ def get_default_fast_model() -> ModelType | None:
     return _default_alias_for("chat:low") or get_default_model()
 
 
-# One sentence per tool call, one risk score, one condition verdict — generous for a batch
-# of a few summaries, low enough that a model ignoring "ONE short sentence" cannot stretch
-# the call. Utility work must never inherit the reasoning tiers' 8k-32k ceiling. Same value
-# as `llm_gateway.gateway_chat`'s default for the same reason (see REASONING_OFF on why that
-# module keeps its own copy). A caller whose answer outgrows it should raise it explicitly
-# rather than discover the truncation: with thinking off, the cap only binds real output.
-_FAST_MODEL_MAX_TOKENS = 1024
+# Floor for a single short answer: one risk score, one condition verdict, a sentence or two.
+# Low enough that a model ignoring "ONE short sentence" cannot stretch the call, and utility
+# work never inherits the reasoning tiers' 8k-32k ceiling. Same value as
+# `llm_gateway.gateway_chat`'s default for the same reason (see REASONING_OFF on why that
+# module keeps its own copy).
+#
+# PUBLIC because it is a floor, not a ceiling: a caller whose answer scales with its input
+# (the tool-call summarizer batches one sentence per pending call) must raise it in
+# proportion, and needs this value to scale *from*. With thinking off the cap binds only
+# real output, so the risk of it being too low is silent truncation — see
+# `tool_call_summarizer._summary_token_budget`.
+FAST_MODEL_MAX_TOKENS = 1024
 
 
 def create_fast_model(
     model_type: ModelType,
     *,
-    max_tokens: int = _FAST_MODEL_MAX_TOKENS,
+    max_tokens: int = FAST_MODEL_MAX_TOKENS,
     callbacks: list | None = None,
 ) -> BaseChatModel:
     """A cheap-tier model configured for LOW LATENCY: thinking off, no streaming, short cap.
 
-    For the utility calls that ride `get_default_fast_model()` — tool-call summaries, risk
-    scoring, watch-condition checks, chunk descriptions. They want the cheap tier's speed,
-    not its reasoning, and several of them sit on a user-visible critical path.
+    For the utility calls that ride `get_default_fast_model()`: they want the cheap tier's
+    speed, not its reasoning, and several sit on a user-visible critical path.
+
+    Currently used by ONE of them — `tool_call_summarizer`, the worst-placed, sitting between
+    the model's tool call and the HITL approval card. The other agent-common fast-model
+    callers still build their own client and still inherit provider-default thinking:
+    `tool_risk_scorer` (which gates that same card), `hitl_resume` (between the user\'s reply
+    and the resume) and `indexing_store` (per chunk, so it multiplies by corpus size).
+    Converting them is a quality judgement — reasoning may be buying something in a score or
+    a classification — not a mechanical swap, so they are deliberately left alone here.
+    (Watch conditions are NOT in this set: they run through console-backend\'s `gateway_chat`,
+    which has defaulted to thinking off since #209.)
 
     Thinking off is the whole point. `create_model` sends `reasoning_effort` only when a
     caller passes a `thinking_level`, so these calls sent nothing and inherited the PROVIDER

--- a/packages/agent-common/agent_common/core/model_factory.py
+++ b/packages/agent-common/agent_common/core/model_factory.py
@@ -248,6 +248,12 @@ _NON_PORTABLE_EFFORT: dict[str, str] = {"minimal": "low", "xhigh": "high"}
 # drops it for models with no reasoning to disable). NOT a `ThinkingLevel` member: the app
 # models thinking-off as a toggle rather than a tier, so it can only be requested through
 # `create_model(reasoning_effort=...)` — which is what `create_fast_model` does.
+#
+# console-backend's `llm_gateway.gateway_chat` defaults to this same value, and states the
+# same policy (thinking is opt-in for mechanical utility calls). That copy is deliberate —
+# console-backend stays dependency-light and imports neither agent-common nor langchain, the
+# way it also duplicates the gateway Bearer-key default — but the two are one decision:
+# change the policy here and change it there.
 REASONING_OFF = "none"
 
 
@@ -760,7 +766,10 @@ def get_default_fast_model() -> ModelType | None:
 
 # One sentence per tool call, one risk score, one condition verdict — generous for a batch
 # of a few summaries, low enough that a model ignoring "ONE short sentence" cannot stretch
-# the call. Utility work must never inherit the reasoning tiers' 8k-32k ceiling.
+# the call. Utility work must never inherit the reasoning tiers' 8k-32k ceiling. Same value
+# as `llm_gateway.gateway_chat`'s default for the same reason (see REASONING_OFF on why that
+# module keeps its own copy). A caller whose answer outgrows it should raise it explicitly
+# rather than discover the truncation: with thinking off, the cap only binds real output.
 _FAST_MODEL_MAX_TOKENS = 1024
 
 

--- a/packages/agent-common/agent_common/core/tool_call_summarizer.py
+++ b/packages/agent-common/agent_common/core/tool_call_summarizer.py
@@ -97,6 +97,35 @@ def _compact_args(args: dict[str, Any]) -> dict[str, Any]:
     return compact
 
 
+def _log_unusable_reply(envelope: dict, call_count: int) -> None:
+    """Say WHY a reply yielded no summaries: cut off at the cap, or simply unreadable.
+
+    console-backend's ``gateway_chat`` / ``gateway_chat_json`` learned this the hard way —
+    a reply stopped at ``max_tokens`` reads exactly like one that said little, and only
+    ``finish_reason`` tells them apart (see ``GatewayText``: the distinction "went unlogged
+    for a month"). ``create_fast_model`` asks for a deliberately short output cap, so this
+    is the path that has to name it when a batch outgrows it: without this, truncation
+    arrives as a generic parse failure and the fix (raise the cap, or split the batch)
+    isn't visible from the log.
+
+    Warning, not exception: the caller's fallback (render raw args) is correct either way.
+    """
+    raw = envelope.get("raw")
+    finish_reason = (getattr(raw, "response_metadata", None) or {}).get("finish_reason")
+    if finish_reason == "length":
+        logger.warning(
+            "Tool call summaries for %d call(s) hit the output cap (finish_reason=length); falling back to raw args",
+            call_count,
+        )
+        return
+    logger.warning(
+        "Tool call summaries for %d call(s) were unreadable (finish_reason=%s): %s; falling back to raw args",
+        call_count,
+        finish_reason,
+        envelope.get("parsing_error"),
+    )
+
+
 @traceable(name="tool-call-summarize", run_type="tool")
 async def summarize_action_requests(
     calls: list[tuple[str, dict[str, Any], str]],
@@ -120,7 +149,11 @@ async def summarize_action_requests(
 
     try:
         model = create_fast_model(get_default_fast_model() or require_default_model())
-        structured_model = model.with_structured_output(ToolCallSummaries)
+        # ``include_raw`` keeps the provider's finish reason reachable: a parse failure is
+        # then returned in the envelope rather than raised, so ``_log_unusable_reply`` can
+        # tell "cut off at max_tokens" from "wrote something unreadable". See
+        # ``_log_unusable_reply`` for why that distinction is worth the extra unwrapping.
+        structured_model = model.with_structured_output(ToolCallSummaries, include_raw=True)
 
         lines: list[str] = [f"User language: {language}", ""]
         for idx, (tool_name, args, description) in enumerate(calls, start=1):
@@ -138,7 +171,7 @@ async def summarize_action_requests(
         from agent_common.middleware.gateway_attribution_middleware import run_config_attribution_scope
 
         with run_config_attribution_scope():
-            result: ToolCallSummaries = await asyncio.wait_for(
+            envelope: dict = await asyncio.wait_for(
                 structured_model.ainvoke(
                     [
                         {"role": "system", "content": _SYSTEM_PROMPT},
@@ -147,6 +180,15 @@ async def summarize_action_requests(
                 ),
                 timeout=_SUMMARY_TIMEOUT_SECONDS,
             )
+
+        # Inside the try on purpose: the envelope's shape is the provider's business, and
+        # this is a best-effort path whose caller is mid-``interrupt()``. Anything
+        # unexpected here degrades to raw args like every other failure, rather than
+        # raising into the HITL request.
+        result: ToolCallSummaries | None = envelope.get("parsed")
+        if result is None:
+            _log_unusable_reply(envelope, len(calls))
+            return None
     except TimeoutError:
         # Not exception-worthy: a slow gateway is expected weather, and the caller has a
         # correct answer for it (raw args). Logged at warning so a systematic regression —

--- a/packages/agent-common/agent_common/core/tool_call_summarizer.py
+++ b/packages/agent-common/agent_common/core/tool_call_summarizer.py
@@ -17,10 +17,16 @@ to draw the card, and once on the resume, for a sentence that can no longer be
 shown to anyone. ``attach_summaries`` therefore skips itself while a resume is
 pending (see ``_resume_pending``). Measured on an embedded ``client_action``
 apply: the wasted call sat in front of the form write for 15.6 s.
+
+The call it cannot avoid making is configured for latency, not quality: the cheap tier
+with thinking OFF (``create_fast_model``) and a hard timeout past which the card renders
+raw args. Both exist because this call is the last thing between the model deciding and
+the user being asked.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from collections.abc import Callable
@@ -46,6 +52,15 @@ _SELF_EVIDENT_TOOLS = frozenset({CLIENT_ACTION_TOOL_NAME})
 
 # Keep the prompt bounded even if a tool call carries a huge payload.
 _MAX_VALUE_CHARS = 300
+
+# Hard ceiling on how long a card may wait for its prose. The summary is a nicety; the
+# approval card is the thing the user is waiting for, and this call sits between the two.
+# Past the budget we abandon it and render raw args — the documented ``None`` fallback.
+# Sized well above what a one-sentence answer needs with thinking off, leaving headroom for
+# a cold gateway connection. It only became a sane guard once `create_fast_model` landed:
+# the observed spread before that was 2.7-25.5 s, so any useful budget would have been
+# trimming the norm rather than the tail.
+_SUMMARY_TIMEOUT_SECONDS = 5.0
 
 _SYSTEM_PROMPT = (
     "You explain pending tool calls to a non-technical user (e.g. a journalist) "
@@ -101,10 +116,10 @@ async def summarize_action_requests(
     if not calls:
         return []
 
-    from agent_common.core.model_factory import create_model, get_default_fast_model, require_default_model
+    from agent_common.core.model_factory import create_fast_model, get_default_fast_model, require_default_model
 
     try:
-        model = create_model(get_default_fast_model() or require_default_model(), streaming=False)
+        model = create_fast_model(get_default_fast_model() or require_default_model())
         structured_model = model.with_structured_output(ToolCallSummaries)
 
         lines: list[str] = [f"User language: {language}", ""]
@@ -123,12 +138,25 @@ async def summarize_action_requests(
         from agent_common.middleware.gateway_attribution_middleware import run_config_attribution_scope
 
         with run_config_attribution_scope():
-            result: ToolCallSummaries = await structured_model.ainvoke(
-                [
-                    {"role": "system", "content": _SYSTEM_PROMPT},
-                    {"role": "user", "content": "\n".join(lines)},
-                ]
+            result: ToolCallSummaries = await asyncio.wait_for(
+                structured_model.ainvoke(
+                    [
+                        {"role": "system", "content": _SYSTEM_PROMPT},
+                        {"role": "user", "content": "\n".join(lines)},
+                    ]
+                ),
+                timeout=_SUMMARY_TIMEOUT_SECONDS,
             )
+    except TimeoutError:
+        # Not exception-worthy: a slow gateway is expected weather, and the caller has a
+        # correct answer for it (raw args). Logged at warning so a systematic regression —
+        # thinking back on, a mis-set default — is still visible.
+        logger.warning(
+            "Tool call summarization exceeded %.1fs for %d call(s); falling back to raw args",
+            _SUMMARY_TIMEOUT_SECONDS,
+            len(calls),
+        )
+        return None
     except Exception:
         logger.exception("Tool call summarization failed; falling back to raw args")
         return None

--- a/packages/agent-common/agent_common/core/tool_call_summarizer.py
+++ b/packages/agent-common/agent_common/core/tool_call_summarizer.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -61,6 +62,25 @@ _MAX_VALUE_CHARS = 300
 # the observed spread before that was 2.7-25.5 s, so any useful budget would have been
 # trimming the norm rather than the tail.
 _SUMMARY_TIMEOUT_SECONDS = 5.0
+
+# Output budget per pending call. One sentence is ~30-40 tokens, more in a token-heavy
+# language, plus its share of the JSON envelope — so this is roughly 3x headroom.
+_TOKENS_PER_SUMMARY = 160
+
+
+def _summary_token_budget(call_count: int) -> int:
+    """Output cap for a batch of ``call_count`` summaries.
+
+    The batch is UNBOUNDED: ``attach_summaries`` passes every non-self-evident tool call in
+    the turn, so a turn interrupting on ~15-20 parallel calls needs several times the
+    single-answer floor. A flat cap fails exactly backwards — the biggest approval batches,
+    where opaque raw args are hardest to read, would be the ones that lose their prose.
+    Scaled from the shared floor so a small batch keeps the fast-model default.
+    """
+    from agent_common.core.model_factory import FAST_MODEL_MAX_TOKENS
+
+    return max(FAST_MODEL_MAX_TOKENS, _TOKENS_PER_SUMMARY * call_count)
+
 
 _SYSTEM_PROMPT = (
     "You explain pending tool calls to a non-technical user (e.g. a journalist) "
@@ -126,6 +146,21 @@ def _log_unusable_reply(envelope: dict, call_count: int) -> None:
     )
 
 
+async def _invoke(build, lines: list[str]) -> dict:
+    """Build the client off the loop, then run the request — both inside the caller's budget.
+
+    Split out so ``asyncio.wait_for`` wraps ONE awaitable covering both halves; see
+    ``_build`` for why the construction cannot simply be called inline.
+    """
+    structured_model = await asyncio.to_thread(build)
+    return await structured_model.ainvoke(
+        [
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": "\n".join(lines)},
+        ]
+    )
+
+
 @traceable(name="tool-call-summarize", run_type="tool")
 async def summarize_action_requests(
     calls: list[tuple[str, dict[str, Any], str]],
@@ -147,14 +182,30 @@ async def summarize_action_requests(
 
     from agent_common.core.model_factory import create_fast_model, get_default_fast_model, require_default_model
 
-    try:
-        model = create_fast_model(get_default_fast_model() or require_default_model())
+    def _build():
+        """Resolve the alias and build the client — SYNCHRONOUS, and sometimes slow.
+
+        Both resolvers go through ``_refresh_if_stale``, which on a cold cache runs the fetch
+        in the calling thread (2 s urllib timeout) or blocks a cold waiter up to ``_COLD_WAIT``
+        (3 s). On the event loop that stalls every other coroutine in the process, and it sits
+        outside anything ``asyncio.wait_for`` can interrupt — a timeout cannot cancel code that
+        never awaits. Hence ``to_thread``: it makes the block cancellable from the loop's point
+        of view and brings it under the summary budget. The thread itself runs to completion
+        after a timeout (nothing can stop it), but it finishes into a discarded result instead
+        of holding the card.
+        """
+        model = create_fast_model(
+            get_default_fast_model() or require_default_model(),
+            max_tokens=_summary_token_budget(len(calls)),
+        )
         # ``include_raw`` keeps the provider's finish reason reachable: a parse failure is
         # then returned in the envelope rather than raised, so ``_log_unusable_reply`` can
         # tell "cut off at max_tokens" from "wrote something unreadable". See
         # ``_log_unusable_reply`` for why that distinction is worth the extra unwrapping.
-        structured_model = model.with_structured_output(ToolCallSummaries, include_raw=True)
+        return model.with_structured_output(ToolCallSummaries, include_raw=True)
 
+    started = time.monotonic()
+    try:
         lines: list[str] = [f"User language: {language}", ""]
         for idx, (tool_name, args, description) in enumerate(calls, start=1):
             lines.append(f"Tool call {idx}:")
@@ -172,12 +223,7 @@ async def summarize_action_requests(
 
         with run_config_attribution_scope():
             envelope: dict = await asyncio.wait_for(
-                structured_model.ainvoke(
-                    [
-                        {"role": "system", "content": _SYSTEM_PROMPT},
-                        {"role": "user", "content": "\n".join(lines)},
-                    ]
-                ),
+                _invoke(_build, lines),
                 timeout=_SUMMARY_TIMEOUT_SECONDS,
             )
 
@@ -193,10 +239,19 @@ async def summarize_action_requests(
         # Not exception-worthy: a slow gateway is expected weather, and the caller has a
         # correct answer for it (raw args). Logged at warning so a systematic regression —
         # thinking back on, a mis-set default — is still visible.
+        #
+        # Reports measured elapsed time rather than asserting the budget expired: since 3.10
+        # ``socket.timeout`` IS ``TimeoutError``, so a transport timeout raised inside the
+        # request lands here too, having taken a fraction of the budget. Reading "exceeded
+        # 5.0s" for a 0.3 s socket failure sends the next reader after gateway latency
+        # instead of the client.
+        elapsed = time.monotonic() - started
         logger.warning(
-            "Tool call summarization exceeded %.1fs for %d call(s); falling back to raw args",
-            _SUMMARY_TIMEOUT_SECONDS,
+            "Tool call summarization for %d call(s) timed out after %.2fs (budget %.1fs, %s); falling back to raw args",
             len(calls),
+            elapsed,
+            _SUMMARY_TIMEOUT_SECONDS,
+            "budget expired" if elapsed >= _SUMMARY_TIMEOUT_SECONDS else "transport timeout, not the budget",
         )
         return None
     except Exception:

--- a/packages/agent-common/tests/test_create_fast_model.py
+++ b/packages/agent-common/tests/test_create_fast_model.py
@@ -1,0 +1,44 @@
+"""Tests for create_fast_model — the low-latency configuration for utility LLM calls.
+
+`create_model` sends `reasoning_effort` only when a caller passes a `thinking_level`, so the
+utility calls that ride the cheap tier sent nothing and inherited the PROVIDER default —
+dynamic thinking on the current `chat:low`. That put 2.7-25.5 s (median ~8 s) in front of a
+HITL approval card to write one sentence. These tests pin the three properties that fix it:
+thinking off, no streaming, and a short output cap.
+"""
+
+from unittest.mock import patch
+
+from agent_common.core.model_factory import REASONING_OFF, _FAST_MODEL_MAX_TOKENS, create_fast_model
+
+
+def _captured_kwargs(**kwargs):
+    """create_fast_model's delegation to create_model, without building a real client."""
+    with patch("agent_common.core.model_factory.create_model") as create:
+        create_fast_model("fast-alias", **kwargs)
+    assert create.call_args.args == ("fast-alias",)
+    return create.call_args.kwargs
+
+
+def test_thinking_is_off():
+    # The whole point: an explicit "none" instead of silence, so the provider default
+    # (dynamic thinking) never applies to a one-sentence utility call.
+    assert _captured_kwargs()["reasoning_effort"] == REASONING_OFF
+
+
+def test_streaming_is_off():
+    # Every caller awaits the complete answer (structured output, a score, a verdict);
+    # a token stream buys nothing and costs a per-chunk callback trip.
+    assert _captured_kwargs()["streaming"] is False
+
+
+def test_output_is_capped_short():
+    caps = _captured_kwargs()["max_tokens"]
+    assert caps == _FAST_MODEL_MAX_TOKENS
+    # Bounded well below the reasoning tiers' ceilings: a model ignoring "ONE short
+    # sentence" must not be able to stretch the call.
+    assert caps <= 2048
+
+
+def test_caller_can_raise_the_cap():
+    assert _captured_kwargs(max_tokens=64)["max_tokens"] == 64

--- a/packages/agent-common/tests/test_create_fast_model.py
+++ b/packages/agent-common/tests/test_create_fast_model.py
@@ -9,7 +9,9 @@ thinking off, no streaming, and a short output cap.
 
 from unittest.mock import patch
 
-from agent_common.core.model_factory import REASONING_OFF, _FAST_MODEL_MAX_TOKENS, create_fast_model
+import pytest
+
+from agent_common.core.model_factory import FAST_MODEL_MAX_TOKENS, REASONING_OFF, create_fast_model, create_model
 
 
 def _captured_kwargs(**kwargs):
@@ -34,7 +36,7 @@ def test_streaming_is_off():
 
 def test_output_is_capped_short():
     caps = _captured_kwargs()["max_tokens"]
-    assert caps == _FAST_MODEL_MAX_TOKENS
+    assert caps == FAST_MODEL_MAX_TOKENS
     # Bounded well below the reasoning tiers' ceilings: a model ignoring "ONE short
     # sentence" must not be able to stretch the call.
     assert caps <= 2048
@@ -42,3 +44,18 @@ def test_output_is_capped_short():
 
 def test_caller_can_raise_the_cap():
     assert _captured_kwargs(max_tokens=64)["max_tokens"] == 64
+
+
+def test_an_empty_effort_is_rejected():
+    # "" is not a LiteLLM value: it would take the override branch, then fail the `if effort:`
+    # test and send nothing — silently inheriting the provider default this helper exists to
+    # override. Fail at the boundary instead.
+    with pytest.raises(ValueError, match="REASONING_OFF"):
+        create_model("alias", reasoning_effort="")
+
+
+@pytest.mark.parametrize("bad", [0, -1])
+def test_a_non_positive_cap_is_rejected(bad):
+    # Forwarded verbatim it becomes a gateway 400 or an empty completion, far from the call.
+    with pytest.raises(ValueError, match="must be positive"):
+        create_model("alias", max_tokens=bad)

--- a/packages/agent-common/tests/test_max_tokens_for_effort.py
+++ b/packages/agent-common/tests/test_max_tokens_for_effort.py
@@ -12,6 +12,7 @@ import pytest
 from agent_common.core.model_factory import (
     _DEFAULT_REASONING_MAX_TOKENS,
     _MAX_TOKENS_BY_EFFORT,
+    REASONING_OFF,
     max_tokens_for_effort,
 )
 
@@ -39,3 +40,10 @@ def test_xhigh_gets_the_most_headroom():
 
 def test_unknown_effort_falls_back_to_default():
     assert max_tokens_for_effort("mystery-tier") == _DEFAULT_REASONING_MAX_TOKENS
+
+
+def test_reasoning_off_leaves_max_tokens_unset():
+    # REASONING_OFF is the explicit off switch, not a tier: it has no thinking budget to
+    # make room for, so it must not raise the ceiling (it used to hit the unknown-effort
+    # fallback and quietly request _DEFAULT_REASONING_MAX_TOKENS).
+    assert max_tokens_for_effort(REASONING_OFF) is None

--- a/packages/agent-common/tests/test_tool_call_summarizer.py
+++ b/packages/agent-common/tests/test_tool_call_summarizer.py
@@ -173,3 +173,42 @@ class TestSummarizerCostAttribution:
             assert current_sub_agent_id.get() is None
         finally:
             current_sub_agent_id.reset(prev)
+
+
+class TestSummaryTimeout:
+    """The card is what the user is waiting for; the prose is a nicety.
+
+    A slow gateway must not hold the approval card open indefinitely — past the budget the
+    call is abandoned and the documented ``None`` fallback (render raw args) applies.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_slow_model_gives_up_and_falls_back(self):
+        import asyncio
+
+        class _SlowStructured:
+            async def ainvoke(self, _msgs):
+                await asyncio.sleep(5)
+                raise AssertionError("the timeout should have abandoned this call")
+
+        class _SlowModel:
+            def with_structured_output(self, _schema):
+                return _SlowStructured()
+
+        with (
+            patch("agent_common.core.model_factory.create_fast_model", return_value=_SlowModel()),
+            patch("agent_common.core.model_factory.get_default_fast_model", return_value="fast"),
+            patch.object(tcs, "_SUMMARY_TIMEOUT_SECONDS", 0.01),
+        ):
+            assert await tcs.summarize_action_requests([("ls", {"path": "/x"}, "list files")]) is None
+
+    @pytest.mark.asyncio
+    async def test_a_timeout_leaves_the_action_request_untouched(self):
+        # The client renders the raw args; a half-populated card would be worse than none.
+        request = {"name": "ls", "args": {"path": "/x", "_call_id": "c1"}}
+        with (
+            patch.object(tcs, "_resume_pending", return_value=False),
+            patch.object(tcs, "summarize_action_requests", AsyncMock(return_value=None)),
+        ):
+            await tcs.attach_summaries([request])
+        assert request["args"] == {"path": "/x", "_call_id": "c1"}

--- a/packages/agent-common/tests/test_tool_call_summarizer.py
+++ b/packages/agent-common/tests/test_tool_call_summarizer.py
@@ -152,10 +152,14 @@ class TestSummarizerCostAttribution:
         class _FakeStructured:
             async def ainvoke(self, _msgs):
                 seen["sub_agent_id"] = current_sub_agent_id.get()
-                return tcs.ToolCallSummaries(summaries=["lists the folder"])
+                return {
+                    "raw": None,
+                    "parsed": tcs.ToolCallSummaries(summaries=["lists the folder"]),
+                    "parsing_error": None,
+                }
 
         class _FakeModel:
-            def with_structured_output(self, _schema):
+            def with_structured_output(self, _schema, include_raw=False):
                 return _FakeStructured()
 
         async def run(_: object):
@@ -192,7 +196,7 @@ class TestSummaryTimeout:
                 raise AssertionError("the timeout should have abandoned this call")
 
         class _SlowModel:
-            def with_structured_output(self, _schema):
+            def with_structured_output(self, _schema, include_raw=False):
                 return _SlowStructured()
 
         with (
@@ -212,3 +216,59 @@ class TestSummaryTimeout:
         ):
             await tcs.attach_summaries([request])
         assert request["args"] == {"path": "/x", "_call_id": "c1"}
+
+
+class TestUnusableReply:
+    """A reply with no summaries in it must say WHY in the log, then fall back to raw args.
+
+    `create_fast_model` asks for a short output cap, so this path owns the truncation risk:
+    console-backend's `gateway_chat`/`GatewayText` exist because a reply stopped at
+    `max_tokens` reads exactly like one that said little. Only `finish_reason` separates
+    them, and the remedy (raise the cap, split the batch) differs from a content miss.
+    """
+
+    def _model(self, envelope):
+        class _Structured:
+            async def ainvoke(self, _msgs):
+                return envelope
+
+        class _Model:
+            def with_structured_output(self, _schema, include_raw=False):
+                assert include_raw, "the finish reason has to survive to the failure path"
+                return _Structured()
+
+        return _Model()
+
+    async def _summarize(self, envelope):
+        with (
+            patch("agent_common.core.model_factory.create_fast_model", return_value=self._model(envelope)),
+            patch("agent_common.core.model_factory.get_default_fast_model", return_value="fast"),
+        ):
+            return await tcs.summarize_action_requests([("ls", {"path": "/x"}, "list files")])
+
+    @pytest.mark.asyncio
+    async def test_a_truncated_reply_names_the_cap(self, caplog):
+        raw = types.SimpleNamespace(response_metadata={"finish_reason": "length"})
+        with caplog.at_level("WARNING"):
+            out = await self._summarize({"raw": raw, "parsed": None, "parsing_error": ValueError("boom")})
+        assert out is None
+        # "hit the output cap" is the actionable half — a generic parse failure would send
+        # the reader looking at the prompt instead of the budget.
+        assert "output cap" in caplog.text
+        assert "finish_reason=length" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_reply_is_reported_as_such(self, caplog):
+        raw = types.SimpleNamespace(response_metadata={"finish_reason": "stop"})
+        with caplog.at_level("WARNING"):
+            out = await self._summarize({"raw": raw, "parsed": None, "parsing_error": ValueError("not json")})
+        assert out is None
+        assert "unreadable" in caplog.text
+        assert "not json" in caplog.text
+        # Not the truncation message: the budget was fine, the content wasn't.
+        assert "output cap" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_a_missing_raw_message_still_falls_back_cleanly(self):
+        # Nothing about the envelope is guaranteed; the fallback must not depend on it.
+        assert await self._summarize({"raw": None, "parsed": None, "parsing_error": None}) is None

--- a/packages/agent-common/tests/test_tool_call_summarizer.py
+++ b/packages/agent-common/tests/test_tool_call_summarizer.py
@@ -186,8 +186,7 @@ class TestSummaryTimeout:
     call is abandoned and the documented ``None`` fallback (render raw args) applies.
     """
 
-    @pytest.mark.asyncio
-    async def test_a_slow_model_gives_up_and_falls_back(self):
+    def _slow_model(self):
         import asyncio
 
         class _SlowStructured:
@@ -199,20 +198,32 @@ class TestSummaryTimeout:
             def with_structured_output(self, _schema, include_raw=False):
                 return _SlowStructured()
 
+        return _SlowModel()
+
+    @pytest.mark.asyncio
+    async def test_a_slow_model_gives_up_and_falls_back(self):
         with (
-            patch("agent_common.core.model_factory.create_fast_model", return_value=_SlowModel()),
+            patch("agent_common.core.model_factory.create_fast_model", return_value=self._slow_model()),
             patch("agent_common.core.model_factory.get_default_fast_model", return_value="fast"),
             patch.object(tcs, "_SUMMARY_TIMEOUT_SECONDS", 0.01),
         ):
             assert await tcs.summarize_action_requests([("ls", {"path": "/x"}, "list files")]) is None
 
     @pytest.mark.asyncio
-    async def test_a_timeout_leaves_the_action_request_untouched(self):
-        # The client renders the raw args; a half-populated card would be worse than none.
+    async def test_a_timed_out_batch_leaves_the_action_request_untouched(self):
+        """End to end: a slow model must leave the card renderable, not half-populated.
+
+        Drives the real ``summarize_action_requests`` — only the model is faked. The earlier
+        version of this test stubbed that function out, so it only re-tested
+        ``attach_summaries``' None branch and would still have passed if the timeout handler
+        started returning ``[]`` or mutating args before giving up.
+        """
         request = {"name": "ls", "args": {"path": "/x", "_call_id": "c1"}}
         with (
             patch.object(tcs, "_resume_pending", return_value=False),
-            patch.object(tcs, "summarize_action_requests", AsyncMock(return_value=None)),
+            patch("agent_common.core.model_factory.create_fast_model", return_value=self._slow_model()),
+            patch("agent_common.core.model_factory.get_default_fast_model", return_value="fast"),
+            patch.object(tcs, "_SUMMARY_TIMEOUT_SECONDS", 0.01),
         ):
             await tcs.attach_summaries([request])
         assert request["args"] == {"path": "/x", "_call_id": "c1"}
@@ -272,3 +283,48 @@ class TestUnusableReply:
     async def test_a_missing_raw_message_still_falls_back_cleanly(self):
         # Nothing about the envelope is guaranteed; the fallback must not depend on it.
         assert await self._summarize({"raw": None, "parsed": None, "parsing_error": None}) is None
+
+
+class TestBatchTokenBudget:
+    """The cap has to scale with the batch, which `attach_summaries` does not bound.
+
+    A flat cap fails backwards: the largest approval batches — the ones whose raw args are
+    hardest for a non-technical user to read — would be the ones that lose their prose.
+    """
+
+    def test_a_small_batch_keeps_the_fast_model_floor(self):
+        from agent_common.core.model_factory import FAST_MODEL_MAX_TOKENS
+
+        assert tcs._summary_token_budget(1) == FAST_MODEL_MAX_TOKENS
+        assert tcs._summary_token_budget(3) == FAST_MODEL_MAX_TOKENS
+
+    def test_a_large_batch_scales_past_the_floor(self):
+        from agent_common.core.model_factory import FAST_MODEL_MAX_TOKENS
+
+        budget = tcs._summary_token_budget(20)
+        assert budget > FAST_MODEL_MAX_TOKENS
+        assert budget == 20 * tcs._TOKENS_PER_SUMMARY
+
+    def test_the_budget_never_shrinks_as_the_batch_grows(self):
+        budgets = [tcs._summary_token_budget(n) for n in range(1, 40)]
+        assert budgets == sorted(budgets)
+
+    async def test_the_batch_budget_reaches_the_model(self):
+        # The scaling is worthless if the call site doesn't pass it.
+        seen: dict = {}
+
+        class _Structured:
+            async def ainvoke(self, _msgs):
+                return {"raw": None, "parsed": tcs.ToolCallSummaries(summaries=["a"] * 12), "parsing_error": None}
+
+        def _create(_alias, *, max_tokens=None, **_kw):
+            seen["max_tokens"] = max_tokens
+            return types.SimpleNamespace(with_structured_output=lambda _s, include_raw=False: _Structured())
+
+        calls = [("ls", {"path": f"/{i}"}, "list files") for i in range(12)]
+        with (
+            patch("agent_common.core.model_factory.create_fast_model", _create),
+            patch("agent_common.core.model_factory.get_default_fast_model", return_value="fast"),
+        ):
+            assert await tcs.summarize_action_requests(calls) == ["a"] * 12
+        assert seen["max_tokens"] == tcs._summary_token_budget(12)


### PR DESCRIPTION
closes #

<!-- No board item: this came out of a latency question on the HITL approval path, not a filed task. -->

## What

`create_model` sends `reasoning_effort` only when a caller passes a `thinking_level`, so the utility calls riding `get_default_fast_model()` sent nothing and inherited the **provider** default — dynamic thinking on `gemini-3.5-flash`, the current `chat:low`.

Measured on LangSmith (dev project, 2026-09-09), `tool-call-summarize` took **2.7–25.5 s, median ~8 s**, to write one sentence about one `ls` call. All of it sits between the model emitting the tool call and the HITL approval card the user is waiting for. The slowest run produced exactly this, in 25.5 s:

> "I am going to look at the list of files and folders in the main system directory."

Its invocation params carried `model: gemini-3.5-flash`, `stream: false`, and no `reasoning_effort` at all.

Same class of bug as the `gateway_chat` fix in #209 — which is why console-backend's `llm_gateway` already defaults to `reasoning_effort="none"`. agent-common had no way to express it: `ThinkingLevel` deliberately has no `none` member, since the app models thinking-off as a toggle rather than a tier.

## How

- **`REASONING_OFF`** + keyword-only `create_model(reasoning_effort=…, max_tokens=…)` overrides, so a caller can state "off" instead of staying silent.
- **`create_fast_model()`** — cheap tier, thinking off, no streaming, short output cap. For the utility calls: summaries, risk scores, watch conditions, chunk descriptions.
- **`max_tokens_for_effort(REASONING_OFF)` now returns `None`.** It previously fell through to the unknown-tier fallback and would have quietly requested `_DEFAULT_REASONING_MAX_TOKENS` for a call that does no thinking at all — a trap for the first caller to pass `"none"`.
- **The summarizer uses it, and bounds its own tail**: a 5 s `asyncio.wait_for` past which the card renders raw args (the already-documented `None` fallback). `TimeoutError` is logged at warning rather than as an exception — a slow gateway is expected weather, but a systematic regression should stay visible.

- **Truncation is named, not swallowed.** The short cap is a risk this PR introduces, and with `with_structured_output` a reply stopped at `max_tokens` comes back as invalid JSON — logged, before this, as a generic "summarization failed". console-backend's `gateway_chat` / `GatewayText` already learned that lesson (*"went unlogged for a month"*), so the summarizer requests `include_raw=True` and splits the two cases: `finish_reason == "length"` warns that the batch hit the output cap, anything else warns *unreadable* with the parse error. The raw-args fallback is unchanged in both, and the unwrapping sits inside the existing `try` — the envelope's shape is the provider's business, and a caller mid-`interrupt()` must not receive an exception from a display-only nicety.
- **The duplicated policy is cross-referenced.** `REASONING_OFF` and `_FAST_MODEL_MAX_TOKENS` hold the same values as `gateway_chat`'s defaults for the same reasons; console-backend keeps its own copy because it imports neither agent-common nor langchain (the way it also duplicates the gateway Bearer-key default). One decision, two homes — the comments now say so on both sides.

## Deliberately not in scope

Six other fast-model call sites stay on plain `create_model`: `hitl_resume.py`, `tool_risk_scorer.py`, `indexing_store.py`, `dynamic_tool_dispatch.py`, `toolset_selector.py`, `file_analyzer.py`. Risk scoring, toolset selection and file analysis may lean on reasoning for quality, so switching them is a judgement call, not a mechanical one — happy to do it in a follow-up if we think the quality cost is nil.

The structural fix — render the approval card immediately and patch the summary in afterwards — is a bigger change and a worse fit for Slack (the card is a posted message, so it means a `chat.update` per summary, and a card that rewrites itself a second later reads as a glitch). Worth filing separately.

## Testing

- 4 new tests pinning `create_fast_model`'s contract (thinking off, no streaming, capped output), 2 for the timeout fallback, 1 for `REASONING_OFF`, and 3 for the unusable-reply paths (truncation names the cap; an unreadable reply names the parse error and specifically does *not* claim truncation; a missing `raw` still falls back cleanly).
- Full agent-common suite: **995 passed**.
- `ruff check --line-length 120` clean on all touched files.

Not verified against a live gateway — the latency win is inferred from the traces above plus the removal of the thinking default, so worth a look at a fresh `tool-call-summarize` trace after this deploys.

## Checklist
- [x] I have performed a self-review of my code
- [x] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨 — no; `create_model`'s new params are keyword-only with defaults that preserve today's behaviour.

---
🤖 Written by Claude Code (Opus 5) in a session driven by @aartaria.
