### PR TITLE
fix(agent-common): per-argument risk profile as a list, not an open map

### DIFF
--- a/packages/agent-common/agent_common/core/tool_risk_scorer.py
+++ b/packages/agent-common/agent_common/core/tool_risk_scorer.py
@@ -35,12 +35,62 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-class RiskyValuesOutput(BaseModel):
+# NOTE: Every collection below is a LIST of objects with named fields, never a dict
+# keyed by strings the model has to invent. That is load-bearing: it is the
+# difference between per-argument risk matching working and silently not working.
+#
+# A `dict[str, X]` serializes to a JSON schema carrying `additionalProperties` and
+# *no* `properties` at all -- an object with zero named fields, whose keys the model
+# is expected to invent. Providers do not agree on what to do with that. Measured on
+# `fs_delete_path` (params path / recursive / confirm):
+#
+#   * gpt-4o-2024-08-06 (Azure) under method="json_schema": 400, strict mode cannot
+#     express an open map at all.
+#   * gemini-3.1-pro-preview, gemini-3.5-flash, gemini-3.5-flash-lite (Vertex),
+#     even under method="function_calling": HTTP 200, a well-formed tool call, a
+#     correct `base_score`, a sensible `reasoning` -- and `risk_factors: {}`, on
+#     every observed call. No error raised anywhere in the stack.
+#   * Claude (Bedrock) and gpt-4o-2024-08-06 under function_calling: populated.
+#
+# The silent case is the dangerous one: an empty profile is persisted with a *real*
+# schema hash, so unlike a hard failure it never self-corrects, and per-argument
+# matching stays off for that tool permanently (#199 / #201).
+#
+# With these list shapes the Vertex aliases populate the map reliably (8/8 sampled
+# on gemini-3.5-flash) on the same prompt and method.
+#
+# One alias still fails, and it is worth knowing it is not a schema problem:
+# `deepseek-v4-pro` (azure_ai) populates roughly half the time, while `v3.2`
+# (bedrock/eu-north-1/deepseek.v3.2 -- same model family) is 15/15 on the identical
+# schema, prompt and method. Ruled out on the azure_ai route: truncation
+# (finish_reason is `tool_calls`, 266 output tokens against a ~4096 budget, and an
+# 8192 cap changes nothing), the schema shape, the field descriptions (five wording
+# variants x3 calls showed no signal), and the gateway registration, which matches
+# v3.2's. So it looks like that deployment, not DeepSeek, and the conclusion is to
+# keep it away from the `chat:low` tier rather than to tune the prompt for it. See
+# orchestrator-agent tests/integration/test_tool_risk_scoring.py.
+
+
+class RiskyValueOutput(BaseModel):
+    """One glob pattern and the risk that matching it implies."""
+
+    pattern: str = Field(
+        description="Glob pattern matched against the argument's value, e.g. 'DELETE*', '*DROP*', '/etc/*'.",
+    )
+    score: float = Field(
+        description="Risk score (0.0-1.0) when the argument's value matches this pattern.",
+    )
+
+
+class ParamRiskOutput(BaseModel):
     """A single parameter's risk profile as returned by the LLM."""
 
-    risky_values: dict[str, float] = Field(
-        default_factory=dict,
-        description="Glob pattern -> risk score (0.0-1.0). Patterns like 'DELETE*', '*DROP*', '/etc/*'.",
+    param_name: str = Field(
+        description="The parameter's name, exactly as it appears in the tool's input schema.",
+    )
+    risky_values: list[RiskyValueOutput] = Field(
+        default_factory=list,
+        description="Value patterns for this parameter that indicate elevated risk.",
     )
     default_contribution: float = Field(
         default=0.0,
@@ -64,8 +114,8 @@ class ToolRiskOutput(BaseModel):
         "0.7 = elevated (writes to shared resources), "
         "1.0 = critical (destructive, irreversible, or security-sensitive operations).",
     )
-    risk_factors: dict[str, RiskyValuesOutput] = Field(
-        default_factory=dict,
+    risk_factors: list[ParamRiskOutput] = Field(
+        default_factory=list,
         description="Parameters that control the risk level of this tool. "
         "Only include params whose values meaningfully change the risk "
         "(e.g., 'action', 'method', 'file_path', 'query'). "
@@ -272,10 +322,18 @@ For risk_factors, use glob patterns:
 - `?` matches a single character
 - `[abc]` matches character set
 
-Examples of control params and risky patterns:
-- "method": {"DELETE*": 0.9, "PUT*": 0.6, "POST*": 0.5}
-- "file_path": {"/etc/*": 0.9, "/tmp/*": 0.3, "*.exe": 0.8}
-- "query": {"*DROP*": 0.95, "*DELETE*": 0.9, "*ALTER*": 0.8}
+Return risk_factors as a LIST with one entry per control parameter. Name every
+control parameter you find — an empty list means the tool has no parameter whose
+value changes its risk, which is rare for anything that writes or deletes.
+
+  "risk_factors": [
+    {"param_name": "method", "risky_values": [
+        {"pattern": "DELETE*", "score": 0.9}, {"pattern": "PUT*", "score": 0.6}]},
+    {"param_name": "file_path", "risky_values": [
+        {"pattern": "/etc/*", "score": 0.9}, {"pattern": "*.exe", "score": 0.8}]},
+    {"param_name": "query", "risky_values": [
+        {"pattern": "*DROP*", "score": 0.95}, {"pattern": "*DELETE*", "score": 0.9}]}
+  ]
 
 Do NOT include content/payload parameters (body, data, message) as risk factors —
 only parameters whose VALUES determine HOW risky the operation is.\
@@ -296,19 +354,18 @@ async def _score_tool_via_llm(
     from agent_common.core.model_factory import create_model, get_default_fast_model, require_default_model
 
     model = create_model(get_default_fast_model() or require_default_model(), streaming=False)
-    # method="function_calling", not the langchain-openai>=0.3 default of "json_schema".
-    # OpenAI's strict structured-output validator requires every object to declare
-    # additionalProperties: false and to list every property in `required`, but
-    # ToolRiskOutput is built on open maps (risk_factors, risky_values) whose keys are
-    # the tool's own parameter names, unknowable ahead of the call. Under the default
-    # every scoring request came back 400 ("'additionalProperties' is required to be
-    # supplied and to be false"), so each tool silently fell through to the
-    # deterministic fallback after paying a full round trip.
-    #
-    # Tool calling accepts the same schema and is what the rest of this stack already
-    # speaks: the gateway normalizes every provider (Bedrock included) into
-    # OpenAI-shape tool_calls (see a2a.structured_response.select_response_format,
+    # method="function_calling", not the langchain-openai>=0.3 default of "json_schema",
+    # which routes through OpenAI's *strict* validator: it requires every object to
+    # declare additionalProperties: false and to list every property in `required`,
+    # neither of which pydantic emits here. Tool calling is also what the rest of this
+    # stack already speaks -- the gateway normalizes every provider (Bedrock included)
+    # into OpenAI-shape tool_calls (see a2a.structured_response.select_response_format,
     # which picks ToolStrategy for the same reason).
+    #
+    # This keyword alone is NOT what makes risk scoring work across the fleet; the
+    # list shape of ToolRiskOutput is (see the note above its definition). Under
+    # function calling with the old open-map schema, Vertex and Azure AI still
+    # returned an empty risk_factors, silently.
     structured_model = model.with_structured_output(ToolRiskOutput, method="function_calling")
 
     # Build user prompt with tool details
@@ -332,11 +389,19 @@ async def _score_tool_via_llm(
             ]
         )
 
-    # Convert LLM output to ToolRiskEntry
+    # Convert LLM output to ToolRiskEntry. The wire format is a list of named
+    # parameters (see ToolRiskOutput); the cache is keyed by param name, so fold it
+    # back into a dict here. A factor with no param_name has told us nothing
+    # matchable, and an empty pattern would compile to a glob matching everything --
+    # skip both rather than persist a profile that misfires at execution time.
     risk_factors: dict[str, ParamRiskProfile] = {}
-    for param_name, profile in result.risk_factors.items():
+    for profile in result.risk_factors:
+        param_name = (profile.param_name or "").strip()
+        if not param_name:
+            logger.warning("Tool %s: LLM returned a risk factor with no param_name, skipping", tool_name)
+            continue
         risk_factors[param_name] = ParamRiskProfile(
-            risky_values=profile.risky_values,
+            risky_values={rv.pattern: rv.score for rv in profile.risky_values if rv.pattern},
             default_contribution=profile.default_contribution,
         )
 

--- a/packages/orchestrator-agent/AGENTS.md
+++ b/packages/orchestrator-agent/AGENTS.md
@@ -199,6 +199,7 @@ Two cross-cutting invariants: the seed key is **`runnable.tracking_key`** (`agen
 uv run pytest                      # everything except integration (~8s)
 uv run pytest tests/test_x.py -v   # one file
 uv run pytest -m integration       # real LLM calls, needs a gateway (~4min, ~$1.40)
+uv run pytest -m integration -n 8  # the same tests, concurrently (~3x faster)
 ```
 
 Integration tests are **collected on every run but deselected** by `-m "not integration"`
@@ -211,6 +212,49 @@ user-supplied expression replaces it, and every integration module also carries
 `slow` — so `-m slow` would select the integration directory and nothing else.
 `tests/integration/conftest.py` therefore also requires the tier to be *requested*:
 `-m integration`, or `RUN_INTEGRATION_TESTS=1` when selecting by path or keyword.
+`-n <workers>` works on any selection, not just this tier — the unit suite runs
+clean under it (1023 passed, 12.6s to 7.7s). The gain there is small because
+those tests are import- and CPU-bound, so worker startup eats most of it;
+nothing runs in parallel unless you ask for `-n`.
+
+Where it pays is the integration tier. Model-parametrized tests are almost
+entirely network wait on independent aliases, so a serial sweep costs the sum of
+the fleet where it could cost its slowest member. `-n <workers>` (pytest-xdist) makes them concurrent — measured
+141s to 45s on `test_tool_risk_scoring.py`. Spend is unchanged: the same calls
+are made, just not one at a time.
+
+The integration conftest tags every item carrying a `model_type` param with an
+`xdist_group` named after the alias, so all tests for one model stay on one
+worker. That keeps per-model memoization intact (otherwise a score shared
+between two tests is billed twice — measured 9.7k tokens against 5.0k for the
+same three aliases) and holds each alias to one in-flight request, since fanning
+several at a single Bedrock model earns throttling that surfaces as a 500.
+
+Two details there are easy to get wrong, and both fail *silently* — grouping
+simply stops happening, with no error:
+
+- The marker is added from `pytest_itemcollected`, not from
+  `pytest_collection_modifyitems`. xdist turns `xdist_group` into a nodeid
+  suffix from its own `pytest_collection_modifyitems`; its worker plugin
+  registers after conftests load, and pluggy calls implementations
+  last-registered-first, so xdist's runs before ours and finds no markers.
+  `pytest_itemcollected` fires from `Session.genitems`, which finishes before
+  any `pytest_collection_modifyitems` — a phase guarantee, rather than the
+  relative hint `tryfirst` gives (which only orders against implementations that
+  do not also claim it, and `cacheprovider`, `stepwise` and two xdist plugins are
+  all in that hook). It is also called only for items in this directory, so the
+  tier scoping is structural rather than a path check.
+- `--dist=loadgroup` lives in `addopts`, not in a conftest. xdist hands workers
+  the original command line, so a `config.option.dist` mutated at configure time
+  never reaches the worker that actually reads it. It is inert without `-n`.
+
+Confirm grouping is live by looking for `@<alias>` suffixes on the nodeids in the
+report; without them, each alias is being scored once per test.
+
+Token accounting reaches the controller on the report's `user_properties`;
+writing straight to the `EvalSession` from a fixture would be invisible under
+`-n` and every row would read `-`.
+
 The predicate lives in `tests/support/marker_gate.py` and is pinned by
 `tests/test_marker_gate.py`; it fails closed, since a skipped test is cheaper than
 a surprise bill.

--- a/packages/orchestrator-agent/pyproject.toml
+++ b/packages/orchestrator-agent/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
     "pytest-cov>=4.1.0",
     "pytest-env>=1.2.0",
     "pytest-mock>=3.12.0",
+    "pytest-xdist>=3.6.0",
     "langsmith[pytest]>=0.4.37",
     "docker>=7.0.0",
     "testcontainers[postgres]>=4.0.0",
@@ -78,6 +79,17 @@ python_functions = "test_*"
 addopts = [
     "-v",
     "--tb=short",
+    # Group-aware distribution, so that `-n <workers>` alone does the right
+    # thing. The integration tier tags model-parametrized items with an
+    # `xdist_group` per alias, keeping each model on one worker (see
+    # tests/integration/conftest.py). A bare `-n` would select `--dist load`,
+    # which ignores those groups and scores every alias twice instead of once.
+    #
+    # It has to be here rather than applied from a conftest: xdist hands workers
+    # the original command line, so a `config.option.dist` mutated at configure
+    # time never reaches the worker that reads it. `addopts` is read from this
+    # file by controller and workers alike. Inert without `-n`.
+    "--dist=loadgroup",
     "--strict-markers",
     "--disable-warnings",
     # Integration tests are collected (so breakage in them is visible) but

--- a/packages/orchestrator-agent/tests/integration/conftest.py
+++ b/packages/orchestrator-agent/tests/integration/conftest.py
@@ -321,6 +321,48 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(no_gateway)
 
 
+def pytest_itemcollected(item):
+    """Group model-parametrized items by alias, so ``-n`` splits them sanely.
+
+    These tests are almost entirely network wait on independent aliases, so a
+    serial sweep costs the sum of the fleet when it could cost its slowest
+    member. ``-n`` makes that concurrent; this marker decides *how* the work is
+    split, and the default split is wrong for us in two ways. Keeping every test
+    for one model on a single worker means:
+
+      * Per-model memoization keeps working. ``test_tool_risk_scoring`` scores
+        each alias once and has two tests read that one result; split across
+        workers, the saving silently becomes a second billed call.
+      * One in-flight request per alias. Fanning several at a single Bedrock
+        model earns throttling that surfaces as a 500, which reads like a
+        provider outage rather than self-inflicted load.
+
+    xdist reads these markers in its own ``pytest_collection_modifyitems`` and
+    rewrites the nodeid to carry an ``@group`` suffix, which is the whole
+    mechanism -- the scheduler groups on that string alone. So the marker has to
+    exist *before* any ``pytest_collection_modifyitems`` runs, and it would not
+    if this lived in ours: xdist's worker plugin registers after conftests are
+    loaded, and pluggy calls hook implementations last-registered-first, so its
+    implementation runs before ours and finds no markers.
+
+    ``pytest_itemcollected`` sidesteps the ordering question instead of fighting
+    it. It fires from ``Session.genitems``, which finishes before
+    ``pytest_collection_modifyitems`` is called at all -- a phase guarantee
+    rather than a relative hint like ``tryfirst``, which only orders against
+    implementations that do not also claim it (``cacheprovider``, ``stepwise``
+    and two xdist plugins are all in that hook). Being a hook on a conftest in
+    this directory, it is also called only for items *in* this directory, so the
+    tier scoping is structural rather than a path check.
+
+    Harmless without ``-n``: pytest ignores the marker in a serial run. Grouping
+    is live when the report's nodeids carry ``@<alias>``; without them, each
+    alias is being scored once per test. Nothing errors either way.
+    """
+    model_type = getattr(item, "callspec", None) and item.callspec.params.get("model_type")
+    if model_type:
+        item.add_marker(pytest.mark.xdist_group(str(model_type)))
+
+
 # ---------------------------------------------------------------------------
 # LangSmith experiment metadata (used by langsmith pytest plugin)
 # ---------------------------------------------------------------------------
@@ -501,14 +543,21 @@ def _is_integration(nodeid: str) -> bool:
 
 @pytest.fixture()
 def usage_recorder(request):
-    """Per-test token accounting, reachable from the terminal summary."""
+    """Per-test token accounting, reachable from the terminal summary.
+
+    The counts travel to the summary on the test's *report* rather than being
+    written straight into ``_EVAL``. Under ``-n`` this fixture runs in a worker
+    process while the cost table and the gate live on the controller, so a direct
+    write would be invisible there and every row would read "-".
+    ``user_properties`` is serialized with the report by xdist and behaves
+    identically in a single-process run, so there is one code path either way.
+    """
     recorder = UsageRecorder()
     request.node.stash_usage_recorder = recorder  # type: ignore[attr-defined]
     yield recorder
-    record = _EVAL.record_for(request.node.nodeid)
-    record.input_tokens += recorder.input_tokens
-    record.output_tokens += recorder.output_tokens
-    record.unattributed_calls += recorder.unattributed_calls
+    request.node.user_properties.append(
+        ("usage", [recorder.input_tokens, recorder.output_tokens, recorder.unattributed_calls])
+    )
 
 
 def pytest_runtest_logreport(report):
@@ -522,7 +571,20 @@ def pytest_runtest_logreport(report):
     if report.failed:
         _EVAL.note_problem(report.nodeid, report.when)
 
-    if report.when != "call" or not _is_integration(report.nodeid):
+    if not _is_integration(report.nodeid):
+        return
+
+    # Token counts are appended during fixture teardown, so they ride the
+    # teardown report rather than the call report. Read them wherever they turn
+    # up; a JSON round-trip through xdist turns the list back into a list.
+    for key, value in getattr(report, "user_properties", ()):
+        if key == "usage" and value:
+            record = _EVAL.record_for(report.nodeid)
+            record.input_tokens += value[0]
+            record.output_tokens += value[1]
+            record.unattributed_calls += value[2]
+
+    if report.when != "call":
         return
     record = _EVAL.record_for(report.nodeid)
     record.outcome = report.outcome
@@ -581,6 +643,13 @@ def pytest_sessionfinish(session, exitstatus):
     absolving them would turn a real regression green in CI. See
     ``EvalSession.unaccounted_problems``.
     """
+    # xdist runs this hook in every worker as well as the controller, and a
+    # worker only ever saw its own slice. Deciding the run's exit status from a
+    # partial sample there would be meaningless; the controller has the whole
+    # picture, because every report is forwarded to it.
+    if hasattr(session.config, "workerinput"):
+        return
+
     if not _EVAL.judged:
         return
 

--- a/packages/orchestrator-agent/tests/integration/test_tool_risk_scoring.py
+++ b/packages/orchestrator-agent/tests/integration/test_tool_risk_scoring.py
@@ -1,0 +1,308 @@
+"""Integration tests: LLM tool-risk scoring against the live fleet.
+
+``_score_tool_via_llm`` asks a model to classify a tool's risk and to return,
+per parameter, the value patterns that make a call dangerous. Whether a given
+model can actually do that is a property of the model and the provider behind
+it, not of this code — so it can only be established by asking them.
+
+The invariant under test is therefore behavioural: *scoring a risk-bearing tool
+yields a populated ``risk_factors``*. Deliberately not "the call was made with
+such-and-such structured-output options" — that pins an implementation detail,
+passes whenever the detail is present regardless of whether it still works, and
+would go red on a correct cleanup if the detail ever stopped being needed.
+
+An empty ``risk_factors`` is the outcome worth guarding, and it is worse than an
+error. A failed call raises, falls through to the deterministic fallback, and is
+retried on the next pass. An empty map arrives as HTTP 200 with a plausible
+``base_score``, is indistinguishable downstream from a model that looked and
+found nothing, and is persisted with a *real* schema hash — so it never
+self-corrects, and per-argument risk matching stays off for that tool
+permanently (see #199 / #201).
+
+Parametrized over ``ALL_MODELS`` rather than ``one_model_per_provider()``,
+because the behaviour diverges per *model* and not per provider: aliases sharing
+a provider disagree with each other, so collapsing to one per provider would
+discard exactly the signal this exists for. One short structured call per model,
+which is cheap next to the orchestrator turns in this directory.
+
+Two tests share that one call, split by what each can fairly assert:
+
+* The map being non-empty is ``strict``, so no aggregate pass ratio can absolve
+  it — not because the emptiness is always deterministic (at least one alias
+  returns an empty map only *some* of the time) but because the result is cached
+  forever. An alias that populates the map three times in four still leaves a
+  quarter of the tools it scores permanently unmatched. That is a reason to
+  disqualify the alias, not to average it away.
+* Which parameter the model called controlling, and how high it scored the tool,
+  are genuine samples of model judgement. Those stay under the pass ratio, where
+  a lone odd draw is a data point rather than a verdict.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+from agent_common.core import model_factory
+from agent_common.core.tool_risk_cache import ToolRiskEntry
+from agent_common.core.tool_risk_scorer import _score_tool_via_llm
+from agent_common.models.base import ModelType
+from langsmith import testing as t
+
+from .conftest import ALL_MODELS
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+
+# ---------------------------------------------------------------------------
+# The probe tool
+# ---------------------------------------------------------------------------
+# Chosen so that an empty ``risk_factors`` is unambiguously wrong. A tool that is
+# destructive in itself (say, a delete) is a poor probe: "the risk is fixed and no
+# single parameter controls it" is a defensible answer there, and a model that
+# returns no factors still reports a high base_score, so the call stays gated and
+# the miss is half-masked.
+#
+# An HTTP client has no fixed risk at all. GET is a read; DELETE against an
+# internal address is not. A model that returns no controlling parameters for this
+# tool has asserted that its risk does not depend on its arguments, which is
+# simply false — and it pairs that with a *low* base_score, so the call is waved
+# through with nothing left to match on. That is the failure this feature exists
+# to prevent, so it is the one worth probing.
+
+_TOOL_NAME = "http_request"
+_TOOL_DESCRIPTION = "Send an HTTP request to a URL and return the response."
+_TOOL_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "method": {
+            "type": "string",
+            "description": "HTTP verb: GET, POST, PUT, PATCH or DELETE.",
+        },
+        "url": {
+            "type": "string",
+            "description": "Absolute URL to call.",
+        },
+        "body": {
+            "type": "string",
+            "description": "Request body, for verbs that take one.",
+        },
+    },
+    "required": ["method", "url"],
+}
+
+# Two calls to the same tool that any usable risk profile must separate. Same URL
+# in both, so `method` is the only variable and a profile keyed on anything else
+# cannot accidentally satisfy the assertion.
+_SAFE_CALL = {"method": "GET", "url": "https://api.example.com/v1/items"}
+_DANGEROUS_CALL = {"method": "DELETE", "url": "https://api.example.com/v1/items"}
+
+
+@pytest.fixture()
+def fast_tier_pinned_to(monkeypatch, usage_recorder):
+    """Pin the fast tier to one alias, and route its spend into the run report.
+
+    ``_score_tool_via_llm`` takes no model argument — it resolves
+    ``get_default_fast_model()`` itself and builds the model with no callbacks.
+    Without the first patch every parametrization would score on whichever alias
+    the fleet default happens to be; without the second the call is invisible to
+    ``UsageRecorder`` and the test shows "-" in the integration cost table.
+
+    Patching the module attributes is enough: the scorer imports both names
+    *inside* the function body, so the lookup happens per call.
+    """
+    real_create_model = model_factory.create_model
+
+    def _pin(model_type: ModelType) -> None:
+        monkeypatch.setattr(model_factory, "get_default_fast_model", lambda: model_type)
+        monkeypatch.setattr(
+            model_factory,
+            "create_model",
+            lambda *args, **kwargs: real_create_model(
+                *args, **{**kwargs, "callbacks": [usage_recorder]}
+            ),
+        )
+
+    return _pin
+
+
+# One call per alias, shared by both tests below. They ask two questions about the
+# same single response, so scoring twice would double the spend to learn nothing —
+# and would let the two tests disagree about a non-deterministic model. Session
+# lifetime: parametrization runs the strict test across the fleet first, so it pays
+# for every call and the qualitative test's rows show "-" in the cost table.
+_SCORED: dict[ModelType, "ToolRiskEntry | BaseException"] = {}
+
+
+async def _score_once(model_type: ModelType, pin) -> ToolRiskEntry:
+    """Score the probe tool with *model_type*, reusing an earlier result if there is one.
+
+    A raised exception is cached and re-raised too: a provider that rejects the
+    request must fail both tests, not fail the first and be silently retried by
+    the second.
+    """
+    if model_type not in _SCORED:
+        pin(model_type)
+        try:
+            _SCORED[model_type] = await _score_tool_via_llm(
+                _TOOL_NAME, _TOOL_DESCRIPTION, _TOOL_SCHEMA
+            )
+        except BaseException as exc:  # noqa: BLE001 — recorded, then re-raised below
+            _SCORED[model_type] = exc
+
+    result = _SCORED[model_type]
+    if isinstance(result, BaseException):
+        raise result
+    return result
+
+
+@pytest.mark.strict
+@pytest.mark.langsmith
+@pytest.mark.parametrize("model_type", ALL_MODELS, ids=ALL_MODELS)
+async def test_risk_scoring_never_returns_an_empty_risk_factors_map(
+    model_type: ModelType, fast_tier_pinned_to
+):
+    """An empty ``risk_factors`` is a failure, on every alias the gateway serves.
+
+    ``strict``, so the pass-ratio gate cannot absolve it. That gate exists for
+    sampling noise, and this does not qualify even where the emptiness is itself
+    intermittent: the profile is written to the cache with a real schema hash and
+    never revisited, so an alias that populates the map only sometimes corrupts
+    the rest permanently. "Usually works" is not a passing grade for a value that
+    is computed once and then trusted forever.
+    """
+    t.log_inputs(
+        {"model": model_type, "tool": _TOOL_NAME, "asserts": "risk_factors non-empty"}
+    )
+
+    entry = await _score_once(model_type, fast_tier_pinned_to)
+
+    t.log_outputs(
+        {"base_score": entry.base_score, "control_params": sorted(entry.risk_factors)}
+    )
+
+    assert entry.risk_factors, (
+        f"{model_type} named no controlling parameters for {_TOOL_NAME} (base_score="
+        f"{entry.base_score}, so the model did read the schema). The structured-output call "
+        "was accepted and the per-parameter profile came back empty — that profile is persisted "
+        "with a real schema hash, so unlike a hard failure it never self-corrects, and "
+        "per-argument risk matching stays off for every tool scored by this alias."
+    )
+
+
+@pytest.mark.langsmith
+@pytest.mark.parametrize("model_type", ALL_MODELS, ids=ALL_MODELS)
+async def test_risk_scoring_separates_a_dangerous_call_from_a_safe_one(
+    model_type: ModelType, fast_tier_pinned_to
+):
+    """The profile actually discriminates, measured the way HITL measures it.
+
+    ``match_args`` is what the middleware calls, and it floors every result at
+    ``base_score`` — so a profile with no usable per-argument patterns scores a
+    DELETE exactly like a GET, and the gate can no longer tell them apart. That is
+    the end-to-end symptom of the empty map the strict test above catches, and it
+    also catches a profile that is populated but keyed on nothing useful.
+
+    Not strict: which parameter a model treats as controlling, and which patterns
+    it writes, are samples of its judgement. A lone odd draw belongs under the
+    pass ratio.
+    """
+    t.log_inputs(
+        {"model": model_type, "tool": _TOOL_NAME, "asserts": "DELETE scores above GET"}
+    )
+
+    entry = await _score_once(model_type, fast_tier_pinned_to)
+
+    safe = entry.match_args(_SAFE_CALL)
+    dangerous = entry.match_args(_DANGEROUS_CALL)
+    outcome = {
+        "base_score": entry.base_score,
+        "control_params": sorted(entry.risk_factors),
+        "risky_values": {
+            name: sorted(profile.risky_values)
+            for name, profile in entry.risk_factors.items()
+        },
+        "GET": safe,
+        "DELETE": dangerous,
+    }
+    t.log_outputs(outcome)
+    logger.info("[%s] risk profile: %s", model_type, outcome)
+
+    assert dangerous > safe, (
+        f"{model_type} scored DELETE and GET identically ({dangerous}) on the same URL, so the "
+        f"profile cannot separate them. Control params: {sorted(entry.risk_factors)}, "
+        f"base_score={entry.base_score}. Per-argument gating is inert for this tool."
+    )
+
+
+# ---------------------------------------------------------------------------
+# The strict-schema matrix, recorded rather than asserted
+# ---------------------------------------------------------------------------
+
+_ENV_STRICT_MATRIX = "RISK_SCORER_STRICT_MATRIX"
+
+
+class _ForceStrictJsonSchema:
+    """Model proxy that forces the langchain-openai >= 0.3 default back on.
+
+    Wrapping the model rather than rebuilding the call means the probe runs the
+    *real* scorer — same system prompt, same schema, same attribution scope — so
+    the only difference from the test above is the one variable being measured.
+    """
+
+    def __init__(self, inner):
+        self._inner = inner
+
+    def with_structured_output(self, schema, **kwargs):
+        return self._inner.with_structured_output(
+            schema, **{**kwargs, "method": "json_schema"}
+        )
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+@pytest.mark.skipif(
+    not os.getenv(_ENV_STRICT_MATRIX),
+    reason=f"Strict-schema matrix is opt-in: set {_ENV_STRICT_MATRIX}=1 to regenerate it.",
+)
+@pytest.mark.parametrize("model_type", ALL_MODELS, ids=ALL_MODELS)
+async def test_report_strict_json_schema_matrix(
+    model_type: ModelType, monkeypatch, usage_recorder
+):
+    """Record what each alias does under langchain's strict ``json_schema`` default.
+
+    Deliberately assertion-free. Whether a provider rejects the strict schema
+    outright or accepts it and quietly drops fields is a fact about that
+    provider's validator: a test pinning it would go red the day they fix it,
+    which is the opposite of what you want to hear. So this records the behaviour
+    per alias and leaves the judgement to the reader — run it when the fleet
+    changes, when langchain moves, or before proposing to drop the ``method``
+    override.
+    """
+    real_create_model = model_factory.create_model
+    monkeypatch.setattr(model_factory, "get_default_fast_model", lambda: model_type)
+    monkeypatch.setattr(
+        model_factory,
+        "create_model",
+        lambda *args, **kwargs: _ForceStrictJsonSchema(
+            real_create_model(*args, **{**kwargs, "callbacks": [usage_recorder]})
+        ),
+    )
+
+    try:
+        entry = await _score_tool_via_llm(_TOOL_NAME, _TOOL_DESCRIPTION, _TOOL_SCHEMA)
+    except Exception as exc:  # noqa: BLE001 — any provider rejection is a result, not an error
+        verdict = f"REJECTED — {type(exc).__name__}: {str(exc)[:300]}"
+    else:
+        verdict = (
+            f"ACCEPTED but risk_factors EMPTY (silent degradation), base_score={entry.base_score}"
+            if not entry.risk_factors
+            else f"ACCEPTED, base_score={entry.base_score}, factors={sorted(entry.risk_factors)}"
+        )
+
+    print(f"\n[strict json_schema] {model_type}: {verdict}")
+    logger.warning("[strict json_schema] %s: %s", model_type, verdict)

--- a/packages/orchestrator-agent/uv.lock
+++ b/packages/orchestrator-agent/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -700,6 +700,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -1795,6 +1804,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-env" },
     { name = "pytest-mock" },
+    { name = "pytest-xdist" },
     { name = "pyyaml" },
     { name = "testcontainers" },
 ]
@@ -1852,6 +1862,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-env", specifier = ">=1.2.0" },
     { name = "pytest-mock", specifier = ">=3.12.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "testcontainers", extras = ["postgres"], specifier = ">=4.0.0" },
 ]
@@ -2302,6 +2313,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stacked on #128, which carries the integration tier this relies on (`marker_gate`, `eval_report`, `usage`). Supersedes #202 — see the bottom.

## The bug

`ToolRiskOutput.risk_factors` was a `dict[str, RiskyValuesOutput]`. That serializes to a JSON schema with `additionalProperties` and **no `properties`** — an object with zero named fields, whose keys the model must invent. Providers disagree on what to do with that, and most of the disagreement is silent.

Scoring `fs_delete_path` (params `path` / `recursive` / `confirm`) across the fleet:

| model | before |
|---|---|
| `gpt-4o-2024-08-06` (Azure), `method="json_schema"` | **400** — strict mode cannot express an open map. The failure #188 worked around. |
| `gemini-3.1-pro-preview`, `gemini-3.5-flash`, `gemini-3.5-flash-lite` (Vertex), **under `function_calling`** | **HTTP 200**, well-formed tool call, correct `base_score`, sensible `reasoning` — and `risk_factors: {}`, every observed call |
| Claude (Bedrock), `gpt-4o-2024-08-06` under `function_calling` | populated |

So #188's keyword fixed Azure and Bedrock and left Vertex **silently broken**. The raw tool call confirms the model itself emits the empty map — nothing is lost in the gateway:

```
tool_calls: [{"name": "ToolRiskOutput", "args": {
    "reasoning": "This tool performs irreversible deletion...",
    "base_score": 0.85,
    "risk_factors": {}
}}]
parsing_error: None
```

The silent case is the worse one. A hard failure raises, falls through to the deterministic fallback and retries next pass. An empty map is persisted with a **real schema hash**, so it never self-corrects — per-argument matching stays off for that tool permanently (see #199 / #201). And `match_args` floors every call at `base_score`, so a `DELETE` and a `GET` to the same URL score identically and HITL can no longer tell them apart.

## The fix

Every collection becomes a list of objects with named fields: `risk_factors` → `list[ParamRiskOutput]` (`param_name` + `risky_values`), `risky_values` → `list[RiskyValueOutput]` (`pattern` + `score`).

**The cache format is untouched.** `ToolRiskEntry` / `ParamRiskProfile` still store dicts; the conversion folds the list back into one, skipping entries with no `param_name` and empty patterns (an empty glob compiles to match-everything).

With the list shape the Vertex aliases populate reliably — 8/8 sampled on `gemini-3.5-flash`, against 0/n before. `method="function_calling"` stays, and its comment now says what is actually load-bearing: the keyword only avoids OpenAI's strict validator; the list shape is what makes the fleet work.

**One alias still fails, and it is not the schema.** `deepseek-v4-pro` (`azure_ai/deepseek-v4-pro`) populates roughly half the time. But `v3.2` (`bedrock/eu-north-1/deepseek.v3.2`, same model family) is **15/15** on the identical schema, prompt and method — so this is not DeepSeek being incapable.

Ruled out on the azure_ai route:

| hypothesis | evidence against |
|---|---|
| output truncated by the token budget | `finish_reason='tool_calls'` (clean stop), 266 output tokens against a ~4096 gateway default; an explicit `max_tokens=8192` changes nothing |
| the schema shape | Bedrock-served DeepSeek is 15/15 on the identical schema |
| the field descriptions | five wording variants × 3 calls each — 1/3 to 2/3 across the board, no signal |
| the gateway registration | matches `v3.2`'s: same `max_retries`, both declare `supports_function_calling`, `supports_tool_choice`, `supports_reasoning` |

So it points at that deployment rather than the model, and the conclusion is to keep it off the `chat:low` tier (which is what `get_default_fast_model()` resolves to) rather than tune the prompt for it. Worth someone checking what `azure_ai/deepseek-v4-pro` actually serves.

## Integration coverage

Whether a model can return a per-argument profile is a property of the model and its provider, so only a live call establishes it. A mocked `with_structured_output` cannot: it passes whether or not the real call would work, and is blind to the case that matters — the provider accepting the request and quietly returning nothing.

The probe is `http_request` (method / url / body), deliberately **not** something destructive. A dangerous-by-nature tool is a poor probe: "risk is fixed, no single parameter controls it" is defensible there, and a model naming no factors still reports a high `base_score`, so the call stays gated and the miss is half-masked. An HTTP client has no fixed risk, so an empty profile is unambiguously wrong *and* arrives with a low base score:

```
deepseek-v4-pro         base=0.35  control_params=[]              GET=0.35  DELETE=0.35
gemini-3.5-flash        base=0.60  method=[DELETE,PATCH,POST,PUT]
                                   url=[*169.254.169.254*, *://10.*, file://*, gopher://*]
                                                                  GET=0.60  DELETE=0.90
```

Two tests share one call per alias:

- **non-empty `risk_factors` is `strict`**, so no aggregate pass ratio can absolve it. Not because emptiness is always deterministic — at least one alias is intermittent — but because the result is cached forever. An alias that populates three times in four still leaves a quarter of its tools permanently unmatched. "Usually works" is not a passing grade for a value computed once and then trusted forever.
- **that the profile discriminates** is measured through `match_args`, the call the middleware makes, on a GET and a DELETE to one URL. Stays under the pass ratio: which parameter a model calls controlling is a sample of its judgement.

Parametrized over `ALL_MODELS`, not `one_model_per_provider()` — the behaviour diverges per *model*; aliases sharing a provider disagree.

## Parallelism

Model-parametrized tests are almost all network wait on independent aliases. `-n 8` takes `test_tool_risk_scoring.py` from **141s to 31s**, with the same pass/fail set and unchanged spend. It applies to every such test without a per-file opt-in.

Items are grouped by alias (`xdist_group`) so each model stays on one worker — preserving per-model memoization (5.0k tokens grouped vs 9.7k ungrouped on three aliases) and holding each alias to one in-flight request.

Three things here fail **silently** and are documented in the code:

- the marker is added from `pytest_itemcollected`, which finishes before any `pytest_collection_modifyitems`. xdist's worker plugin registers after conftests load and pluggy calls implementations last-registered-first, so xdist's hook would otherwise run before ours and find no markers. `tryfirst=True` also works, but it only orders against implementations that do not also claim it — `cacheprovider`, `stepwise` and two xdist plugins are all in that hook — so the earlier phase is the sturdier guarantee;
- `--dist=loadgroup` must be in `addopts` — xdist hands workers the original command line, so a `config.option.dist` mutated at configure time never reaches them (both conftest locations were tried);
- token counts must ride `report.user_properties`, or every row reads `-` under `-n`.

`pytest_sessionfinish` is guarded to the controller, which otherwise decides exit status from a worker's partial slice.

## Verification

- `agent-common`: full suite passes (9 pre-existing failures on this base, unchanged).
- serial unit suite: 1023 passed; serial integration still shares one call per alias.
- integration, full fleet under `-n 8`: **28/30, 14 of 15 aliases pass both tests**. The only failure is `deepseek-v4-pro` (both tests), as described above — it returns an empty list on roughly three calls in four with or without this change.

```
pass ratio 93% (28/30), threshold 75%  |  176s of test time in 54s wall  |  34,443 tokens
GATE FAILED: 1 strict test(s) failed:
  test_risk_scoring_never_returns_an_empty_risk_factors_map[deepseek-v4-pro]
```

  Covers every provider the gateway serves: Bedrock (`claude-opus-5`, `claude-sonnet-5/4.6/4.5`, `claude-opus-4-8`, `claude-haiku-4-5` ×3, `v3.2`), Vertex (`gemini-3.1-pro-preview`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3-flash-preview`), Azure (`gpt-4o-2024-08-06`) and Azure AI (`deepseek-v4-pro`). Every Gemini alias, which returned `risk_factors: {}` on every call before this change, now passes both tests.

  That run also confirms the grouping end to end: all 30 nodeids carry their `@<alias>` suffix and all 15 `separates_...` rows show `0.0s` / `-`, i.e. one scoring call per alias shared by both tests.
- `ruff check`: 13 pre-existing findings in `tests/integration/conftest.py` on this base, same 13 after.

## Relationship to #202

#202 pinned the `method="function_calling"` keyword with a mocked `with_structured_output`. That mock records the keyword and returns an object the test built itself, so it catches exactly one mutation and cannot see the silent-empty case this PR is about. Its second test asserts the open maps are *present* — now false by design, and its own docstring says the two should be "revisited together rather than deleting either in isolation". This is that revisit, so #202 can be closed.

## Checklist
- [x] I have performed a self-review of my code
- [x] If it is a core feature and/or a bugfix, I have added thorough tests.
- [ ] Does this PR introduce a breaking change? 🚨 — no. The LLM wire format changes; the cache/API format does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


